### PR TITLE
212 add clickable functionality to dashboard feeds

### DIFF
--- a/packages/client/src/store/modules/grants.js
+++ b/packages/client/src/store/modules/grants.js
@@ -133,9 +133,11 @@ export default {
       state.grantsPaginated = grants;
     },
     UPDATE_GRANT(state, { grantId, data }) {
-      const grant = state.grantsPaginated.data.find((g) => g.grant_id === grantId);
-      if (grant) {
-        Object.assign(grant, data);
+      if (state.grantsPaginated.data) {
+        const grant = state.grantsPaginated.data.find((g) => g.grant_id === grantId);
+        if (grant) {
+          Object.assign(grant, data);
+        }
       }
       if (state.currentGrant && state.currentGrant.grant_id === grantId) {
         Object.assign(state.currentGrant, data);


### PR DESCRIPTION
### Ticket #212 

### Description

Adds the ability to click on dashboard feed items to bring up the grant details modal

### Screenshots / Demo Video

![8-9](https://user-images.githubusercontent.com/56096100/183765596-bc531bc2-a978-4153-bc54-b7a857d25ba8.PNG)

### Testing

Go to dashboard -> click on a feed item in one of the two feeds -> make sure grant modal appears with correct grant and full functionality

### Checklist
- [x] Provided ticket and description
- [x] Your PR title contains the ISSUE ticket number e.g "86: ..."
- [x] Provided screenshots/demo
- [x] Provided testing information
- [x] Provided adequate test coverage for all new code
- [x] Added PR reviewers
- [x] Ensure at least 1 review before merging