### PR TITLE
248 make upcoming dates entries show only those interested by selected agency or subagencies

### DIFF
--- a/packages/server/__tests__/db/db.test.js
+++ b/packages/server/__tests__/db/db.test.js
@@ -102,9 +102,9 @@ describe('db', () => {
         it('gets closest grants', async () => {
             // arrange  #done in fixtures
             // act
-            const result = await db.getClosestGrants();
+            const result = await db.getClosestGrants(0);
             // assert
-            expect(result.length).to.equal(2);
+            expect(result.length).to.equal(1);
         });
     });
 

--- a/packages/server/src/db/index.js
+++ b/packages/server/src/db/index.js
@@ -377,13 +377,15 @@ async function getSingleGrantDetails({ grantId, agencies }) {
     };
 }
 
-async function getClosestGrants() {
+async function getClosestGrants(agency) {
+    const userAgencies = await getAgencies(agency);
     const timestamp = new Date().toLocaleDateString('en-US');
     const query = await knex(TABLES.grants)
         .select('title', 'close_date', 'grant_id')
         .where('close_date', '>=', timestamp)
         .whereIn('grant_id', function () {
-            this.select('grant_id').from('grants_interested');
+            this.select('grant_id').from('grants_interested')
+            .where('agency_id', 'IN', userAgencies.map((subAgency) => subAgency.id));
         })
         .orderBy('close_date', 'asc')
         .limit(3)

--- a/packages/server/src/db/index.js
+++ b/packages/server/src/db/index.js
@@ -385,7 +385,7 @@ async function getClosestGrants(agency) {
         .where('close_date', '>=', timestamp)
         .whereIn('grant_id', function () {
             this.select('grant_id').from('grants_interested')
-            .where('agency_id', 'IN', userAgencies.map((subAgency) => subAgency.id));
+                .where('agency_id', 'IN', userAgencies.map((subAgency) => subAgency.id));
         })
         .orderBy('close_date', 'asc')
         .limit(3)

--- a/packages/server/src/routes/dashboard.js
+++ b/packages/server/src/routes/dashboard.js
@@ -23,7 +23,7 @@ router.get('/', requireUser, async (req, res) => {
         result.totalInterestedGrants = await db.getTotalInterestedGrants();
     }
     if (req.query.getClosestGrants) {
-        result.getClosestGrants = await db.getClosestGrants();
+        result.getClosestGrants = await db.getClosestGrants(req.session.selectedAgency);
     }
     if (req.query.totalInterestedGrantsByAgencies) {
         result.totalInterestedGrantsByAgencies = await db.getTotalInterestedGrantsByAgencies();


### PR DESCRIPTION
### Ticket #248 

### Description

Adjusts the getClosestsGrants query to only get the closest grants with interests from the currently selected agency or subagencies.

### Screenshots / Demo Video

Before
![image](https://user-images.githubusercontent.com/56096100/184386792-48412a4a-e46c-4cdb-a8a6-80f34819b713.png)

After 
![image](https://user-images.githubusercontent.com/56096100/184386710-a5987c33-4546-46eb-ac87-07901ca7ab1b.png)

### Testing

Mark grants as interest -> check the upcoming grants feed to see if grants have interested agencies and that those agencies are either the currently selected agency or subagencies of that agency

### Checklist
- [x] Provided ticket and description
- [x] Your PR title contains the ISSUE ticket number e.g "86: ..."
- [x] Provided screenshots/demo
- [x] Provided testing information
- [x] Provided adequate test coverage for all new code
- [x] Added PR reviewers
- [ ] Ensure at least 1 review before merging