### PR TITLE
Fix other tests affected by invalid seed user

### DIFF
--- a/packages/server/__tests__/api/agencies.test.js
+++ b/packages/server/__tests__/api/agencies.test.js
@@ -34,7 +34,7 @@ describe('`/api/organizations/:organizationId/agencies` endpoint', async () => {
 
     before(async function beforeHook() {
         this.timeout(9000); // Getting session cookies can exceed default timeout.
-        fetchOptions.admin.headers.cookie = await getSessionCookie('michael@stanford.notreal');
+        fetchOptions.admin.headers.cookie = await getSessionCookie('mindy@usdigitalresponse.org');
         fetchOptions.staff.headers.cookie = await getSessionCookie('user2@nv.gov');
     });
 

--- a/packages/server/__tests__/api/eligibilityCodes.test.js
+++ b/packages/server/__tests__/api/eligibilityCodes.test.js
@@ -36,7 +36,7 @@ describe('`/api/eligibility-codes` endpoint', async () => {
 
     before(async function beforeHook() {
         this.timeout(9000); // Getting session cookies can exceed default timeout.
-        fetchOptions.admin.headers.cookie = await getSessionCookie('michael@stanford.notreal');
+        fetchOptions.admin.headers.cookie = await getSessionCookie('mindy@usdigitalresponse.org');
         fetchOptions.staff.headers.cookie = await getSessionCookie('user2@nv.gov');
     });
 

--- a/packages/server/__tests__/api/grants.test.js
+++ b/packages/server/__tests__/api/grants.test.js
@@ -42,7 +42,7 @@ describe('`/api/grants` endpoint', async () => {
 
     before(async function beforeHook() {
         this.timeout(9000); // Getting session cookies can exceed default timeout.
-        fetchOptions.admin.headers.cookie = await getSessionCookie('michael@nv.gov');
+        fetchOptions.admin.headers.cookie = await getSessionCookie('admin1@nv.gov');
         fetchOptions.staff.headers.cookie = await getSessionCookie('user1@nv.gov');
         fetchOptions.dallasAdmin.headers.cookie = await getSessionCookie('user1@dallas.gov');
     });

--- a/packages/server/__tests__/api/users.test.js
+++ b/packages/server/__tests__/api/users.test.js
@@ -27,7 +27,7 @@ describe('`/api/users` endpoint', async () => {
 
     before(async function beforeHook() {
         this.timeout(9000); // Getting session cookies can exceed default timeout.
-        fetchOptions.admin.headers.cookie = await getSessionCookie('michael@nv.gov');
+        fetchOptions.admin.headers.cookie = await getSessionCookie('admin1@nv.gov');
         fetchOptions.staff.headers.cookie = await getSessionCookie('user1@nv.gov');
     });
 
@@ -99,13 +99,13 @@ describe('`/api/users` endpoint', async () => {
                 const response = await fetchApi(`/users`, agencies.own, fetchOptions.admin);
                 expect(response.statusText).to.equal('OK');
                 const json = await response.json();
-                expect(json.length).to.equal(11);
+                expect(json.length).to.equal(7);
             });
             it('lists users for a subagency of this user\'s own agency', async () => {
                 const response = await fetchApi(`/users`, agencies.ownSub, fetchOptions.admin);
                 expect(response.statusText).to.equal('OK');
                 const json = await response.json();
-                expect(json.length).to.equal(6);
+                expect(json.length).to.equal(3);
             });
             it('is forbidden for an agency outside this user\'s hierarchy', async () => {
                 const response = await fetchApi(`/users`, agencies.offLimits, fetchOptions.admin);


### PR DESCRIPTION
Depends on #62

As mentioned in #62's description, in the course of working on the PR I discovered some other tests failing locally because they referenced users that do not exist in the users seed. This fixes that for the other affected tests that were not directly related to what I was doing in #62.

I also found that two tests depended on a specific number of users that did not match what the seed creates and fixed that here too.

More broadly, I'm wondering if I'm misunderstanding the use case of these DB seeds -- I assumed they were intended just for local and test environments, but the existence of #15 implies they are used for creating agencies, keywords, etc. in production as well? It also seems that for the issues above to arise, the users seed would have needed to be modified after the tests were written (indeed #36 seems to be the culprit). Perhaps there should be a separate set of (seldom changed) seeds for API tests specifically?