### PR TITLE
175: Remove debugging columns from Keywords page

### DIFF
--- a/packages/client/src/views/Keywords.vue
+++ b/packages/client/src/views/Keywords.vue
@@ -39,12 +39,6 @@ export default {
         {
           key: 'notes',
         },
-        {
-          key: 'created_at',
-        },
-        {
-          key: 'updated_at',
-        },
         { key: 'actions', label: 'Actions' },
       ],
       showAddKeywordModal: false,


### PR DESCRIPTION
### Ticket #175

### Description

Removes the "Created At" and "Updated At" columns from the Keywords page. These were only intended for debugging purposes.

### Screenshots / Demo Video

![image](https://user-images.githubusercontent.com/1957636/184069281-cfbbae17-17f6-4bbd-a72d-978479ff7c9f.png)

### Testing

Tested locally.

### Checklist
- [x] Provided ticket and description
- [x] Your PR title contains the ISSUE ticket number e.g "86: ..."
- [x] Provided screenshots/demo
- [x] Provided testing information
- [x] Provided adequate test coverage for all new code
- [ ] Added PR reviewers
- [ ] Ensure at least 1 review before merging