### PR TITLE
155: add backend for GrantDetails from clickable entries in dashboard, implement with "show all" activity feed

### DIFF
--- a/packages/client/src/router/index.js
+++ b/packages/client/src/router/index.js
@@ -40,7 +40,7 @@ const routes = [
           requiresAuth: true,
         },
       },
-       {
+      {
         path: '/RecentActivity',
         name: 'RecentActivity',
         component: () => import('../views/RecentActivity.vue'),
@@ -48,7 +48,7 @@ const routes = [
           requiresAuth: true,
         },
       },
-       {
+      {
         path: '/UpcomingClosingDates',
         name: 'UpcomingClosingDates',
         component: () => import('../views/UpcomingClosingDates.vue'),

--- a/packages/client/src/store/modules/grants.js
+++ b/packages/client/src/store/modules/grants.js
@@ -7,7 +7,7 @@ function initialState() {
     keywords: [],
     interestedCodes: [],
     grantsInterested: [],
-    workingGrant: {},
+    currentGrant: {},
   };
 }
 
@@ -18,7 +18,7 @@ export default {
     grants: (state) => state.grantsPaginated.data || [],
     grantsPagination: (state) => state.grantsPaginated.pagination,
     grantsInterested: (state) => state.grantsInterested,
-    workingGrant: (state) => state.workingGrant,
+    currentGrant: (state) => state.currentGrant,
     eligibilityCodes: (state) => state.eligibilityCodes,
     interestedCodes: (state) => ({
       rejections: state.interestedCodes.filter((c) => c.is_rejection),
@@ -43,7 +43,7 @@ export default {
     },
     fetchGrantDetails({ commit }, { grantId }) {
       return fetchApi.get(`/api/organizations/:organizationId/grants/${grantId}/grantDetails`)
-        .then((data) => commit('SET_GRANT_WORKING', data));
+        .then((data) => commit('SET_GRANT_CURRENT', data));
     },
     fetchGrantsInterested({ commit }) {
       return fetchApi.get('/api/organizations/:organizationId/grants/grantsInterested')
@@ -137,8 +137,8 @@ export default {
       if (grant) {
         Object.assign(grant, data);
       }
-      if (state.workingGrant && state.workingGrant.grant_id === grantId) {
-        Object.assign(state.workingGrant, data);
+      if (state.currentGrant && state.currentGrant.grant_id === grantId) {
+        Object.assign(state.currentGrant, data);
       }
     },
     SET_ELIGIBILITY_CODES(state, eligibilityCodes) {
@@ -153,8 +153,8 @@ export default {
     SET_GRANTS_INTERESTED(state, grantsInterested) {
       state.grantsInterested = grantsInterested;
     },
-    SET_GRANT_WORKING(state, workingGrant) {
-      state.workingGrant = workingGrant;
+    SET_GRANT_CURRENT(state, currentGrant) {
+      state.currentGrant = currentGrant;
     },
   },
 };

--- a/packages/client/src/store/modules/grants.js
+++ b/packages/client/src/store/modules/grants.js
@@ -7,6 +7,7 @@ function initialState() {
     keywords: [],
     interestedCodes: [],
     grantsInterested: [],
+    workingGrant: {},
   };
 }
 
@@ -17,6 +18,7 @@ export default {
     grants: (state) => state.grantsPaginated.data || [],
     grantsPagination: (state) => state.grantsPaginated.pagination,
     grantsInterested: (state) => state.grantsInterested,
+    workingGrant: (state) => state.workingGrant,
     eligibilityCodes: (state) => state.eligibilityCodes,
     interestedCodes: (state) => ({
       rejections: state.interestedCodes.filter((c) => c.is_rejection),
@@ -38,6 +40,10 @@ export default {
         .join('&');
       return fetchApi.get(`/api/organizations/:organizationId/grants?${query}`)
         .then((data) => commit('SET_GRANTS', data));
+    },
+    fetchGrantDetails({ commit }, { grantId }) {
+      return fetchApi.get(`/api/organizations/:organizationId/grants/${grantId}/grantDetails`)
+        .then((data) => commit('SET_GRANT_WORKING', data));
     },
     fetchGrantsInterested({ commit }) {
       return fetchApi.get('/api/organizations/:organizationId/grants/grantsInterested')
@@ -131,6 +137,9 @@ export default {
       if (grant) {
         Object.assign(grant, data);
       }
+      if (state.workingGrant && state.workingGrant.grant_id === grantId) {
+        Object.assign(state.workingGrant, data);
+      }
     },
     SET_ELIGIBILITY_CODES(state, eligibilityCodes) {
       state.eligibilityCodes = eligibilityCodes;
@@ -143,6 +152,9 @@ export default {
     },
     SET_GRANTS_INTERESTED(state, grantsInterested) {
       state.grantsInterested = grantsInterested;
+    },
+    SET_GRANT_WORKING(state, workingGrant) {
+      state.workingGrant = workingGrant;
     },
   },
 };

--- a/packages/client/src/views/RecentActivity.vue
+++ b/packages/client/src/views/RecentActivity.vue
@@ -94,7 +94,7 @@ export default {
     ...mapGetters({
       grants: 'grants/grants',
       grantsInterested: 'grants/grantsInterested',
-      workingGrant: 'grants/workingGrant',
+      currentGrant: 'grants/currentGrant',
     }),
     activityItems() {
       const rtf = new Intl.RelativeTimeFormat('en', {
@@ -117,9 +117,9 @@ export default {
         await this.fetchGrantsInterested();
       }
     },
-    workingGrant() {
-      if (this.selectedGrant && this.workingGrant) {
-        this.onRowSelected([this.workingGrant]);
+    currentGrant() {
+      if (this.selectedGrant && this.currentGrant) {
+        this.onRowSelected([this.currentGrant]);
       }
     },
   },
@@ -137,7 +137,7 @@ export default {
       const [row] = items;
       if (row) {
         await this.fetchGrantDetails({ grantId: row.grant_id }).then(() => {
-          this.selectedGrant = this.workingGrant;
+          this.selectedGrant = this.currentGrant;
         });
       }
     },

--- a/packages/server/src/db/index.js
+++ b/packages/server/src/db/index.js
@@ -356,10 +356,10 @@ async function getSingleGrantDetails({ grantId, agencies }) {
         .where({ grant_id: grantId });
 
     const viewedBy = await knex(TABLES.agencies)
-    .join(TABLES.grants_viewed, `${TABLES.agencies}.id`, '=', `${TABLES.grants_viewed}.agency_id`)
-    .whereIn('grant_id', [grantId])
-    .andWhere(`${TABLES.agencies}.id`, 'IN', agencies)
-    .select(`${TABLES.grants_viewed}.grant_id`, `${TABLES.grants_viewed}.agency_id`, `${TABLES.agencies}.name as agency_name`, `${TABLES.agencies}.abbreviation as agency_abbreviation`);
+        .join(TABLES.grants_viewed, `${TABLES.agencies}.id`, '=', `${TABLES.grants_viewed}.agency_id`)
+        .whereIn('grant_id', [grantId])
+        .andWhere(`${TABLES.agencies}.id`, 'IN', agencies)
+        .select(`${TABLES.grants_viewed}.grant_id`, `${TABLES.grants_viewed}.agency_id`, `${TABLES.agencies}.name as agency_name`, `${TABLES.agencies}.abbreviation as agency_abbreviation`);
 
     const interestedBy = await getInterestedAgencies({ grantIds: [grantId], agencies });
 

--- a/packages/server/src/routes/grants.js
+++ b/packages/server/src/routes/grants.js
@@ -71,6 +71,15 @@ router.get('/', requireUser, async (req, res) => {
     res.json(grants);
 });
 
+// get a single grant details
+router.get('/:grantId/grantDetails', requireUser, async (req, res) => {
+    const { grantId } = req.params;
+    const { selectedAgency, user } = req.session;
+    const agencies = await getAgencyForUser(selectedAgency, user, { filterByMainAgency: true });
+    const response = await db.getSingleGrantDetails({ grantId, agencies });
+    res.json(response);
+});
+
 // For API tests, reduce the limit to 100 -- this is so we can test the logic around the limit
 // without the test having to insert 10k rows, which slows down the test.
 const MAX_CSV_EXPORT_ROWS = process.env.NODE_ENV !== 'test' ? 10000 : 100;


### PR DESCRIPTION
### Ticket #155 

### Description

Adds the backend for bringing up the GrantDetails modal by clicking on entries in the dashboard feeds, implements the functionality with the full screen recent activity feed. The functionality will be added to both the feeds and the upcoming grants full screen view in the future.

### Screenshots / Demo Video

![image](https://user-images.githubusercontent.com/56096100/182205310-2b3a98d0-3fbb-4e40-b0fe-14fb6accac6f.png)

### Testing

From the activity feed click the see all button to bring up the full screen view -> click on an entry to test that the GrantDetails modal shows with the correct information -> test functionality for marking as interested/assigned

### Checklist
- [x] Provided ticket and description
- [x] Your PR title contains the ISSUE ticket number e.g "86: ..."
- [x] Provided screenshots/demo
- [x] Provided testing information
- [x] Provided adequate test coverage for all new code
- [x] Added PR reviewers
- [x] Ensure at least 1 review before merging