### PR TITLE
50: Add way to show/hide rejected and interested grants

### DIFF
--- a/packages/client/src/components/GrantsTable.vue
+++ b/packages/client/src/components/GrantsTable.vue
@@ -23,7 +23,7 @@
         </b-button>
       </b-col>
     </b-row>
-    <b-row class="mt-3 mb-3" align-h="between">
+    <b-row v-if="!showInterested && !showRejected && !showAssignedToAgency" class="mt-3 mb-3" align-h="between" style="position: relative; z-index: 999">
       <b-col cols="3">
         <multiselect v-model="reviewStatusFilters" :options="reviewStatusOptions"
           :multiple="true" :close-on-select="false"
@@ -34,6 +34,7 @@
     </b-row>
     <b-table
       id="grants-table"
+      sticky-header="600px"
       hover
       :items="formattedGrants"
       :fields="fields"
@@ -87,6 +88,7 @@ export default {
   components: { GrantDetails, Multiselect },
   props: {
     showInterested: Boolean,
+    showRejected: Boolean,
     showAging: Boolean,
     showAssignedToAgency: String,
   },
@@ -254,8 +256,8 @@ export default {
           interestedByMe: this.showInterested,
           aging: this.showAging,
           assignedToAgency: this.showAssignedToAgency,
-          positiveInterest: this.reviewStatusFilters.includes('interested') ? true : null,
-          rejected: this.reviewStatusFilters.includes('rejected') ? true : null,
+          positiveInterest: this.showInterested || (this.reviewStatusFilters.includes('interested') ? true : null),
+          rejected: this.showRejected || (this.reviewStatusFilters.includes('rejected') ? true : null),
         });
       } catch (e) {
         console.log(e);
@@ -332,6 +334,8 @@ export default {
         interestedByMe: this.showInterested,
         aging: this.showAging,
         assignedToAgency: this.showAssignedToAgency,
+        positiveInterest: this.showInterested || (this.reviewStatusFilters.includes('interested') ? true : null),
+        rejected: this.showRejected || (this.reviewStatusFilters.includes('rejected') ? true : null),
       });
     },
   },

--- a/packages/client/src/components/GrantsTable.vue
+++ b/packages/client/src/components/GrantsTable.vue
@@ -23,9 +23,17 @@
         </b-button>
       </b-col>
     </b-row>
+    <b-row class="mt-3 mb-3" align-h="between">
+      <b-col cols="3">
+        <multiselect v-model="reviewStatusFilters" :options="reviewStatusOptions"
+          :multiple="true" :close-on-select="false"
+          :clear-on-select="false"
+          placeholder="Review Status">
+        </multiselect>
+      </b-col>
+    </b-row>
     <b-table
       id="grants-table"
-      sticky-header="600px"
       hover
       :items="formattedGrants"
       :fields="fields"
@@ -69,13 +77,14 @@
 <script>
 import { mapActions, mapGetters } from 'vuex';
 import { debounce } from 'lodash';
+import Multiselect from 'vue-multiselect';
 
 import { titleize } from '@/helpers/form-helpers';
 
 import GrantDetails from '@/components/Modals/GrantDetails.vue';
 
 export default {
-  components: { GrantDetails },
+  components: { GrantDetails, Multiselect },
   props: {
     showInterested: Boolean,
     showAging: Boolean,
@@ -140,6 +149,8 @@ export default {
       orderBy: '',
       searchInput: null,
       debouncedSearchInput: null,
+      reviewStatusFilters: [],
+      reviewStatusOptions: ['interested', 'rejected'],
     };
   },
   mounted() {
@@ -192,6 +203,9 @@ export default {
     },
   },
   watch: {
+    reviewStatusFilters() {
+      this.paginateGrants();
+    },
     selectedAgency() {
       this.setup();
     },
@@ -240,6 +254,8 @@ export default {
           interestedByMe: this.showInterested,
           aging: this.showAging,
           assignedToAgency: this.showAssignedToAgency,
+          positiveInterest: this.reviewStatusFilters.includes('interested') ? true : null,
+          rejected: this.reviewStatusFilters.includes('rejected') ? true : null,
         });
       } catch (e) {
         console.log(e);

--- a/packages/client/src/components/GrantsTable.vue
+++ b/packages/client/src/components/GrantsTable.vue
@@ -23,7 +23,8 @@
         </b-button>
       </b-col>
     </b-row>
-    <b-row v-if="!showInterested && !showRejected && !showAssignedToAgency" class="mt-3 mb-3" align-h="between" style="position: relative; z-index: 999">
+    <b-row v-if="!showInterested && !showRejected && !showAssignedToAgency" class="mt-3 mb-3" align-h="between"
+    style="position: relative; z-index: 999">
       <b-col cols="3">
         <multiselect v-model="reviewStatusFilters" :options="reviewStatusOptions"
           :multiple="true" :close-on-select="false"

--- a/packages/client/src/store/modules/grants.js
+++ b/packages/client/src/store/modules/grants.js
@@ -24,10 +24,10 @@ export default {
   },
   actions: {
     fetchGrants({ commit }, {
-      currentPage, perPage, orderBy, searchTerm, interestedByMe, assignedToAgency, aging,
+      currentPage, perPage, orderBy, searchTerm, interestedByMe, assignedToAgency, aging, positiveInterest, rejected,
     }) {
       const query = Object.entries({
-        currentPage, perPage, orderBy, searchTerm, interestedByMe, assignedToAgency, aging,
+        currentPage, perPage, orderBy, searchTerm, interestedByMe, assignedToAgency, aging, positiveInterest, rejected,
       })
         // filter out undefined and nulls since api expects parameters not present as undefined
         // eslint-disable-next-line no-unused-vars

--- a/packages/client/src/views/MyGrants.vue
+++ b/packages/client/src/views/MyGrants.vue
@@ -6,6 +6,9 @@
     <b-tab title="Assigned">
       <GrantsTable :showAssignedToAgency="selectedAgencyId"/>
     </b-tab>
+    <b-tab title="Rejected">
+      <GrantsTable :showRejected="true"/>
+    </b-tab>
   </b-tabs>
 </template>
 

--- a/packages/server/src/db/index.js
+++ b/packages/server/src/db/index.js
@@ -274,8 +274,9 @@ async function getGrants({
                 );
             }
             if (filters) {
-                if (filters.interestedByUser) {
-                    queryBuilder.join(TABLES.grants_interested, `${TABLES.grants}.grant_id`, `${TABLES.grants_interested}.grant_id`);
+                if (filters.interestedByUser || filters.positiveInterest || filters.rejected) {
+                    queryBuilder.join(TABLES.grants_interested, `${TABLES.grants}.grant_id`, `${TABLES.grants_interested}.grant_id`)
+                    .join(TABLES.interested_codes, `${TABLES.interested_codes}.id`, `${TABLES.grants_interested}.interested_code_id`);
                 }
                 if (filters.assignedToAgency) {
                     queryBuilder.join(TABLES.assigned_grants_agency, `${TABLES.grants}.grant_id`, `${TABLES.assigned_grants_agency}.grant_id`);
@@ -289,6 +290,14 @@ async function getGrants({
                         }
                         if (filters.assignedToAgency) {
                             qb.where(`${TABLES.assigned_grants_agency}.agency_id`, '=', filters.assignedToAgency);
+                        }
+                        if (!(filters.positiveInterest && filters.rejected)) {
+                            if (filters.positiveInterest) {
+                                qb.where(`${TABLES.interested_codes}.is_rejection`, '=', false);
+                            }
+                            if (filters.rejected) {
+                                qb.where(`${TABLES.interested_codes}.is_rejection`, '=', true);
+                            }
                         }
                     },
                 );

--- a/packages/server/src/routes/grants.js
+++ b/packages/server/src/routes/grants.js
@@ -65,6 +65,8 @@ router.get('/', requireUser, async (req, res) => {
             agencyCriteria,
             interestedByUser: req.query.interestedByMe ? req.signedCookies.userId : null,
             assignedToAgency: req.query.assignedToAgency ? req.query.assignedToAgency : null,
+            positiveInterest: req.query.positiveInterest ? true : null,
+            rejected: req.query.rejected ? true : null,
         },
     });
     res.json(grants);

--- a/packages/server/src/routes/grants.js
+++ b/packages/server/src/routes/grants.js
@@ -94,6 +94,8 @@ router.get('/exportCSV', requireUser, async (req, res) => {
             agencyCriteria,
             interestedByUser: req.query.interestedByMe ? req.signedCookies.userId : null,
             assignedToAgency: req.query.assignedToAgency ? req.query.assignedToAgency : null,
+            positiveInterest: req.query.positiveInterest ? true : null,
+            rejected: req.query.rejected ? true : null,
         },
     });
 


### PR DESCRIPTION
### Ticket #50 

### Description

This branch adds the ability to show/hide rejected and interested grants by using a filtering system. On the grants tab, there is a drop down menu to filter by grants marked as positively interested and rejected. On the my grants tab, there is another tab added exclusively for rejected grants with the interested tab now only showing those grants marked with an interested code that indicates positive interest. These filters were added to the export csv functionality as well.

### Screenshots / Demo Video

Drop down menu on grants tab
![50-1](https://user-images.githubusercontent.com/56096100/178325165-da675ea6-0f95-4754-a9bd-38cd0a62d011.png)

Multiple options can be selected
![50-2](https://user-images.githubusercontent.com/56096100/178325217-f59c0a2a-e495-40c3-a72c-6468c2d3bb3f.PNG)

Or just one option can be selected
![50-3](https://user-images.githubusercontent.com/56096100/178325254-45624ef4-5706-4892-b476-4c5c86a283eb.PNG)

New rejected tab in my grants tab
![50-4](https://user-images.githubusercontent.com/56096100/178325283-0b618e3c-04da-4d1b-93a0-b988e8640812.PNG)


### Testing

In the grants tab, select some grants and mark as interested or rejected -> in the grants tab, use the review status drop down menu to test filtering options. -> switch to the my grants tab to see grants associated with the logged in user and switch between the interested/rejected tabs for testing. -> try export csv to test if currently displayed grants are consistent with the output.

### Checklist
- [x] Provided ticket and description
- [x] Your PR title contains the ISSUE ticket number e.g "86: ..."
- [x] Provided screenshots/demo
- [x] Provided testing information
- [x] Provided adequate test coverage for all new code
- [x] Added PR reviewers
- [x] Ensure at least 1 review before merging