### PR TITLE
Adding tenant model and ability to edit display name

### DIFF
--- a/packages/client/src/components/Layout.vue
+++ b/packages/client/src/components/Layout.vue
@@ -31,6 +31,7 @@
         <b-nav-item to="/keywords" exact exact-active-class="active">Keywords</b-nav-item>
         <b-nav-item to="/users" exact exact-active-class="active" v-if="userRole === 'admin'">Users</b-nav-item>
         <b-nav-item to="/Agencies" exact exact-active-class="active">Agencies</b-nav-item>
+        <b-nav-item to="/Tenants" exact exact-active-class="active">Tenants</b-nav-item>
     </b-nav>
     <div style="margin-top: 10px">
       <router-view />

--- a/packages/client/src/components/Modals/EditTenant.vue
+++ b/packages/client/src/components/Modals/EditTenant.vue
@@ -1,0 +1,76 @@
+<!-- eslint-disable max-len -->
+<template>
+  <div>
+    <b-modal
+      id="edit-tenant-modal"
+      v-model="showDialog"
+      ref="modal"
+      title="Edit Tenant"
+      @hidden="resetModal"
+      @ok="handleOk"
+    >
+    <h3>{{this.tenant && this.tenant.displayName}}</h3>
+      <form ref="form" @submit.stop.prevent="handleSubmit">
+        <b-form-group
+          label-for="name-input"
+        >
+          <template slot="label">Name</template>
+          <b-form-input
+              autofocus
+              id="name-input"
+              type="text"
+              min=2
+              v-model="formData.displayName"
+              required
+            ></b-form-input>
+        </b-form-group>
+      </form>
+    </b-modal>
+  </div>
+</template>
+
+<script>
+import { mapActions, mapGetters } from 'vuex';
+
+export default {
+  props: {
+    tenant: Object,
+  },
+  data() {
+    return {
+      showDialog: false,
+      formData: {
+        displayName: null,
+      },
+    };
+  },
+  watch: {
+    tenant() {
+      this.formData.displayName = this.tenant && this.tenant.display_name;
+      this.showDialog = Boolean(this.tenant !== null);
+    },
+  },
+  computed: {
+    ...mapGetters({
+    }),
+  },
+  mounted() {
+  },
+  methods: {
+    ...mapActions({
+      updateDisplayName: 'tenants/updateDisplayName',
+    }),
+    resetModal() {
+      this.$emit('update:tenant', null);
+    },
+    handleOk(bvModalEvt) {
+      bvModalEvt.preventDefault();
+      this.handleSubmit();
+    },
+    async handleSubmit() {
+      await this.updateDisplayName({ tenantId: this.tenant.id, ...this.formData });
+      this.resetModal();
+    },
+  },
+};
+</script>

--- a/packages/client/src/router/index.js
+++ b/packages/client/src/router/index.js
@@ -64,6 +64,14 @@ const routes = [
         },
       },
       {
+        path: '/tenants',
+        name: 'tenants',
+        component: () => import('../views/Tenants.vue'),
+        meta: {
+          requiresAuth: true,
+        },
+      },
+      {
         path: '/users',
         name: 'users',
         component: () => import('../views/Users.vue'),

--- a/packages/client/src/store/index.js
+++ b/packages/client/src/store/index.js
@@ -7,6 +7,7 @@ import roles from './modules/roles';
 import agencies from './modules/agencies';
 import dashboard from './modules/dashboard';
 import organization from './modules/organization';
+import tenants from './modules/tenants';
 
 Vue.use(Vuex);
 
@@ -21,5 +22,6 @@ export default new Vuex.Store({
     agencies,
     dashboard,
     organization,
+    tenants,
   },
 });

--- a/packages/client/src/store/modules/tenants.js
+++ b/packages/client/src/store/modules/tenants.js
@@ -1,0 +1,35 @@
+const fetchApi = require('@/helpers/fetchApi');
+
+function initialState() {
+  return {
+    tenants: [],
+  };
+}
+
+export default {
+  namespaced: true,
+  state: initialState,
+  getters: {
+    tenants: (state) => state.tenants,
+  },
+  actions: {
+    fetchTenants({ commit }) {
+      fetchApi.get('/api/organizations/:organizationId/tenants').then((data) => commit('SET_TENANTS', data));
+    },
+    async createTenants({ dispatch }, body) {
+      await fetchApi.post('/api/organizations/:organizationId/tenants/', body);
+      dispatch('fetchTenants');
+    },
+    async updateDisplayName({ dispatch }, { tenantId, displayName }) {
+      await fetchApi.put(`/api/organizations/:organizationId/tenants/${tenantId}`, {
+        displayName,
+      });
+      dispatch('fetchTenants');
+    },
+  },
+  mutations: {
+    SET_TENANTS(state, tenants) {
+      state.tenants = tenants;
+    },
+  },
+};

--- a/packages/client/src/views/Tenants.vue
+++ b/packages/client/src/views/Tenants.vue
@@ -1,0 +1,79 @@
+<template>
+<section class="container-fluid">
+  <b-row>
+    <b-col><h2>Tenants</h2></b-col>
+    <b-col></b-col>
+  </b-row>
+  <b-table sticky-header="600px" hover :items="formattedTenants" :fields="fields">
+      <template #cell(display_name)="row">
+        {{row.item.display_name}}
+      </template>
+      <template #cell(actions)="row">
+      <b-button v-if="userRole === 'admin'" class="mr-1" size="sm" @click="openEditTenantModal(row.item)">
+        <b-icon icon="pencil-fill" aria-hidden="true"></b-icon>
+      </b-button>
+    </template>
+  </b-table>
+  <EditTenantModal
+     :tenant.sync="editingTenant"
+  />
+</section>
+</template>
+
+<script>
+
+import { mapActions, mapGetters } from 'vuex';
+
+import EditTenantModal from '@/components/Modals/EditTenant.vue';
+
+export default {
+  components: {
+    EditTenantModal,
+  },
+  data() {
+    return {
+      fields: [
+        {
+          key: 'display_name',
+          sortable: true,
+        },
+        { key: 'actions', label: 'Actions' },
+      ],
+      showEditTenantModal: false,
+      editingTenant: null,
+    };
+  },
+  mounted() {
+    this.setup();
+  },
+  computed: {
+    ...mapGetters({
+      tenants: 'tenants/tenants',
+      userRole: 'users/userRole',
+      selectedAgency: 'users/selectedAgency',
+    }),
+    formattedTenants() {
+      return this.tenants.map((tenant) => ({
+        ...tenant,
+      }));
+    },
+  },
+  watch: {
+    selectedAgency() {
+      this.setup();
+    },
+  },
+  methods: {
+    ...mapActions({
+      fetchTenants: 'tenants/fetchTenants',
+    }),
+    setup() {
+      this.fetchTenants();
+    },
+    openEditTenantModal(tenant) {
+      this.editingTenant = tenant;
+      this.showEditTenantModal = true;
+    },
+  },
+};
+</script>

--- a/packages/server/migrations/20220208185452_add_tenants.js
+++ b/packages/server/migrations/20220208185452_add_tenants.js
@@ -21,11 +21,11 @@ exports.up = function (knex) {
 
 exports.down = function (knex) {
     return knex.schema
-        .dropTable('tenants')
         .table('agencies', (table) => {
             table.dropColumn('tenant_id');
         })
         .table('users', (table) => {
             table.dropColumn('tenant_id');
-        });
+        })
+        .dropTable('tenants');
 };

--- a/packages/server/migrations/20220208185452_add_tenants.js
+++ b/packages/server/migrations/20220208185452_add_tenants.js
@@ -1,0 +1,31 @@
+/* eslint-disable func-names */
+exports.up = function (knex) {
+    return knex.schema
+        .createTable('tenants', (table) => {
+            table.increments('id').primary();
+            table.string('display_name');
+            table.integer('main_agency_id').unsigned();
+            table.foreign('main_agency_id').references('agencies.id');
+            table.timestamp('created_at').notNullable().defaultTo(knex.fn.now());
+            table.timestamp('updated_at');
+        })
+        .table('agencies', (table) => {
+            table.integer('tenant_id').unsigned();
+            table.foreign('tenant_id').references('tenants.id');
+        })
+        .table('users', (table) => {
+            table.integer('tenant_id').unsigned();
+            table.foreign('tenant_id').references('tenants.id');
+        });
+};
+
+exports.down = function (knex) {
+    return knex.schema
+        .dropTable('tenants')
+        .table('agencies', (table) => {
+            table.dropColumn('tenant_id');
+        })
+        .table('users', (table) => {
+            table.dropColumn('tenant_id');
+        });
+};

--- a/packages/server/seeds/dev/index.js
+++ b/packages/server/seeds/dev/index.js
@@ -7,6 +7,7 @@ const interestedCodes = require('./ref/interestedCodes');
 const keywords = require('./ref/keywords');
 const userList = require('./ref/users');
 const { grants, assignedGrantsAgency, grantsInterested } = require('./ref/grants');
+const tenants = require('./ref/tenants');
 
 // const usdrAgency = agencies.find((a) => a.abbreviation === 'USDR');
 // const nevadaAgency = agencies.find((a) => a.abbreviation === 'NV');
@@ -42,7 +43,7 @@ const globalCodes = [
 ];
 
 exports.seed = async (knex) => {
-    const tables = ['agency_eligibility_codes', 'keywords', 'eligibility_codes', 'grants', 'assigned_grants_agency', 'grants_interested'];
+    const tables = ['agency_eligibility_codes', 'keywords', 'eligibility_codes', 'grants', 'assigned_grants_agency', 'grants_interested', 'tenants'];
 
     // eslint-disable-next-line no-restricted-syntax
     for (const table of tables) {
@@ -57,6 +58,8 @@ exports.seed = async (knex) => {
     await knex('agencies').insert(agencies)
         .onConflict('id')
         .merge();
+
+    await knex('tenants').insert(tenants);
 
     if (userList.length) {
         await knex('users').insert(userList)

--- a/packages/server/seeds/dev/ref/tenants.js
+++ b/packages/server/seeds/dev/ref/tenants.js
@@ -1,0 +1,31 @@
+// server/seeds/dev/ref/tenants.js
+
+const agencies = require('./agencies');
+
+const usdrAgency = agencies.find((a) => a.abbreviation === 'USDR');
+const nevadaAgency = agencies.find((a) => a.abbreviation === 'NV');
+const procurementAgency = agencies.find((a) => a.abbreviation === 'NPO');
+const dallasAgency = agencies.find((a) => a.abbreviation === 'DLA');
+
+module.exports = [
+    {
+        id: 1,
+        display_name: 'USDR Tenant',
+        main_agency_id: usdrAgency.id,
+    },
+    {
+        id: 2,
+        display_name: 'Nevada Tenant',
+        main_agency_id: nevadaAgency.id,
+    },
+    {
+        id: 3,
+        display_name: 'NPO Tenant',
+        main_agency_id: procurementAgency.id,
+    },
+    {
+        id: 4,
+        display_name: 'Dallas Agency',
+        main_agency_id: dallasAgency.id,
+    },
+];

--- a/packages/server/seeds/dev/ref/users.js
+++ b/packages/server/seeds/dev/ref/users.js
@@ -2,37 +2,26 @@
 
 const agencies = require('./agencies');
 const roles = require('./roles');
+const tenants = require('./tenants');
 
 const usdrAgency = agencies.find((a) => a.abbreviation === 'USDR');
 const nevadaAgency = agencies.find((a) => a.abbreviation === 'NV');
 const procurementAgency = agencies.find((a) => a.abbreviation === 'NPO');
 const dallasAgency = agencies.find((a) => a.abbreviation === 'DLA');
 
+const usdrTenant = tenants.find((t) => t.display_name === 'USDR Tenant');
+const nevadaenant = tenants.find((t) => t.display_name === 'Nevada Tenant');
+const procurementTenant = tenants.find((t) => t.display_name === 'NPO Tenant');
+const dallasTenant = tenants.find((t) => t.display_name === 'Dallas Agency');
+
 module.exports = [
-    // {
-    //     email: 'rafael.pol+admin_admin@protonmail.com',
-    //     name: 'rafa1',
-    //     agency_id: agencies[1].id,
-    //     role_id: roles[0].id,
-    // },
-    // {
-    //     email: 'bindu+admin_admin@usdigitalresponse.org',
-    //     name: 'bindu',
-    //     agency_id: agencies[1].id,
-    //     role_id: roles[0].id,
-    // },
-    // {
-    //     email: 'rafael.pol+admin_sba@protonmail.com',
-    //     name: 'rafa1',
-    //     agency_id: agencies[0].id,
-    //     role_id: roles[0].id,
-    // },
     {
         id: 1,
         email: 'michael@stanford.notreal',
         name: 'Michael Stanford',
         agency_id: usdrAgency.id,
         role_id: roles[0].id,
+        tenant_id: usdrTenant.id,
     },
     {
         id: 2,
@@ -40,6 +29,7 @@ module.exports = [
         name: 'Michael Stanford NV',
         agency_id: nevadaAgency.id,
         role_id: roles[0].id,
+        tenant_id: nevadaenant.id,
     },
     {
         id: 3,
@@ -47,6 +37,7 @@ module.exports = [
         name: 'Michael Stanford NV-Procurement',
         agency_id: procurementAgency.id,
         role_id: roles[0].id,
+        tenant_id: procurementTenant.id,
     },
     {
         id: 4,
@@ -54,6 +45,7 @@ module.exports = [
         name: 'Rafael Pol',
         agency_id: usdrAgency.id,
         role_id: roles[0].id,
+        tenant_id: usdrTenant.id,
     },
     {
         id: 5,
@@ -61,6 +53,7 @@ module.exports = [
         name: 'Jovon Sotak',
         agency_id: procurementAgency.id,
         role_id: roles[0].id,
+        tenant_id: procurementTenant.id,
     },
     {
         id: 6,
@@ -68,6 +61,7 @@ module.exports = [
         name: 'nv.gov User 1',
         agency_id: nevadaAgency.id,
         role_id: roles[1].id,
+        tenant_id: nevadaenant.id,
     },
     {
         id: 7,
@@ -75,6 +69,7 @@ module.exports = [
         name: 'nv.gov User 2',
         agency_id: nevadaAgency.id,
         role_id: roles[1].id,
+        tenant_id: nevadaenant.id,
     },
     {
         id: 8,
@@ -82,6 +77,7 @@ module.exports = [
         name: 'nv.gov User 3',
         agency_id: nevadaAgency.id,
         role_id: roles[1].id,
+        tenant_id: nevadaenant.id,
     },
     {
         id: 9,
@@ -89,6 +85,7 @@ module.exports = [
         name: 'npo.nv.gov User 1',
         agency_id: procurementAgency.id,
         role_id: roles[1].id,
+        tenant_id: procurementTenant.id,
     },
     {
         id: 10,
@@ -96,6 +93,7 @@ module.exports = [
         name: 'npo.nv.gov User 2',
         agency_id: procurementAgency.id,
         role_id: roles[1].id,
+        tenant_id: procurementTenant.id,
     },
     {
         id: 11,
@@ -103,6 +101,7 @@ module.exports = [
         name: 'npo.nv.gov User 3',
         agency_id: procurementAgency.id,
         role_id: roles[1].id,
+        tenant_id: procurementTenant.id,
     },
     {
         id: 12,
@@ -110,12 +109,6 @@ module.exports = [
         name: 'dallas.gov User 1',
         agency_id: dallasAgency.id,
         role_id: roles[0].id,
+        tenant_id: dallasTenant.id,
     },
-
-    // {
-    //     email: 'rafael.pol+staff_asd@protonmail.com',
-    //     name: 'rafa2',
-    //     agency_id: agencies[2].id,
-    //     role_id: roles[1].id,
-    // },
 ];

--- a/packages/server/seeds/dev/ref/users.js
+++ b/packages/server/seeds/dev/ref/users.js
@@ -17,27 +17,27 @@ const dallasTenant = tenants.find((t) => t.display_name === 'Dallas Agency');
 module.exports = [
     {
         id: 1,
-        email: 'michael@stanford.notreal',
-        name: 'Michael Stanford',
+        email: 'christina@usdigitalresponse.org',
+        name: 'Christina Roberts',
         agency_id: usdrAgency.id,
         role_id: roles[0].id,
         tenant_id: usdrTenant.id,
     },
     {
         id: 2,
-        email: 'michael@nv.gov', // fake email for testing
-        name: 'Michael Stanford NV',
-        agency_id: nevadaAgency.id,
+        email: 'mindy@usdigitalresponse.org', // fake email for testing
+        name: 'Mindy Huant',
+        agency_id: usdrAgency.id,
         role_id: roles[0].id,
-        tenant_id: nevadaenant.id,
+        tenant_id: usdrTenant.id,
     },
     {
         id: 3,
-        email: 'michael+nvpr@stanford.cc',
-        name: 'Michael Stanford NV-Procurement',
-        agency_id: procurementAgency.id,
+        email: 'joecomeau01@gmail.com',
+        name: 'Joe Comeau',
+        agency_id: usdrAgency.id,
         role_id: roles[0].id,
-        tenant_id: procurementTenant.id,
+        tenant_id: usdrTenant.id,
     },
     {
         id: 4,
@@ -49,11 +49,11 @@ module.exports = [
     },
     {
         id: 5,
-        email: 'jsotak@admin.nv.gov',
-        name: 'Jovon Sotak',
-        agency_id: procurementAgency.id,
+        email: 'alex@usdigitalresponse.org',
+        name: 'Alex Allain',
+        agency_id: usdrAgency.id,
         role_id: roles[0].id,
-        tenant_id: procurementTenant.id,
+        tenant_id: usdrTenant.id,
     },
     {
         id: 6,

--- a/packages/server/src/configure.js
+++ b/packages/server/src/configure.js
@@ -30,6 +30,7 @@ module.exports = (app) => {
     app.use('/api/organizations/:organizationId/roles', require('./routes/roles'));
     app.use('/api/sessions', require('./routes/sessions'));
     app.use('/api/organizations/:organizationId/agencies', require('./routes/agencies'));
+    app.use('/api/organizations/:organizationId/tenants', require('./routes/tenants'));
     app.use('/api/organizations/:organizationId/grants', require('./routes/grants'));
     app.use('/api/organizations/:organizationId/dashboard', require('./routes/dashboard'));
     app.use('/api/organizations/:organizationId/eligibility-codes', require('./routes/eligibilityCodes'));

--- a/packages/server/src/db/constants.js
+++ b/packages/server/src/db/constants.js
@@ -3,6 +3,7 @@ module.exports = {
         roles: 'roles',
         users: 'users',
         agencies: 'agencies',
+        tenants: 'tenants',
         grants: 'grants',
         grants_viewed: 'grants_viewed',
         grants_interested: 'grants_interested',

--- a/packages/server/src/db/index.js
+++ b/packages/server/src/db/index.js
@@ -460,6 +460,15 @@ async function getAgencies(rootAgency) {
     return result.rows;
 }
 
+// Use agency id for lookup for now
+async function getTenant(main_agency_id) {
+    const query = `SELECT id, display_name, main_agency_id 
+    FROM tenants WHERE main_agency_id = ?;`;
+    const result = await knex.raw(query, main_agency_id);
+
+    return result.rows;
+}
+
 async function getAgencyEligibilityCodes(agencyId) {
     const eligibilityCodes = await knex(TABLES.eligibility_codes).orderBy('code');
     const agencyEligibilityCodes = await knex(TABLES.agency_eligibility_codes)
@@ -510,6 +519,14 @@ function setAgencyThresholds(id, warning_threshold, danger_threshold) {
             id,
         })
         .update({ warning_threshold, danger_threshold });
+}
+
+function setTenantDisplayName(id, display_name) {
+    return knex(TABLES.tenants)
+        .where({
+            id,
+        })
+        .update({ display_name });
 }
 
 async function createRecord(tableName, row) {
@@ -595,12 +612,14 @@ module.exports = {
     markAccessTokenUsed,
     getAgency,
     getAgencies,
+    getTenant,
     getAgencyEligibilityCodes,
     setAgencyEligibilityCodeEnabled,
     getKeyword,
     getKeywords,
     getAgencyKeywords,
     setAgencyThresholds,
+    setTenantDisplayName,
     createKeyword,
     deleteKeyword,
     getGrants,

--- a/packages/server/src/routes/tenants.js
+++ b/packages/server/src/routes/tenants.js
@@ -1,0 +1,28 @@
+const express = require('express');
+
+const router = express.Router({ mergeParams: true });
+const { requireAdminUser, requireUser } = require('../lib/access-helpers');
+const {
+    getTenant, setTenantDisplayName,
+} = require('../db');
+
+router.get('/', requireUser, async (req, res) => {
+    const { user } = req.session;
+    let response;
+    if (user.role.name === 'admin') {
+        response = await getTenant(req.session.selectedAgency);
+    } else {
+        throw new Error(`You dont have access to tenants`);
+    }
+    res.json(response);
+});
+
+router.put('/:tenant', requireAdminUser, async (req, res) => {
+    // Currently, tenants are seeded into db; only display name is mutable.
+    const { tenant } = req.params;
+    const { displayName } = req.body;
+    const result = await setTenantDisplayName(tenant, displayName);
+    res.json(result);
+});
+
+module.exports = router;


### PR DESCRIPTION
This PR adds the tenant model to the database and the ability to edit the tenant's display name in the app.

Next steps: 
* Using tenant id instead of root agency in access helpers and as the organization id in the client 
* Restricting list of agencies to agencies in the user's tenant

Addresses #6 