### PR TITLE
fix(181): recent activity displays only 4 grants on dashboard and full page recent activity has pagination

### DIFF
--- a/packages/client/src/store/modules/grants.js
+++ b/packages/client/src/store/modules/grants.js
@@ -39,8 +39,8 @@ export default {
       return fetchApi.get(`/api/organizations/:organizationId/grants?${query}`)
         .then((data) => commit('SET_GRANTS', data));
     },
-    fetchGrantsInterested({ commit }) {
-      return fetchApi.get('/api/organizations/:organizationId/grants/grantsInterested')
+    fetchGrantsInterested({ commit }, { perPage, currentPage }) {
+      return fetchApi.get(`/api/organizations/:organizationId/grants/grantsInterested/${perPage}/${currentPage}`)
         .then((data) => commit('SET_GRANTS_INTERESTED', data));
     },
     markGrantAsViewed(context, { grantId, agencyId }) {

--- a/packages/client/src/views/Dashboard.vue
+++ b/packages/client/src/views/Dashboard.vue
@@ -7,7 +7,7 @@
           <b-col cols="1"></b-col>
           <b-col>
             <b-card title='Recent Activity'>
-              <b-table sticky-header='300px' hover :items='activityItems' :fields='activityFields'
+              <b-table sticky-header='500px' hover :items='activityItems' :fields='activityFields'
                 :sort-by.sync="sortBy" :sort-desc.sync="sortAsc" class='table table-borderless overflow-hidden' thead-class="d-none">
                 <template #cell(icon)="list">
                   <b-icon v-if="list.item.interested" icon="check-circle-fill" scale="1" variant="success"></b-icon>
@@ -120,6 +120,8 @@ export default {
     return {
       sortBy: 'dateSort',
       sortAsc: true,
+      perPage: 4,
+      currentPage: 1,
       activityFields: [
         {
           // col for the check or X icon
@@ -244,7 +246,6 @@ export default {
           },
         },
       ],
-
     };
   },
 
@@ -294,7 +295,7 @@ export default {
     }),
     setup() {
       this.fetchDashboard();
-      this.fetchGrantsInterested();
+      this.fetchGrantsInterested({ perPage: this.perPage, currentPage: this.currentPage });
     },
     formatMoney(value) {
       const res = Number(value).toLocaleString('en-US', {

--- a/packages/client/src/views/RecentActivity.vue
+++ b/packages/client/src/views/RecentActivity.vue
@@ -124,12 +124,6 @@ export default {
     },
   },
   watch: {
-    currentPage() {
-      // this.fetchGrantsInterested({ perPage: this.perPage, currentPage: this.currentPage + 1 });
-      this.setup();
-    },
-  },
-  watch: {
     async selectedGrant() {
       if (!this.selectedGrant) {
         await this.fetchGrantsInterested();
@@ -139,6 +133,9 @@ export default {
       if (this.selectedGrant && this.currentGrant) {
         this.onRowSelected([this.currentGrant]);
       }
+    },
+    currentPage() {
+      this.setup();
     },
   },
   methods: {

--- a/packages/client/src/views/RecentActivity.vue
+++ b/packages/client/src/views/RecentActivity.vue
@@ -35,6 +35,12 @@
       </template>
     </b-table>
     </b-card>
+    <b-row align-v="center">
+      <b-pagination class="m-0" v-model="currentPage" :total-rows="totalRows" :per-page="perPage" first-number
+        last-number first-text="First" prev-text="Prev" next-text="Next" last-text="Last"
+        aria-controls="grants-table" />
+      <b-button class="ml-2" variant="outline-primary disabled">{{ grantsInterested.length }} of {{ totalRows }}</b-button>
+    </b-row>
   </section>
 </template>
 <style scoped>
@@ -59,6 +65,8 @@ export default {
   components: {},
   data() {
     return {
+      perPage: 10,
+      currentPage: 1,
       sortBy: 'dateSort',
       sortAsc: true,
       activityFields: [
@@ -88,6 +96,7 @@ export default {
     ...mapGetters({
       grants: 'grants/grants',
       grantsInterested: 'grants/grantsInterested',
+      totalInterestedGrants: 'dashboard/totalInterestedGrants',
     }),
     activityItems() {
       const rtf = new Intl.RelativeTimeFormat('en', {
@@ -102,15 +111,24 @@ export default {
         date: rtf.format(Math.round((new Date(grantsInterested.created_at).getTime() - new Date().getTime()) / oneDayInMs), 'day').charAt(0).toUpperCase() + rtf.format(Math.round((new Date(grantsInterested.created_at).getTime() - new Date().getTime()) / oneDayInMs), 'day').slice(1),
       }));
     },
+    totalRows() {
+      return this.totalInterestedGrants;
+    },
+  },
+  watch: {
+    currentPage() {
+      // this.fetchGrantsInterested({ perPage: this.perPage, currentPage: this.currentPage + 1 });
+      this.setup();
+    },
   },
   methods: {
     ...mapActions({
-      // fetchDashboard: 'dashboard/fetchDashboard',  seems to work without this
+      fetchDashboard: 'dashboard/fetchDashboard',
       fetchGrantsInterested: 'grants/fetchGrantsInterested',
     }),
     setup() {
-      // this.fetchDashboard(); seems to work without this
-      this.fetchGrantsInterested();
+      this.fetchDashboard();
+      this.fetchGrantsInterested({ perPage: this.perPage, currentPage: this.currentPage });
     },
   },
 };

--- a/packages/server/src/db/index.js
+++ b/packages/server/src/db/index.js
@@ -380,11 +380,6 @@ async function getTotalViewedGrants() {
     return rows[0].count;
 }
 
-async function getTotalInterestedGrants() {
-    const rows = await knex(TABLES.grants_interested).count();
-    return rows[0].count;
-}
-
 async function getTotalInterestedGrantsByAgencies() {
     const rows = await knex(TABLES.grants_interested)
         .select(`${TABLES.grants_interested}.agency_id`, `${TABLES.agencies}.name`, `${TABLES.agencies}.abbreviation`,
@@ -460,13 +455,22 @@ async function markGrantAsInterested({
     return results;
 }
 
-async function getGrantsInterested() {
-    const rows = await knex(TABLES.grants_interested)
+async function getGrantsInterested({ perPage, currentPage }) {
+    const { data, pagination } = await knex(TABLES.grants_interested)
         .select(`${TABLES.grants_interested}.created_at`, `${TABLES.agencies}.name`, `${TABLES.interested_codes}.is_rejection`, `${TABLES.grants}.title`, `${TABLES.grants}.grant_id`)
         .join(TABLES.agencies, `${TABLES.grants_interested}.agency_id`, `${TABLES.agencies}.id`)
         .join(TABLES.interested_codes, `${TABLES.grants_interested}.interested_code_id`, `${TABLES.interested_codes}.id`)
-        .join(TABLES.grants, `${TABLES.grants_interested}.grant_id`, `${TABLES.grants}.grant_id`);
-    return rows;
+        .join(TABLES.grants, `${TABLES.grants_interested}.grant_id`, `${TABLES.grants}.grant_id`)
+        .orderBy('created_at', 'desc')
+        .paginate({ perPage, currentPage });
+    return { data, pagination };
+}
+
+async function getTotalInterestedGrants() {
+    const rows = await knex(TABLES.grants_interested)
+        .whereNot('interested_code_id', null)
+        .count();
+    return rows[0].count;
 }
 
 async function unmarkGrantAsInterested({ grantId, userId }) {

--- a/packages/server/src/routes/grants.js
+++ b/packages/server/src/routes/grants.js
@@ -206,9 +206,10 @@ router.get('/:grantId/interested', requireUser, async (req, res) => {
     const interestedAgencies = await db.getInterestedAgencies({ grantIds: [grantId], agencies });
     res.json(interestedAgencies);
 });
-router.get('/grantsInterested', requireUser, async (req, res) => {
-    const grantsInterested = await db.getGrantsInterested();
-    res.json(grantsInterested);
+router.get('/grantsInterested/:perPage/:currentPage', requireUser, async (req, res) => {
+    const { perPage, currentPage } = req.params;
+    const { data } = await db.getGrantsInterested({ perPage, currentPage });
+    res.json(data);
 });
 
 router.put('/:grantId/interested/:agencyId', requireUser, async (req, res) => {


### PR DESCRIPTION
### Ticket #181

### Description
This PR limits the recent activity table on the dashboard to only display 4 grants using knex pagination and also adds pagination functionality to the full page display of the recent activity 
### Screenshots / Demo Video

https://user-images.githubusercontent.com/60362888/182444239-34d09ed9-b088-4cad-b518-a2b43d4547b4.mov


### Testing
Testing was done by jumping through all possible paged of the full recent activity view using the numbers and the next and prev, as well as refreshing the page at multiple points to make sure the API calls were still being executed correctly
### Checklist
- [x] Provided ticket and description
- [x] Your PR title contains the ISSUE ticket number e.g "86: ..."
- [x] Provided screenshots/demo
- [x] Provided testing information
- [x] Provided adequate test coverage for all new code
- [x] Added PR reviewers
- [ ] Ensure at least 1 review before merging