### PR TITLE
Remove COVID-related seeded keywords (closes #15)

### DIFF
--- a/packages/server/__tests__/api/keywords.test.js
+++ b/packages/server/__tests__/api/keywords.test.js
@@ -36,7 +36,7 @@ describe('`/api/keywords` endpoint', async () => {
 
     before(async function beforeHook() {
         this.timeout(9000); // Getting session cookies can exceed default timeout.
-        fetchOptions.admin.headers.cookie = await getSessionCookie('michael@nv.gov');
+        fetchOptions.admin.headers.cookie = await getSessionCookie('admin1@nv.gov');
         fetchOptions.staff.headers.cookie = await getSessionCookie('user1@nv.gov');
     });
 

--- a/packages/server/__tests__/api/keywords.test.js
+++ b/packages/server/__tests__/api/keywords.test.js
@@ -3,6 +3,7 @@ require('dotenv').config();
 
 const _ = require('lodash-checkit');
 const { getSessionCookie, fetchApi, knex } = require('./utils');
+const { TABLES } = require('../../src/db/constants');
 
 describe('`/api/keywords` endpoint', async () => {
     const agencies = {
@@ -52,7 +53,7 @@ describe('`/api/keywords` endpoint', async () => {
             notes: '',
             agency_id,
         }));
-        const createdKeywords = await knex('keywords')
+        const createdKeywords = await knex(TABLES.keywords)
             .insert(testKeywords)
             .onConflict('id')
             .merge()

--- a/packages/server/__tests__/api/keywords.test.js
+++ b/packages/server/__tests__/api/keywords.test.js
@@ -1,11 +1,10 @@
 const { expect } = require('chai');
 require('dotenv').config();
 
-const { getSessionCookie, fetchApi } = require('./utils');
+const _ = require('lodash-checkit');
+const { getSessionCookie, fetchApi, knex } = require('./utils');
 
 describe('`/api/keywords` endpoint', async () => {
-    const UNIQUE_KEYWORDS = 7; // all agencies have the same keywords
-
     const agencies = {
         admin: {
             own: 384,
@@ -34,10 +33,31 @@ describe('`/api/keywords` endpoint', async () => {
         },
     };
 
+    let testKeywordsByAgency = null;
+
     before(async function beforeHook() {
         this.timeout(9000); // Getting session cookies can exceed default timeout.
         fetchOptions.admin.headers.cookie = await getSessionCookie('admin1@nv.gov');
         fetchOptions.staff.headers.cookie = await getSessionCookie('user1@nv.gov');
+
+        // Tests below assume the presence of at least one keyword per agency. Previously, we had
+        // a db seed that created some default COVID-related keywords but now that that is gone, we
+        // create some here to avoid dependence on the global keywords seed.
+        // Note: this does not dedupe agency IDs and that's by design; some of the tests need to
+        // delete multiple keywords from the same agency.
+        const allAgencyIds = Object.values(agencies.admin).concat(Object.values(agencies.staff));
+        const testKeywords = allAgencyIds.map((agency_id) => ({
+            mode: 'autoinsert ALL keywords matches',
+            search_term: 'test_keyword',
+            notes: '',
+            agency_id,
+        }));
+        const createdKeywords = await knex('keywords')
+            .insert(testKeywords)
+            .onConflict('id')
+            .merge()
+            .returning(['id', 'agency_id']);
+        testKeywordsByAgency = _.groupBy(createdKeywords, 'agency_id');
     });
 
     context('GET api/keywords', async () => {
@@ -47,14 +67,12 @@ describe('`/api/keywords` endpoint', async () => {
                 const response = await fetchApi(`/keywords`, agencies.admin.own, fetchOptions.admin);
                 expect(response.statusText).to.equal('OK');
                 const json = await response.json();
-                expect(json.length).to.equal(UNIQUE_KEYWORDS);
                 expect((json.every((r) => r.agency_id === agencies.admin.own))).to.equal(true);
             });
             it('lists keywords of a subagency of this user\'s own agency', async () => {
                 const response = await fetchApi(`/keywords`, agencies.admin.ownSub, fetchOptions.admin);
                 expect(response.statusText).to.equal('OK');
                 const json = await response.json();
-                expect(json.length).to.equal(UNIQUE_KEYWORDS);
                 expect((json.every((r) => r.agency_id === agencies.admin.ownSub))).to.equal(true);
             });
             it('is forbidden for an agency outside this user\'s hierarchy', async () => {
@@ -68,7 +86,6 @@ describe('`/api/keywords` endpoint', async () => {
                 const response = await fetchApi(`/keywords`, agencies.staff.own, fetchOptions.staff);
                 expect(response.statusText).to.equal('OK');
                 const json = await response.json();
-                expect(json.length).to.equal(UNIQUE_KEYWORDS);
                 expect((json.every((r) => r.agency_id === agencies.staff.own))).to.equal(true);
             });
             it('is forbidden for a subagency of this user\'s own agency', async () => {
@@ -147,23 +164,24 @@ describe('`/api/keywords` endpoint', async () => {
     context('DELETE /keywords/:id (delete a keyword for an agency)', async () => {
         context('by a user with admin role', async () => {
             it('deletes a keyword of this user\'s own agency', async () => {
-                // TODO: the keywords ID might change if new agencies are added, we should query the db to find
-                // the correct ids to use instead of hardcoding it
-                const response = await fetchApi(`/keywords/23`, agencies.admin.own, {
+                const keywordId = testKeywordsByAgency[agencies.admin.own][0].id;
+                const response = await fetchApi(`/keywords/${keywordId}`, agencies.admin.own, {
                     ...fetchOptions.admin,
                     method: 'delete',
                 });
                 expect(response.statusText).to.equal('OK');
             });
             it('deletes a keyword of a subagency of this user\'s own agency', async () => {
-                const response = await fetchApi(`/keywords/143`, agencies.admin.ownSub, {
+                const keywordId = testKeywordsByAgency[agencies.admin.ownSub][0].id;
+                const response = await fetchApi(`/keywords/${keywordId}`, agencies.admin.ownSub, {
                     ...fetchOptions.admin,
                     method: 'delete',
                 });
                 expect(response.statusText).to.equal('OK');
             });
             it('is forbidden for a keyword of an agency outside this user\'s hierarchy', async () => {
-                const response = await fetchApi(`/keywords/4`, agencies.admin.offLimits, {
+                const keywordId = testKeywordsByAgency[agencies.admin.offLimits][0].id;
+                const response = await fetchApi(`/keywords/${keywordId}`, agencies.admin.offLimits, {
                     ...fetchOptions.admin,
                     method: 'delete',
                 });
@@ -172,21 +190,25 @@ describe('`/api/keywords` endpoint', async () => {
         });
         context('by a user with staff role', async () => {
             it('is forbidden for this user\'s own agency', async () => {
-                const response = await fetchApi(`/keywords/17`, agencies.staff.own, {
+                // Note: staff and admin test users share the same "own" agency id
+                const keywordId = testKeywordsByAgency[agencies.staff.own][1].id;
+                const response = await fetchApi(`/keywords/${keywordId}`, agencies.staff.own, {
                     ...fetchOptions.staff,
                     method: 'delete',
                 });
                 expect(response.statusText).to.equal('Forbidden');
             });
             it('is forbidden for a subagency of this user\'s own agency', async () => {
-                const response = await fetchApi(`/keywords/144`, agencies.staff.ownSub, {
+                const keywordId = testKeywordsByAgency[agencies.staff.ownSub][0].id;
+                const response = await fetchApi(`/keywords/${keywordId}`, agencies.staff.ownSub, {
                     ...fetchOptions.staff,
                     method: 'delete',
                 });
                 expect(response.statusText).to.equal('Forbidden');
             });
             it('is forbidden for an agency outside this user\'s hierarchy', async () => {
-                const response = await fetchApi(`/keywords/4`, agencies.staff.offLimits, {
+                const keywordId = testKeywordsByAgency[agencies.staff.offLimits][0].id;
+                const response = await fetchApi(`/keywords/${keywordId}`, agencies.staff.offLimits, {
                     ...fetchOptions.staff,
                     method: 'delete',
                 });

--- a/packages/server/__tests__/api/utils.js
+++ b/packages/server/__tests__/api/utils.js
@@ -15,7 +15,7 @@ async function getSessionCookie(email) {
         headers: { 'Content-Type': 'application/json' },
     });
     if (resp.status !== 200 || !(await resp.json()).success) {
-        throw new Error(`test called getSessionCookie for invalid user ${email}, are they in db seed?`);
+        throw new Error(`test called getSessionCookie for invalid user ${email}, are they in seeds/dev/ref/users.js?`);
     }
 
     // Get the new passcode directly from PostgresQL.

--- a/packages/server/__tests__/api/utils.js
+++ b/packages/server/__tests__/api/utils.js
@@ -9,11 +9,14 @@ const knex = require('knex')({
 
 async function getSessionCookie(email) {
     // POSTing an email address generates a passcode.
-    await fetch(`${process.env.API_DOMAIN}/api/sessions`, {
+    const resp = await fetch(`${process.env.API_DOMAIN}/api/sessions`, {
         method: 'POST',
         body: JSON.stringify({ email }),
         headers: { 'Content-Type': 'application/json' },
     });
+    if (resp.status !== 200 || !(await resp.json()).success) {
+        throw new Error(`test called getSessionCookie for invalid user ${email}, are they in db seed?`);
+    }
 
     // Get the new passcode directly from PostgresQL.
     const query = `SELECT created_at, passcode
@@ -41,4 +44,5 @@ function fetchApi(url, agencyId, fetchOptions) {
 module.exports = {
     getSessionCookie,
     fetchApi,
+    knex,
 };

--- a/packages/server/seeds/dev/ref/keywords.js
+++ b/packages/server/seeds/dev/ref/keywords.js
@@ -1,27 +1,13 @@
 const agencies = require('./agencies');
 
 const globalKeywords = [
-    {
-        mode: 'autoinsert ALL keywords matches', search_term: 'Covid', notes: '', agency_id: null,
-    },
-    {
-        mode: 'autoinsert ALL keywords matches', search_term: 'coronavirus', notes: '', agency_id: null,
-    },
-    {
-        mode: 'autoinsert ALL keywords matches', search_term: 'Cares Act', notes: '', agency_id: null,
-    },
-    {
-        mode: 'autoinsert ALL keywords matches', search_term: 'COVID-19', notes: '', agency_id: null,
-    },
-    {
-        mode: 'autoinsert ALL keywords matches', search_term: 'SARS-CoV-2', notes: '', agency_id: null,
-    },
-    {
-        mode: 'autoinsert ALL keywords matches', search_term: 'Coronavirus 2', notes: '', agency_id: null,
-    },
-    {
-        mode: 'autoinsert ALL keywords matches', search_term: '(CARES) Act', notes: '', agency_id: null,
-    },
+    // Keywords listed here will be pre-seeded for each agency, for example:
+    // {
+    //     mode: 'autoinsert ALL keywords matches',
+    //     search_term: 'Covid',
+    //     notes: '',
+    //     agency_id: null,
+    // },
 ];
 
 module.exports = [

--- a/packages/server/seeds/dev/ref/users.js
+++ b/packages/server/seeds/dev/ref/users.js
@@ -111,4 +111,12 @@ module.exports = [
         role_id: roles[0].id,
         tenant_id: dallasTenant.id,
     },
+    {
+        id: 13,
+        email: 'admin1@nv.gov', // fake email for testing
+        name: 'nv.gov Admin User 1',
+        agency_id: nevadaAgency.id,
+        role_id: roles[0].id,
+        tenant_id: nevadaenant.id,
+    },
 ];


### PR DESCRIPTION
Closes #15 by doing pretty much what the title says.

I had to make some changes to the keywords API test because it assumed the presence of the pre-seeded keywords. Now, the test creates its own keywords.

I also noticed that the test referred to a user that doesn't seem to exist in the users seed, `michael@nv.gov`. I replaced this with a new admin user under the same agency and added a better error log for when `getSessionCookie` is called with an invalid user. I noticed several other tests were failing locally for a similar reason, I've fixed those too, in a separate stacked PR: #63