### PR TITLE
133 upcoming grants table backend

### DIFF
--- a/packages/client/src/App.vue
+++ b/packages/client/src/App.vue
@@ -14,9 +14,9 @@ export default {
 </script>
 
 <style lang="scss">
-@import '../../node_modules/bootstrap/scss/bootstrap.scss';
-@import '../../node_modules/bootstrap-vue/src/index.scss';
-@import "../../node_modules/vue-select/src/scss/vue-select.scss";
+@import '../node_modules/bootstrap/scss/bootstrap.scss';
+@import '../node_modules/bootstrap-vue/src/index.scss';
+@import "../node_modules/vue-select/src/scss/vue-select.scss";
 
 #app {
   font-family: Avenir, Helvetica, Arial, sans-serif;

--- a/packages/client/src/App.vue
+++ b/packages/client/src/App.vue
@@ -14,9 +14,9 @@ export default {
 </script>
 
 <style lang="scss">
-@import '../node_modules/bootstrap/scss/bootstrap.scss';
-@import '../node_modules/bootstrap-vue/src/index.scss';
-@import "../node_modules/vue-select/src/scss/vue-select.scss";
+@import 'bootstrap/scss/bootstrap.scss';
+@import 'bootstrap-vue/src/index.scss';
+@import 'vue-select/src/scss/vue-select.scss';
 
 #app {
   font-family: Avenir, Helvetica, Arial, sans-serif;

--- a/packages/client/src/views/Dashboard.vue
+++ b/packages/client/src/views/Dashboard.vue
@@ -33,9 +33,7 @@
 </template>
 
 <script>
-
 import { mapActions, mapGetters } from 'vuex';
-
 import resizableTableMixin from '@/mixin/resizableTable';
 
 export default {
@@ -84,7 +82,6 @@ export default {
       grantsUpdatedInTimeframeMatchingCriteria: 'dashboard/grantsUpdatedInTimeframeMatchingCriteria',
       totalInterestedGrantsByAgencies: 'dashboard/totalInterestedGrantsByAgencies',
       selectedAgency: 'users/selectedAgency',
-      grants: 'grants/grants',
     }),
   },
   watch: {
@@ -98,27 +95,6 @@ export default {
     }),
     setup() {
       this.fetchDashboard();
-    },
-    fetchUpcomingGrants() {
-      const DAYS_TO_MILLISECS = 24 * 60 * 60 * 1000;
-      const warningThreshold = (this.agency.warning_threshold || 30) * DAYS_TO_MILLISECS;
-      const dangerThreshold = (this.agency.danger_threshold || 15) * DAYS_TO_MILLISECS;
-      const now = new Date();
-
-      return this.grants.map((grant) => ({
-        ...grant,
-        close_date: new Date(grant.close_date).toLocaleDateString('en-US'),
-        _cellVariants: (() => {
-          const diff = new Date(grant.close_date) - now;
-          if (diff <= dangerThreshold) {
-            return { close_date: 'danger' };
-          }
-          if (diff <= warningThreshold) {
-            return { close_date: 'warning' };
-          }
-          return {};
-        })(),
-      }));
     },
   },
 };

--- a/packages/client/src/views/Dashboard.vue
+++ b/packages/client/src/views/Dashboard.vue
@@ -84,6 +84,7 @@ export default {
       grantsUpdatedInTimeframeMatchingCriteria: 'dashboard/grantsUpdatedInTimeframeMatchingCriteria',
       totalInterestedGrantsByAgencies: 'dashboard/totalInterestedGrantsByAgencies',
       selectedAgency: 'users/selectedAgency',
+      grants: 'grants/grants',
     }),
   },
   watch: {
@@ -97,6 +98,27 @@ export default {
     }),
     setup() {
       this.fetchDashboard();
+    },
+    fetchUpcomingGrants() {
+      const DAYS_TO_MILLISECS = 24 * 60 * 60 * 1000;
+      const warningThreshold = (this.agency.warning_threshold || 30) * DAYS_TO_MILLISECS;
+      const dangerThreshold = (this.agency.danger_threshold || 15) * DAYS_TO_MILLISECS;
+      const now = new Date();
+
+      return this.grants.map((grant) => ({
+        ...grant,
+        close_date: new Date(grant.close_date).toLocaleDateString('en-US'),
+        _cellVariants: (() => {
+          const diff = new Date(grant.close_date) - now;
+          if (diff <= dangerThreshold) {
+            return { close_date: 'danger' };
+          }
+          if (diff <= warningThreshold) {
+            return { close_date: 'warning' };
+          }
+          return {};
+        })(),
+      }));
     },
   },
 };

--- a/packages/client/src/views/Dashboard.vue
+++ b/packages/client/src/views/Dashboard.vue
@@ -82,6 +82,7 @@ export default {
       grantsUpdatedInTimeframeMatchingCriteria: 'dashboard/grantsUpdatedInTimeframeMatchingCriteria',
       totalInterestedGrantsByAgencies: 'dashboard/totalInterestedGrantsByAgencies',
       selectedAgency: 'users/selectedAgency',
+      getClosestGrants: 'grants/getClosestGrants',
     }),
   },
   watch: {

--- a/packages/server/src/db/index.js
+++ b/packages/server/src/db/index.js
@@ -341,14 +341,17 @@ async function getGrant({ grantId }) {
 }
 
 async function getClosestGrants() {
-    const query = await knex('grants')
+    const timestamp = new Date();
+    const query = await knex(TABLES.grants)
         .select('title')
-        .orderby('close_date', asc)
+        .where('close_date', '>=', timestamp)
+        .orderBy('close_date', 'asc')
         .limit(3)
     return query;
 }
 
 async function getTotalGrants({ agencyCriteria, createdTsBounds, updatedTsBounds } = {}) {
+    // console.log(await getClosestGrants());
     const rows = await knex(TABLES.grants)
         .modify(helpers.whereAgencyCriteriaMatch, agencyCriteria)
         .modify((qb) => {

--- a/packages/server/src/db/index.js
+++ b/packages/server/src/db/index.js
@@ -340,6 +340,14 @@ async function getGrant({ grantId }) {
     return results[0];
 }
 
+async function getClosestGrants() {
+    const query = await knex('grants')
+        .select('title')
+        .orderby('close_date', asc)
+        .limit(3)
+    return query;
+}
+
 async function getTotalGrants({ agencyCriteria, createdTsBounds, updatedTsBounds } = {}) {
     const rows = await knex(TABLES.grants)
         .modify(helpers.whereAgencyCriteriaMatch, agencyCriteria)
@@ -623,6 +631,7 @@ module.exports = {
     createKeyword,
     deleteKeyword,
     getGrants,
+    getClosestGrants,
     getGrant,
     getTotalGrants,
     getTotalViewedGrants,

--- a/packages/server/src/db/index.js
+++ b/packages/server/src/db/index.js
@@ -343,7 +343,7 @@ async function getGrant({ grantId }) {
 async function getClosestGrants() {
     const timestamp = new Date();
     const query = await knex(TABLES.grants)
-        .select('title')
+        .select('title', 'close_date')
         .where('close_date', '>=', timestamp)
         .orderBy('close_date', 'asc')
         .limit(3)
@@ -351,7 +351,6 @@ async function getClosestGrants() {
 }
 
 async function getTotalGrants({ agencyCriteria, createdTsBounds, updatedTsBounds } = {}) {
-    // console.log(await getClosestGrants());
     const rows = await knex(TABLES.grants)
         .modify(helpers.whereAgencyCriteriaMatch, agencyCriteria)
         .modify((qb) => {


### PR DESCRIPTION
Issue #133 

Issue Solution: 
Created getClosestGrants() query to get 3 grants that have the closest close dates in comparison to the current date, returns the title and date of the of the grant since the Upcoming Closing Dates sections will only display those pieces of grant information. The API for getting the abbreviations of all agencies interested (to be placed under the grant name) already exists (used in the Grants Table "interested Agencies" column).

Screenshots:
Only backend API work and no frontend implementation

Testing:
Checking the grants date in the Grants Table using the sorting feature and comparing them to the query return value.
