### PR TITLE
201 update unmark grant as interesting functionality

### DIFF
--- a/packages/client/src/components/Modals/GrantDetails.vue
+++ b/packages/client/src/components/Modals/GrantDetails.vue
@@ -61,7 +61,7 @@
       <b-table :items="selectedGrant.interested_agencies" :fields="interestedAgenciesFields">
         <template #cell(actions)="row">
           <b-row
-            v-if="loggedInUser.email === row.item.user_email && (String(row.item.agency_id) === selectedAgencyId)">
+            v-if="(String(row.item.agency_id) === selectedAgencyId) || isAbleToUnmark(row.item.agency_id)">
             <b-button variant="danger" class="mr-1" size="sm" @click="unmarkGrantAsInterested(row)">
               <b-icon icon="trash-fill" aria-hidden="true"></b-icon>
             </b-button>
@@ -190,9 +190,7 @@ export default {
     async selectedGrant() {
       this.showDialog = Boolean(this.selectedGrant);
       if (this.selectedGrant) {
-        if (!this.agencies.length) {
-          this.fetchAgencies();
-        }
+        this.fetchAgencies();
         console.log(JSON.stringify(this.selectedGrant));
         if (!this.alreadyViewed) {
           try {
@@ -237,7 +235,7 @@ export default {
     async unmarkGrantAsInterested(row) {
       await this.unmarkGrantAsInterestedAction({
         grantId: this.selectedGrant.grant_id,
-        agencyIds: [row.item.id],
+        agencyIds: [row.item.agency_id],
         interestedCode: this.selectedInterestedCode,
       });
       this.selectedGrant.interested_agencies = await this.getInterestedAgencies({ grantId: this.selectedGrant.grant_id });
@@ -262,6 +260,9 @@ export default {
       await this.generateGrantForm({
         grantId: this.selectedGrant.grant_id,
       });
+    },
+    isAbleToUnmark(agencyId) {
+      return this.agencies.some((agency) => agency.id === agencyId);
     },
     resetSelectedGrant() {
       this.$emit('update:selectedGrant', null);

--- a/packages/server/src/db/index.js
+++ b/packages/server/src/db/index.js
@@ -501,12 +501,12 @@ async function getTotalInterestedGrants() {
     return rows[0].count;
 }
 
-async function unmarkGrantAsInterested({ grantId, userId }) {
+async function unmarkGrantAsInterested({ grantId, agencyIds }) {
     const result = await knex(TABLES.grants_interested)
         .where({
             grant_id: grantId,
-            user_id: userId,
         })
+        .andWhere('agency_id', 'IN', agencyIds)
         .del();
     return result;
 }


### PR DESCRIPTION
### Ticket #201 

### Description

* Parent agencies now have the option to unmark statuses for children
* Unmarking is available to other users in the same agency or a parent agency, it is no longer only available to the user who created the status
* Unmarking one agency/subagency as interested from a grant now only deletes that row or status and not every status for other agencies entered by the user for that grant
* Fixed a bug where the agencies list in GrantDetails was not updating when changing selected agency/subagency
* Note: This would be a good thing for multiple people to test together in staging to make sure it works with different users

### Screenshots / Demo Video

With usdr3, a USDR subagency, selected:
![8-4-1](https://user-images.githubusercontent.com/56096100/182915967-20ea41cb-eef8-4662-8ecb-a8e8abd9f725.PNG)

With USDR selected, all child statuses are available to be deleted:
![8-4-2](https://user-images.githubusercontent.com/56096100/182916045-590c01ed-6c8e-4217-b380-f4e78557810f.PNG)


### Testing

* Check that parent agencies can delete their own and their child agency statuses, but children cannot delete parent statuses
* Check that other users in the same agency or a parent agency are able to unmark a status
* Check the assignable agency dropdown in GrantDetails to make sure it is the correct subagency list for the selected agency/subagency (this list was used in checking ability to unmark)

### Checklist
- [x] Provided ticket and description
- [x] Your PR title contains the ISSUE ticket number e.g "86: ..."
- [x] Provided screenshots/demo
- [x] Provided testing information
- [x] Provided adequate test coverage for all new code
- [x] Added PR reviewers
- [ ] Ensure at least 1 review before merging