### PR TITLE
228 display full date on activity feed for entries more than 7 days ago

### DIFF
--- a/packages/client/src/views/Dashboard.vue
+++ b/packages/client/src/views/Dashboard.vue
@@ -327,7 +327,14 @@ export default {
         grant: grantsInterested.title,
         interested: !grantsInterested.is_rejection,
         dateSort: new Date(grantsInterested.created_at).toLocaleString(),
-        date: rtf.format(Math.round((new Date(grantsInterested.created_at).getTime() - new Date().getTime()) / oneDayInMs), 'day').charAt(0).toUpperCase() + rtf.format(Math.round((new Date(grantsInterested.created_at).getTime() - new Date().getTime()) / oneDayInMs), 'day').slice(1),
+        date: (() => {
+          const timeSince = rtf.format(Math.round((new Date(grantsInterested.created_at).getTime() - new Date().getTime()) / oneDayInMs), 'day');
+          const timeSinceInt = parseInt(timeSince, 10);
+          if (!Number.isNaN(timeSinceInt) && timeSinceInt > 7) {
+            return new Date(grantsInterested.created_at).toLocaleDateString('en-US');
+          }
+          return timeSince.charAt(0).toUpperCase() + timeSince.slice(1);
+        })(),
       }));
     },
   },

--- a/packages/client/src/views/RecentActivity.vue
+++ b/packages/client/src/views/RecentActivity.vue
@@ -127,7 +127,14 @@ export default {
         grant_id: grantsInterested.grant_id,
         interested: !grantsInterested.is_rejection,
         dateSort: new Date(grantsInterested.created_at).toLocaleString(),
-        date: rtf.format(Math.round((new Date(grantsInterested.created_at).getTime() - new Date().getTime()) / oneDayInMs), 'day').charAt(0).toUpperCase() + rtf.format(Math.round((new Date(grantsInterested.created_at).getTime() - new Date().getTime()) / oneDayInMs), 'day').slice(1),
+        date: (() => {
+          const timeSince = rtf.format(Math.round((new Date(grantsInterested.created_at).getTime() - new Date().getTime()) / oneDayInMs), 'day');
+          const timeSinceInt = parseInt(timeSince, 10);
+          if (!Number.isNaN(timeSinceInt) && timeSinceInt > 7) {
+            return new Date(grantsInterested.created_at).toLocaleDateString('en-US');
+          }
+          return timeSince.charAt(0).toUpperCase() + timeSince.slice(1);
+        })(),
       }));
     },
     totalRows() {


### PR DESCRIPTION
### Ticket #228 

### Description

Changes the activity feed on dashboard and full page to display full dates for entries added more than 7 days ago.

### Screenshots / Demo Video

Before (dashboard):
![before1 8-8](https://user-images.githubusercontent.com/56096100/183519137-3a959cae-4a30-4213-963f-4541f0abb756.PNG)

After (dashboard):
![after1 8-8](https://user-images.githubusercontent.com/56096100/183519156-320b633f-40b3-4536-b05f-2df9dd4613a1.PNG)

Before (full screen):
![before2 8-8](https://user-images.githubusercontent.com/56096100/183519183-6af1f6b3-94dc-45b4-b513-33a6f80dde2f.PNG)

After (full screen):
![after2 8-8](https://user-images.githubusercontent.com/56096100/183519203-3702ea37-99ec-4bcd-a6f8-8c36f01f33f2.PNG)

### Testing

Add entries to recent activity feed, observe that those more than 7 days ago are showing full dates instead of "Today" or "x days ago" on both the dashboard feed and full screen feed.

### Checklist
- [x] Provided ticket and description
- [x] Your PR title contains the ISSUE ticket number e.g "86: ..."
- [x] Provided screenshots/demo
- [x] Provided testing information
- [x] Provided adequate test coverage for all new code
- [x] Added PR reviewers
- [ ] Ensure at least 1 review before merging