### PR TITLE
43 add spoc button to tenants

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ yarn-debug.log*
 yarn-error.log*
 lerna-debug.log*
 
+# asdf tool version
+.tool-versions
+
 # Diagnostic reports (https://nodejs.org/api/report.html)
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
 

--- a/packages/client/src/components/Modals/GrantDetails.vue
+++ b/packages/client/src/components/Modals/GrantDetails.vue
@@ -56,7 +56,7 @@
               <b-button variant="outline-success" @click="markGrantAsInterested">Submit</b-button>
             </b-col>
           </b-row>
-          <b-row v-if="interested && !interested.interested_is_rejection">
+          <b-row v-if="interested && !interested.interested_is_rejection && shouldShowSpocButton">
             <b-col>
               <b-button variant="primary" @click="generateSpoc">Generate SPOC</b-button>
             </b-col>
@@ -166,18 +166,27 @@ export default {
       agencies: 'agencies/agencies',
       users: 'users/users',
       interestedCodes: 'grants/interestedCodes',
+      user: 'users/loggedInUser',
     }),
     alreadyViewed() {
       if (!this.selectedGrant) {
         return false;
       }
-      return this.selectedGrant.viewed_by_agencies.find((viewed) => viewed.agency_id.toString() === this.selectedAgencyId);
+      return this.selectedGrant.viewed_by_agencies.find(
+        (viewed) => viewed.agency_id.toString() === this.selectedAgencyId,
+      );
+    },
+    shouldShowSpocButton() {
+      if (!this.user.tenant.uses_spoc_process) return false;
+      return true;
     },
     interested() {
       if (!this.selectedGrant) {
         return false;
       }
-      return this.selectedGrant.interested_agencies.find((interested) => interested.agency_id.toString() === this.selectedAgencyId);
+      return this.selectedGrant.interested_agencies.find(
+        (interested) => interested.agency_id.toString() === this.selectedAgencyId,
+      );
     },
   },
   watch: {

--- a/packages/client/src/components/Modals/GrantDetails.vue
+++ b/packages/client/src/components/Modals/GrantDetails.vue
@@ -164,6 +164,7 @@ export default {
       agency: 'users/agency',
       selectedAgencyId: 'users/selectedAgencyId',
       agencies: 'agencies/agencies',
+      currentTenant: 'users/currentTenant',
       users: 'users/users',
       interestedCodes: 'grants/interestedCodes',
       user: 'users/loggedInUser',
@@ -177,7 +178,7 @@ export default {
       );
     },
     shouldShowSpocButton() {
-      if (!this.user.tenant.uses_spoc_process) return false;
+      if (!this.currentTenant.uses_spoc_process) return false;
       return true;
     },
     interested() {

--- a/packages/client/src/store/modules/users.js
+++ b/packages/client/src/store/modules/users.js
@@ -15,6 +15,7 @@ export default {
   state: initialState,
   getters: {
     loggedInUser: (state) => state.loggedInUser,
+    currentTenant: (state, getters) => (getters.loggedInUser ? getters.loggedInUser.tenant : null),
     users: (state) => state.users,
     userRole: (state, getters) => (getters.loggedInUser ? getters.loggedInUser.role.name : null),
     agency: (state, getters) => (getters.loggedInUser ? getters.loggedInUser.agency : null),

--- a/packages/server/migrations/20220417025208_add-spoc-setting-to-tenants.js
+++ b/packages/server/migrations/20220417025208_add-spoc-setting-to-tenants.js
@@ -1,0 +1,14 @@
+/* eslint-disable func-names */
+exports.up = function (knex) {
+    return knex.schema
+        .table('tenants', (table) => {
+            table.bool('uses_spoc_process').defaultTo(false);
+        });
+};
+
+exports.down = function (knex) {
+    return knex.schema
+        .table('tenants', (table) => {
+            table.dropColumn('uses_spoc_process');
+        });
+};

--- a/packages/server/src/db/index.js
+++ b/packages/server/src/db/index.js
@@ -91,10 +91,15 @@ async function getUser(id) {
             'agencies.main_agency_id as agency_main_agency_id',
             'agencies.warning_threshold as agency_warning_threshold',
             'agencies.danger_threshold as agency_danger_threshold',
+            'tenants.id as tenant_id',
+            'tenants.display_name as tenant_display_name',
+            'tenants.main_agency_id as tenant_main_agency_id',
+            'tenants.uses_spoc_process as tenant_uses_spoc_process',
             'users.tags',
         )
         .leftJoin('roles', 'roles.id', 'users.role_id')
         .leftJoin('agencies', 'agencies.id', 'users.agency_id')
+        .leftJoin('tenants', 'tenants.main_agency_id', 'agencies.main_agency_id')
         .where('users.id', id);
     if (user.role_id != null) {
         user.role = {
@@ -113,6 +118,12 @@ async function getUser(id) {
             danger_threshold: user.agency_danger_threshold,
             main_agency_id: user.agency_main_agency_id,
         };
+        user.tenant = {
+            id: user.tenant_id,
+            display_name: user.tenant_display_name,
+            main_agency_id: user.tenant_main_agency_id,
+            uses_spoc_process: user.tenant_uses_spoc_process,
+        };
         let subagencies = [];
         if (user.role.name === 'admin') {
             subagencies = await getAgencies(user.agency_id);
@@ -121,6 +132,10 @@ async function getUser(id) {
         }
         user.agency.subagencies = subagencies;
     }
+    delete user.tenant_id;
+    delete user.tenant_display_name;
+    delete user.tenant_main_agency_id;
+    delete user.tenant_uses_spoc_process;
     return user;
 }
 
@@ -440,11 +455,26 @@ function getInterestedCodes() {
 }
 
 async function getAgency(agencyId) {
-    const query = `SELECT id, name, abbreviation, parent, warning_threshold, danger_threshold 
-    FROM agencies WHERE id = ?;`;
-    const result = await knex.raw(query, agencyId);
+    const query = knex.select(
+        'id',
+        'name',
+        'abbreviation',
+        'parent',
+        'warning_threshold',
+        'danger_threshold',
+    )
+        .from(TABLES.agencies)
+        .where({
+            id: agencyId,
+        })
+        .leftJoin('tenants', 'tenants.main_agency_id', '=', `${TABLES.agencies}.main_agency_id`);
+    // const query = `SELECT id, name, abbreviation, parent, warning_threshold, danger_threshold
+    // FROM agencies WHERE id = ?;`;
+    // const result = await knex.raw(query, agencyId);
+    const result = await query;
 
-    return result.rows;
+    // return result.rows;
+    return result;
 }
 
 async function getAgencies(rootAgency) {

--- a/packages/server/src/db/index.js
+++ b/packages/server/src/db/index.js
@@ -468,12 +468,8 @@ async function getAgency(agencyId) {
             id: agencyId,
         })
         .leftJoin('tenants', 'tenants.main_agency_id', '=', `${TABLES.agencies}.main_agency_id`);
-    // const query = `SELECT id, name, abbreviation, parent, warning_threshold, danger_threshold
-    // FROM agencies WHERE id = ?;`;
-    // const result = await knex.raw(query, agencyId);
     const result = await query;
 
-    // return result.rows;
     return result;
 }
 


### PR DESCRIPTION
addresses #43 by adding `uses_spoc_process` column through migration and checks for the tenant `tenant.uses_spoc_process` to show/hide SPOC button in grants modal.