### PR TITLE
190 subagency can now delete their interested status

### DIFF
--- a/packages/client/src/components/Modals/GrantDetails.vue
+++ b/packages/client/src/components/Modals/GrantDetails.vue
@@ -61,7 +61,7 @@
       <b-table :items="selectedGrant.interested_agencies" :fields="interestedAgenciesFields">
         <template #cell(actions)="row">
           <b-row
-            v-if="loggedInUser.email === row.item.user_email && (row.item.agency_name === loggedInUser.agency_name)">
+            v-if="loggedInUser.email === row.item.user_email && (String(row.item.agency_id) === selectedAgencyId)">
             <b-button variant="danger" class="mr-1" size="sm" @click="unmarkGrantAsInterested(row)">
               <b-icon icon="trash-fill" aria-hidden="true"></b-icon>
             </b-button>


### PR DESCRIPTION
### Ticket #190 

### Description

Adds the ability for a subagency to delete their interested status. 

Note/Question: It looks like unmarking a grant as interested is tied to the user id, so if multiple subagencies and the parent agency all have a grant marked as interesting and one of the agencies deletes their interested status, all of the associated agencies will have their status deleted too. Is this the expected behavior?

### Screenshots / Demo Video

(logged in as usdrtest3)

Before: 
![before 8-1](https://user-images.githubusercontent.com/56096100/182245419-94936adf-b695-49a1-9992-3ad8c3c3bba1.PNG)

After
![after 8-1](https://user-images.githubusercontent.com/56096100/182245439-2d8414e5-e100-4e25-8d0b-e4f640a4f5d2.PNG)

### Testing

Mark a grant as interesting with a subagency and check that the status can be deleted correctly. Also test that it works with parent agencies.

### Checklist
- [x] Provided ticket and description
- [x] Your PR title contains the ISSUE ticket number e.g "86: ..."
- [x] Provided screenshots/demo
- [x] Provided testing information
- [x] Provided adequate test coverage for all new code
- [x] Added PR reviewers
- [ ] Ensure at least 1 review before merging