### PR TITLE
fix(214): updated full page view of upcoming closing dates to match dashboard

### DIFF
--- a/packages/client/src/views/UpcomingClosingDates.vue
+++ b/packages/client/src/views/UpcomingClosingDates.vue
@@ -1,13 +1,15 @@
 <template>
 <section class="container">
-<b-card title='Upcoming Closing Dates' class="border-0">
+<b-card class="border-0">
+  <h4 class="card-title gutter-title1 row">Upcoming Closing Dates</h4>
     <b-table sticky-header='350px' hover :items='upcomingItems' :fields='upcomingFields'
     class='table table-borderless' thead-class="d-none">
-        <template #cell(date)="dates">
+        <template #cell(date)="dates"><strong>
             <!-- color the date to gray, yellow, or red based on the dateColor boolean -->
             <div v-if="dates.item.dateColor === 0" class="color-gray">{{ dates.item.date }}</div>
             <div v-if="dates.item.dateColor === 1" class="color-yellow">{{ dates.item.date }}</div>
             <div v-if="dates.item.dateColor === 2" class="color-red">{{ dates.item.date }}</div>
+        </strong>
         </template>
         <template #cell(agencyAndGrant)="agencies">
             <!-- display the interestedAgencies in a new <div> so it appears below the grant -->
@@ -21,13 +23,18 @@
 
 <style scoped>
 .color-gray {
-  color: gray;
+  color: #757575;
 }
 
 .color-red {
-  color: red;
+  color: #ae1818;
 }
-
+.color-yellow{
+  color: #aa8866;
+}
+.gutter-title1.row {
+    margin-left: +9px;
+  }
 </style>
 
 <script>


### PR DESCRIPTION

### Ticket #214 

### Description
updated full page view of upcoming closing dates to match dashboard
updated colors, bolded dates, aligned header
### Screenshots / Demo Video
old:
![Screen Shot 2022-08-05 at 12 57 19 PM](https://user-images.githubusercontent.com/60362888/183125266-508b8f59-ecf5-4bb3-ba47-7fbbabe1fd51.png)

new:
![Screen Shot 2022-08-05 at 12 57 36 PM](https://user-images.githubusercontent.com/60362888/183125314-6d8e8c86-565c-4df3-9afb-a4912cf1362b.png)

### Testing
Still just a front end mock so no functionality to test for now 

### Checklist
- [x] Provided ticket and description
- [x] Your PR title contains the ISSUE ticket number e.g "86: ..."
- [x] Provided screenshots/demo
- [x] Provided testing information
- [x] Provided adequate test coverage for all new code
- [x] Added PR reviewers
- [ ] Ensure at least 1 review before merging