### PR TITLE
153 updated

### DIFF
--- a/packages/client/src/views/Dashboard.vue
+++ b/packages/client/src/views/Dashboard.vue
@@ -187,10 +187,13 @@ export default {
           thStyle: { width: '20%' },
           tdStyle: {
             color: 'red',
+            fontWeight: 'bold',
           },
           trStyle: {
             color: 'darkkhaki',
+            fontWeight: 'bold',
           },
+          fontWeight: 'bold',
         },
         {
           key: 'interested_agencies',

--- a/packages/client/src/views/Dashboard.vue
+++ b/packages/client/src/views/Dashboard.vue
@@ -47,9 +47,9 @@
                 <template #cell()="{ field, value }">
                   <div v-if="yellowDate == true" :style="field.trStyle" v-text="value"></div>
                   <div v-if="redDate == true" :style="field.tdStyle" v-text="value"></div>
-                  <div v-if="(field.key == 'title') && (value == grantsAndIntAgens[0].title)" :style="{color:'gray'}">{{grantsAndIntAgens[0].interested_agencies}}</div>
-                  <div v-if="(field.key == 'title') && (value == grantsAndIntAgens[1].title)" :style="{color:'gray'}">{{grantsAndIntAgens[1].interested_agencies}}</div>
-                  <div v-if="(field.key == 'title') && (value == grantsAndIntAgens[2].title)" :style="{color:'gray'}">{{grantsAndIntAgens[2].interested_agencies}}</div>
+                  <div v-if="(field.key == 'title') && (value == grantsAndIntAgens[0].title)" :style="{color:'#757575'}">{{grantsAndIntAgens[0].interested_agencies}}</div>
+                  <div v-if="(field.key == 'title') && (value == grantsAndIntAgens[1].title)" :style="{color:'#757575'}">{{grantsAndIntAgens[1].interested_agencies}}</div>
+                  <div v-if="(field.key == 'title') && (value == grantsAndIntAgens[2].title)" :style="{color:'#757575'}">{{grantsAndIntAgens[2].interested_agencies}}</div>
                 </template>
               </b-table>
               <b-row align-v="center">
@@ -186,11 +186,11 @@ export default {
           formatter: 'formatDate',
           thStyle: { width: '20%' },
           tdStyle: {
-            color: 'red',
+            color: '#ae1818',
             fontWeight: 'bold',
           },
           trStyle: {
-            color: 'darkkhaki',
+            color: '#aa8866',
             fontWeight: 'bold',
           },
           fontWeight: 'bold',

--- a/packages/client/src/views/Dashboard.vue
+++ b/packages/client/src/views/Dashboard.vue
@@ -47,9 +47,9 @@
                 <template #cell()="{ field, value }">
                   <div v-if="yellowDate == true" :style="field.trStyle" v-text="value"></div>
                   <div v-if="redDate == true" :style="field.tdStyle" v-text="value"></div>
-                  <div v-if="(field.key == 'title') && (value == grantsAndIntAgens[0].title)" :style="{color:'gray', fontSize: '12px',}">{{grantsAndIntAgens[0].interested_agencies}}</div>
-                  <div v-if="(field.key == 'title') && (value == grantsAndIntAgens[1].title)" :style="{color:'gray', fontSize: '12px',}">{{grantsAndIntAgens[1].interested_agencies}}</div>
-                  <div v-if="(field.key == 'title') && (value == grantsAndIntAgens[2].title)" :style="{color:'gray', fontSize: '12px',}">{{grantsAndIntAgens[2].interested_agencies}}</div>
+                  <div v-if="(field.key == 'title') && (value == grantsAndIntAgens[0].title)" :style="{color:'gray'}">{{grantsAndIntAgens[0].interested_agencies}}</div>
+                  <div v-if="(field.key == 'title') && (value == grantsAndIntAgens[1].title)" :style="{color:'gray'}">{{grantsAndIntAgens[1].interested_agencies}}</div>
+                  <div v-if="(field.key == 'title') && (value == grantsAndIntAgens[2].title)" :style="{color:'gray'}">{{grantsAndIntAgens[2].interested_agencies}}</div>
                 </template>
               </b-table>
               <b-row align-v="center">

--- a/packages/server/__tests__/db/db.test.js
+++ b/packages/server/__tests__/db/db.test.js
@@ -79,7 +79,7 @@ describe('db', () => {
             // act
             const result = await db.getClosestGrants();
             // assert
-            expect(result.length).to.equal(2);
+            expect(result.length).to.equal(3);
         });
     });
 


### PR DESCRIPTION
Issue #153 
#226  PR updated

Solution:
Added UX/UI to fit Upcoming Closing Grants table
Interested Agencies will only list under a grant if the grant has any, so having no abbreviations underneath means there are no agencies interested in that grant.
Changes do not include full page view

Screenshot:
1.) With the bold dates and font size changes

<img width="537" alt="Screen Shot 2022-08-10 at 11 48 08 AM" src="https://user-images.githubusercontent.com/31491718/183970190-ccc8854d-126d-48a5-808a-3ed01ad52ad2.png">

Testing:
Added interest in a given grant and saw it display underneath the correct grant name. 

