### PR TITLE
Issue 131 backend for agency activity table

### DIFF
--- a/packages/server/src/db/index.js
+++ b/packages/server/src/db/index.js
@@ -376,7 +376,7 @@ async function getTotalInterestedGrants() {
 
 async function getTotalInterestedGrantsByAgencies() {
     const rows = await knex(TABLES.grants_interested)
-        .select(`${TABLES.grants_interested}.agency_id`, `${TABLES.agencies}.name`, `${TABLES.agencies}.abbreviation`,  
+        .select(`${TABLES.grants_interested}.agency_id`, `${TABLES.agencies}.name`, `${TABLES.agencies}.abbreviation`,
             knex.raw('SUM(CASE WHEN is_rejection = TRUE THEN 1 ELSE 0 END) rejections'),
             knex.raw('SUM(CASE WHEN is_rejection = FALSE THEN 1 ELSE 0 END) interested'),
             knex.raw('SUM(award_ceiling::numeric) total_grant_money'),

--- a/packages/server/src/db/index.js
+++ b/packages/server/src/db/index.js
@@ -376,11 +376,15 @@ async function getTotalInterestedGrants() {
 
 async function getTotalInterestedGrantsByAgencies() {
     const rows = await knex(TABLES.grants_interested)
-        .select(`${TABLES.grants_interested}.agency_id`, `${TABLES.agencies}.name`, `${TABLES.agencies}.abbreviation`,
+        .select(`${TABLES.grants_interested}.agency_id`, `${TABLES.agencies}.name`, `${TABLES.agencies}.abbreviation`,  
             knex.raw('SUM(CASE WHEN is_rejection = TRUE THEN 1 ELSE 0 END) rejections'),
-            knex.raw('SUM(CASE WHEN is_rejection = FALSE THEN 1 ELSE 0 END) interested'))
+            knex.raw('SUM(CASE WHEN is_rejection = FALSE THEN 1 ELSE 0 END) interested'),
+            knex.raw('SUM(award_ceiling::numeric) total_grant_money'),
+            knex.raw('SUM(CASE WHEN is_rejection = FALSE THEN award_ceiling::numeric ELSE 0 END) total_interested_grant_money'),
+            knex.raw('SUM(CASE WHEN is_rejection = TRUE THEN award_ceiling::numeric ELSE 0 END) total_rejected_grant_money'))
         .join(TABLES.agencies, `${TABLES.grants_interested}.agency_id`, `${TABLES.agencies}.id`)
         .join(TABLES.interested_codes, `${TABLES.grants_interested}.interested_code_id`, `${TABLES.interested_codes}.id`)
+        .join(TABLES.grants, `${TABLES.grants_interested}.grant_id`, `${TABLES.grants}.grant_id`)
         .count(`${TABLES.interested_codes}.is_rejection`)
         .groupBy(`${TABLES.grants_interested}.agency_id`, `${TABLES.agencies}.name`, `${TABLES.agencies}.abbreviation`);
     return rows;


### PR DESCRIPTION
### Ticket #131 

### Description

Adds functionality to getTotalInterestedGrantsByAgencies() function used in the dashboard for filling in the agency activity table. Three more columns of data are available for each agency row: 

* Total value of award ceiling for all grants (both interested and rejected)
* Total value for interested grants
* Total value for rejected grants

These columns are represented by the keys "total_grant_money," "total_interested_grant_money," and "total_rejected_grant_money," respectively

### Screenshots / Demo Video

Only contains backend changes, no visual features to demo.

### Testing

For testing, the values in 'totalInterestedGrantsByAgencies' in Dashboard.vue can be looked at manually by logging or visualized by adding fields in the dashboard file's "groupByFields" that have keys matching those given above. It is helpful to pick an agency and manually add the grant values in each of the three categories to confirm values with those returned by the function.

### Checklist
- [x] Provided ticket and description
- [x] Your PR title contains the ISSUE ticket number e.g "86: ..."
- [x] Provided screenshots/demo
- [x] Provided testing information
- [x] Provided adequate test coverage for all new code
- [x] Added PR reviewers
- [ ] Ensure at least 1 review before merging