### PR TITLE
151 edit dashboard cards

### DIFF
--- a/packages/client/src/views/Dashboard.vue
+++ b/packages/client/src/views/Dashboard.vue
@@ -68,29 +68,24 @@
     </div>
     <b-row>
       <b-col cols='4'>
-        <b-card bg-variant='secondary' text-variant='white' header='Total Grants Matching Search Criteria'
-          class='text-center mb-3'>
-          <h3>{{ totalGrantsMatchingAgencyCriteria }} of {{ totalGrants }}</h3>
-          <b-link class='stretched-link' to='/grants' />
-        </b-card>
         <b-card bg-variant='secondary' text-variant='white' header='New Grants Matching Search Criteria, Last 24Hrs'
-          class='text-center mb-3'>
+          class='text-center mb-3 mt-3'>
           <h3>{{ grantsCreatedInTimeframeMatchingCriteria }} of {{ grantsCreatedInTimeframe }}</h3>
           <b-link class='stretched-link' to='/grants' />
         </b-card>
+      </b-col>
+      <b-col cols='4'>
         <b-card bg-variant='secondary' text-variant='white' header='Updated Grants Matching Search Criteria, Last 24Hrs'
-          class='text-center mb-3'>
+          class='text-center mb-3 mt-3'>
           <h3>{{ grantsUpdatedInTimeframeMatchingCriteria }} of {{ grantsUpdatedInTimeframe }}</h3>
           <b-link class='stretched-link' to='/grants' />
         </b-card>
       </b-col>
       <b-col cols='4'>
-        <b-card bg-variant='secondary' text-variant='white' header='Total Viewed Grants' class='text-center mb-3'>
-          <h3>{{ totalViewedGrants }}</h3>
-        </b-card>
-        <b-card bg-variant='secondary' text-variant='white' header='Total Interested Grants' class='text-center mb-3'>
-          <h3>{{ totalInterestedGrants }}</h3>
-          <b-link class='stretched-link' to='/my-grants' />
+        <b-card bg-variant='secondary' text-variant='white' header='Total Grants Matching Search Criteria'
+          class='text-center mb-3 mt-3'>
+          <h3>{{ totalGrantsMatchingAgencyCriteria }} of {{ totalGrants }}</h3>
+          <b-link class='stretched-link' to='/grants' />
         </b-card>
       </b-col>
     </b-row>


### PR DESCRIPTION
### Ticket #151 

### Description

The original dashboard had five grey cards of information. This removes two of them and rearranges the other three to match the new dashboard wireframe.

### Screenshots / Demo Video

Cards before:
![7-22before](https://user-images.githubusercontent.com/56096100/180512374-4638e11b-b4e3-4c15-ab15-e604036a4942.PNG)

Cards after in context of entire dashboard:
![7-22after](https://user-images.githubusercontent.com/56096100/180512435-3c203641-647c-4bd6-bb66-c509f50ef801.PNG)

### Testing

Go to dashboard -> verify cards match the wireframe of the new dashboard layout.

### Checklist
- [x] Provided ticket and description
- [x] Your PR title contains the ISSUE ticket number e.g "86: ..."
- [x] Provided screenshots/demo
- [x] Provided testing information
- [x] Provided adequate test coverage for all new code
- [x] Added PR reviewers
- [ ] Ensure at least 1 review before merging