### PR TITLE
fix(252): fixed handling of interest code 0

### DIFF
--- a/packages/server/src/db/index.js
+++ b/packages/server/src/db/index.js
@@ -488,7 +488,7 @@ async function markGrantAsInterested({
             agency_id: agencyId,
             grant_id: grantId,
             user_id: userId,
-            interested_code_id: interestedCode,
+            interested_code_id: +interestedCode,
         });
     return results;
 }


### PR DESCRIPTION
### Ticket #252 

### Description
The function markGrantsAsInterested in index.js was being passed a 0 as the interested code when "Not applicable ..." was selected but when the value was logged in the function it was displaying null. I fixed this by adding a unary plus to the interestedCode variable to convert null to the number 0 but not change anything for the other interested codes.

### Screenshots / Demo Video
See issue #252 for demo of the bug

Fixed:
https://user-images.githubusercontent.com/60362888/184424550-144671e6-58e9-4c1a-8405-94af3f88f46b.mov

### Testing
Tried selecting grants of all possible interested codes to ensure they all work as they should. Also tested trying to mark a grant as interested with no interested or rejection prompt to make sure that still did nothing because that technically counts as trying to make a grant with a null selected interested code but since this is checked on the front end before making the markGrantsAsInterested call, everything still works as intended.

### Checklist
- [x] Provided ticket and description
- [x] Your PR title contains the ISSUE ticket number e.g "86: ..."
- [x] Provided screenshots/demo
- [x] Provided testing information
- [x] Provided adequate test coverage for all new code
- [x] Added PR reviewers
- [x] Ensure at least 1 review before merging