### PR TITLE
176 fix duplicates in interested/rejected

### DIFF
--- a/packages/server/src/db/index.js
+++ b/packages/server/src/db/index.js
@@ -265,6 +265,7 @@ async function getGrants({
 } = {}) {
     const { data, pagination } = await knex(TABLES.grants)
         .select(`${TABLES.grants}.*`)
+        .distinct()
         .modify((queryBuilder) => {
             if (searchTerm && searchTerm !== 'null') {
                 queryBuilder.andWhere(


### PR DESCRIPTION
### Ticket #176 

### Description

Fixes the duplicate entries found when applying interested/rejected filters.

### Screenshots / Demo Video

Before
![before 7-28](https://user-images.githubusercontent.com/56096100/181594356-2b485a1b-736d-49f0-8a0e-91c8b57d9ae9.PNG)

After
![after 7-28](https://user-images.githubusercontent.com/56096100/181594389-b1c84056-945a-46e8-95ef-d19f18423a01.PNG)

### Testing

Mark the same grant as interested/rejected with multiple subagencies -> apply an interested or rejected filter in grants or my grants and check that there are no duplicates

### Checklist
- [x] Provided ticket and description
- [x] Your PR title contains the ISSUE ticket number e.g "86: ..."
- [x] Provided screenshots/demo
- [x] Provided testing information
- [x] Provided adequate test coverage for all new code
- [x] Added PR reviewers
- [ ] Ensure at least 1 review before merging