### PR TITLE
100: Change eligibility codes to default as enabled for newly created agencies

### DIFF
--- a/packages/client/src/App.vue
+++ b/packages/client/src/App.vue
@@ -14,9 +14,9 @@ export default {
 </script>
 
 <style lang="scss">
-@import '../../node_modules/bootstrap/scss/bootstrap.scss';
-@import '../../node_modules/bootstrap-vue/src/index.scss';
-@import "../../node_modules/vue-select/src/scss/vue-select.scss";
+@import '../node_modules/bootstrap/scss/bootstrap.scss';
+@import '../node_modules/bootstrap-vue/src/index.scss';
+@import "../node_modules/vue-select/src/scss/vue-select.scss";
 
 #app {
   font-family: Avenir, Helvetica, Arial, sans-serif;

--- a/packages/server/src/db/index.js
+++ b/packages/server/src/db/index.js
@@ -481,7 +481,7 @@ async function getAgencyEligibilityCodes(agencyId) {
                 ...ec,
                 created_at: null,
                 updated_at: null,
-                enabled: false,
+                enabled: true,
             };
         }
         return {


### PR DESCRIPTION
### Ticket #100 

### Description

Changes the assumed value of agency eligibility code enabled to true. Unless otherwise specified in the database, eligibility codes will be enabled and checked.

### Screenshots / Demo Video
Eligibility codes screen for new agency BEFORE:
![i100before](https://user-images.githubusercontent.com/56096100/175625667-d3892c50-e6b4-4cfe-97c6-335e22a95c8b.PNG)

AFTER:
![i100after](https://user-images.githubusercontent.com/56096100/175626636-7e36d562-069c-432d-bcf2-2d3eef1abee8.PNG)


### Testing

Go to agencies -> add -> add the new agency -> refresh the page to make new agency available when selecting -> click on username in top right -> settings -> select new agency -> go to eligibility codes

### Checklist
- [x] Provided ticket and description
- [x] Your PR title contains the ISSUE ticket number e.g "86: ..."
- [x] Provided screenshots/demo
- [x] Provided testing information
- [x] Provided adequate test coverage for all new code
- [x] Added PR reviewers
- [ ] Ensure at least 1 review before merging