### PR TITLE
fix: added agency id check to remove agency button in agency table

### DIFF
--- a/packages/client/src/components/Modals/GrantDetails.vue
+++ b/packages/client/src/components/Modals/GrantDetails.vue
@@ -92,7 +92,7 @@
         :fields="assignedAgenciesFields"
       >
       <template #cell(actions)="row">
-        <b-button variant="danger" class="mr-1" size="sm" @click="unassignAgenciesToGrant(row)">
+        <b-button v-if="row.item.agency_id === agency.id" variant="danger" class="mr-1" size="sm" @click="unassignAgenciesToGrant(row)">
           <b-icon icon="trash-fill" aria-hidden="true"></b-icon>
         </b-button>
       </template>

--- a/packages/server/seeds/dev/ref/users.js
+++ b/packages/server/seeds/dev/ref/users.js
@@ -25,7 +25,7 @@ module.exports = [
     },
     {
         id: 2,
-        email: 'mindy@usdigitalresponse.org', // fake email for testing
+        email: 'mhuang@usdigitalresponse.org', // fake email for testing
         name: 'Mindy Huant',
         agency_id: usdrAgency.id,
         role_id: roles[0].id,


### PR DESCRIPTION
easy fix added a check in the grants modal to only show delete button if the row's agency_id value matched the user's agency.id.

Closes #66 