### PR TITLE
fix(157): added front end full page see all upcoming

### DIFF
--- a/packages/client/src/router/index.js
+++ b/packages/client/src/router/index.js
@@ -41,6 +41,14 @@ const routes = [
         },
       },
       {
+        path: '/UpcomingClosingDates',
+        name: 'UpcomingClosingDates',
+        component: () => import('../views/UpcomingClosingDates.vue'),
+        meta: {
+          requiresAuth: true,
+        },
+      },
+      {
         path: '/grants',
         name: 'grants',
         component: () => import('../views/Grants.vue'),

--- a/packages/client/src/views/Dashboard.vue
+++ b/packages/client/src/views/Dashboard.vue
@@ -1,24 +1,19 @@
 <!-- eslint-disable max-len -->
 <template>
   <section class='m-3'>
-    <!-- couple options here, could use card-group, could use container, could use card-deck, card-columns -->
     <div class="px-5">
-      <!-- adds padding in the margin -->
       <b-container fluid>
         <div class="row">
           <b-col cols="1"></b-col>
           <b-col>
             <b-card title='Recent Activity'>
-              <!-- added -> :sort-by.sync="sortBy" :sort-desc.sync="sortAsc" for sorting -->
               <b-table sticky-header='300px' hover :items='activityItems' :fields='activityFields'
                 :sort-by.sync="sortBy" :sort-desc.sync="sortAsc" class='table table-borderless' thead-class="d-none">
                 <template #cell(icon)="list">
-                  <!-- if interested, display check, if not display X -->
                   <b-icon v-if="list.item.interested" icon="check-circle-fill" scale="1" variant="success"></b-icon>
                   <b-icon v-else icon="x-circle-fill" scale="1" variant="danger"></b-icon>
                 </template>
                 <template #cell(agencyAndGrant)="agencies">
-                  <!-- display agency then either interested or rejected, then the grant all in the same line -->
                   <div>{{ agencies.item.agency }}
                     <span v-if="agencies.item.interested"> is
                       <span class="color-green">interested </span> in
@@ -27,12 +22,10 @@
                   </div>
                 </template>
                 <template #cell(date)="dates">
-                  <!-- make the dates gray -->
                   <div class="color-gray">{{ dates.item.date }}</div>
                 </template>
               </b-table>
               <b-row align-v="center">
-                <!-- see all button -->
                 <b-button variant="link" size="sm" color="primary" class="mr-1" @click="seeAllActivity">
                   See All Activity
                 </b-button>
@@ -56,10 +49,9 @@
                 </template>
               </b-table>
               <b-row align-v="center">
-                <!-- see all button -->
-                <b-button variant="link" size="sm" color="primary" class="mr-1" @click="seeAllUpcoming">
-                  See All Upcoming
-                </b-button>
+                 <b-navbar toggleable="sm py-0" bg-transparent>
+                  <a class="nav-link active" href="#/UpcomingClosingDates">See All Upcoming</a>
+                </b-navbar>
               </b-row>
             </b-card>
           </b-col>

--- a/packages/client/src/views/Dashboard.vue
+++ b/packages/client/src/views/Dashboard.vue
@@ -91,24 +91,6 @@
     </b-card>
   </section>
 </template>
-<style scoped>
-.color-gray{
-color: gray;
-}
-
-.color-yellow {
-  /* darkkhaki is used in place of traditional yellow for readability */
-  color: darkkhaki;
-}
-
-.color-red {
-  color: red;
-}
-
-.color-green {
-  color: green;
-}
-</style>
 
 <style scoped>
 .color-gray{

--- a/packages/client/src/views/UpcomingClosingDates.vue
+++ b/packages/client/src/views/UpcomingClosingDates.vue
@@ -1,0 +1,104 @@
+<template>
+<section class="container">
+<b-card title='Upcoming Closing Dates' class="border-0">
+    <b-table sticky-header='350px' hover :items='upcomingItems' :fields='upcomingFields'
+    class='table table-borderless' thead-class="d-none">
+        <template #cell(date)="dates">
+            <!-- color the date to gray, yellow, or red based on the dateColor boolean -->
+            <div v-if="dates.item.dateColor === 0" class="color-gray">{{ dates.item.date }}</div>
+            <div v-if="dates.item.dateColor === 1" class="color-yellow">{{ dates.item.date }}</div>
+            <div v-if="dates.item.dateColor === 2" class="color-red">{{ dates.item.date }}</div>
+        </template>
+        <template #cell(agencyAndGrant)="agencies">
+            <!-- display the interestedAgencies in a new <div> so it appears below the grant -->
+            <div>{{ agencies.item.agencyAndGrant }}</div>
+            <div class="color-gray">{{ agencies.item.interestedAgencies }}</div>
+        </template>
+    </b-table>
+    </b-card>
+    </section>
+</template>
+
+<style scoped>
+.color-gray {
+  color: gray;
+}
+
+.color-red {
+  color: red;
+}
+
+</style>
+
+<script>
+import { mapActions, mapGetters } from 'vuex';
+import resizableTableMixin from '@/mixin/resizableTable';
+
+export default {
+  components: {
+  },
+  data() {
+    return {
+      sortBy: 'dateSort',
+      sortAsc: true,
+      upcomingFields: [
+        {
+          // col for Grants and interested agencies
+          key: 'agencyAndGrant',
+          label: '',
+          thStyle: { width: '80%' },
+        },
+        {
+          // col for when the grant will be closing
+          key: 'date',
+          label: '',
+          thStyle: { width: '20%' },
+        },
+      ],
+      upcomingItems: [
+        {
+          agencyAndGrant: 'FY21 Supplemental for the Northeast Corridor Cooperative Agreement to the National Railroad Passenger Corporation',
+          interestedAgencies: 'Dept of Admin, State of Nevada,',
+          date: '12/12/12',
+          dateColor: 2, // 2 corresponds to red, 1 corresponds to yellow, 0 corresponds to gray
+        },
+        {
+          agencyAndGrant: 'Environmental Justice Collaborative Problem-Solving (EJCPS) Cooperative Agreement Program',
+          interestedAgencies: 'GO, AP, SNV',
+          date: '12/12/12',
+          dateColor: 1,
+        },
+        {
+          agencyAndGrant: 'Strengthening Public Health Research and Implementation Science (Operations Research) to Control and Eliminate Infectious Diseases Globally',
+          interestedAgencies: 'SHRAB, SNV',
+          date: '12/20/12',
+          dateColor: 0,
+        },
+      ],
+    };
+  },
+
+  mixins: [resizableTableMixin],
+  mounted() {
+    this.setup();
+  },
+  computed: {
+    ...mapGetters({
+    //  Things will need to go here when backend func is added
+    }),
+  },
+  methods: {
+    ...mapActions({
+    //  Things will need to go here when backend func is added
+    //   fetchDashboard: 'dashboard/fetchDashboard',
+    //   fetchGrantsInterested: 'grants/fetchGrantsInterested',
+    }),
+    setup() {
+    //  Things will need to go here when backend func is added
+    //   this.fetchDashboard();
+    //   this.fetchGrantsInterested();
+    },
+  },
+};
+
+</script>


### PR DESCRIPTION
### Ticket #157

### Description
Added the see all upcoming button full page FRONT END functionality, once the changes for the backend functionality of the upcoming closing dates is finished they can be added right in the same way it was for issue #159 

### Screenshots / Demo Video

https://user-images.githubusercontent.com/60362888/181604203-d24070a0-4025-45e9-b360-83151d7b3a2e.mov


### Testing
Not much testing to be done since this is front end only, other than routing. I made sure the user could click on any of the other tabs from the full page display and it would route correctly
### Checklist
- [x] Provided ticket and description
- [x] Your PR title contains the ISSUE ticket number e.g "86: ..."
- [x] Provided screenshots/demo
- [x] Provided testing information
- [x] Provided adequate test coverage for all new code
- [x] Added PR reviewers
- [ ] Ensure at least 1 review before merging