### PR TITLE
248 upcoming closing dates feed now only show grants that have interested agencies

### DIFF
--- a/packages/server/src/db/index.js
+++ b/packages/server/src/db/index.js
@@ -382,7 +382,7 @@ async function getClosestGrants() {
     const query = await knex(TABLES.grants)
         .select('title', 'close_date', 'grant_id')
         .where('close_date', '>=', timestamp)
-        .whereIn('grant_id', function() {
+        .whereIn('grant_id', function () {
             this.select('grant_id').from('grants_interested');
         })
         .orderBy('close_date', 'asc')

--- a/packages/server/src/db/index.js
+++ b/packages/server/src/db/index.js
@@ -382,6 +382,9 @@ async function getClosestGrants() {
     const query = await knex(TABLES.grants)
         .select('title', 'close_date', 'grant_id')
         .where('close_date', '>=', timestamp)
+        .whereIn('grant_id', function() {
+            this.select('grant_id').from('grants_interested');
+        })
         .orderBy('close_date', 'asc')
         .limit(3)
         .then((data) => data)


### PR DESCRIPTION
### Ticket #248

### Description

Changes the upcoming grants feed to only show grants that have interested agencies.

### Screenshots / Demo Video

Before
![before 8-10](https://user-images.githubusercontent.com/56096100/183982416-c50fec35-dbdb-4527-bd7e-a5655289cd6b.PNG)

After 
![after 8-10](https://user-images.githubusercontent.com/56096100/183982445-18d8ef10-b2ff-4941-8c34-4fed17a20492.PNG)

### Testing

In dashboard, make sure the grants in upcoming closing dates have interested agencies, ensure that the dates and interested list are correct.

### Checklist
- [x] Provided ticket and description
- [x] Your PR title contains the ISSUE ticket number e.g "86: ..."
- [x] Provided screenshots/demo
- [x] Provided testing information
- [x] Provided adequate test coverage for all new code
- [x] Added PR reviewers
- [ ] Ensure at least 1 review before merging