### PR TITLE
232 closing grants full page

### DIFF
--- a/packages/client/src/views/Dashboard.vue
+++ b/packages/client/src/views/Dashboard.vue
@@ -421,7 +421,7 @@ export default {
     },
     async formatUpcoming() {
       // https://stackoverflow.com/a/67219279
-      this.getClosestGrants.map(async (grant, idx) => {
+      this.getClosestGrants.slice(0, 3).map(async (grant, idx) => {
         const arr = await this.getInterestedAgenciesAction({ grantId: grant.grant_id });
         const updateGrant = {
           ...grant,

--- a/packages/client/src/views/UpcomingClosingDates.vue
+++ b/packages/client/src/views/UpcomingClosingDates.vue
@@ -1,111 +1,221 @@
 <template>
-<section class="container">
-<b-card class="border-0">
-  <h4 class="card-title gutter-title1 row">Upcoming Closing Dates</h4>
-    <b-table sticky-header='350px' hover :items='upcomingItems' :fields='upcomingFields'
-    class='table table-borderless' thead-class="d-none">
-        <template #cell(date)="dates"><strong>
-            <!-- color the date to gray, yellow, or red based on the dateColor boolean -->
-            <div v-if="dates.item.dateColor === 0" class="color-gray">{{ dates.item.date }}</div>
-            <div v-if="dates.item.dateColor === 1" class="color-yellow">{{ dates.item.date }}</div>
-            <div v-if="dates.item.dateColor === 2" class="color-red">{{ dates.item.date }}</div>
-        </strong>
-        </template>
-        <template #cell(agencyAndGrant)="agencies">
-            <!-- display the interestedAgencies in a new <div> so it appears below the grant -->
-            <div>{{ agencies.item.agencyAndGrant }}</div>
-            <div class="color-gray">{{ agencies.item.interestedAgencies }}</div>
-        </template>
+  <section class="container">
+    <b-card class="border-0">
+      <h4 class="card-title gutter-title1 row">Upcoming Closing Dates</h4>
+    <b-table
+      hover
+      :items="grantsAndIntAgens"
+      :fields="upcomingFields"
+      :sort-by.sync="sortBy"
+      :sort-desc.sync="sortAsc"
+      class="table table-borderless"
+      thead-class="d-none"
+      selectable
+      select-mode="single"
+      @row-selected="onRowSelected"
+    >
+      <template #cell()="{ field, value }">
+        <div v-if="yellowDate == true" :style="field.trStyle" v-text="value"></div>
+        <div v-if="redDate == true" :style="field.tdStyle" v-text="value"></div>
+        <div v-if="(field.key == 'title') && (value == grantsAndIntAgens[0].title)" :style="{color:'#757575'}">{{grantsAndIntAgens[0].interested_agencies}}</div>
+        <div v-if="(field.key == 'title') && (value == grantsAndIntAgens[1].title)" :style="{color:'#757575'}">{{grantsAndIntAgens[1].interested_agencies}}</div>
+        <div v-if="(field.key == 'title') && (value == grantsAndIntAgens[2].title)" :style="{color:'#757575'}">{{grantsAndIntAgens[2].interested_agencies}}</div>
+      </template>
     </b-table>
     </b-card>
-    </section>
+    <b-row align-v="center">
+      <b-pagination class="m-0" v-model="currentPage" :total-rows="totalRows" :per-page="perPage" first-number
+        last-number first-text="First" prev-text="Prev" next-text="Next" last-text="Last"
+        aria-controls="grants-table" />
+      <b-button class="ml-2" variant="outline-primary disabled">{{ grantsInterested.length }} of {{ totalRows }}</b-button>
+    </b-row>
+    <GrantDetails :selected-grant.sync="selectedGrant" />
+  </section>
 </template>
-
 <style scoped>
 .color-gray {
-  color: #757575;
+  color: #757575
 }
-
 .color-red {
   color: #ae1818;
 }
-.color-yellow{
-  color: #aa8866;
+.color-green {
+  color: green;
 }
-.gutter-title1.row {
-    margin-left: +9px;
+.gutter-icon.row {
+    margin-right: -8px;
+    margin-left: -8px;
+    margin-top: 3px;
+  }
+   .gutter-title1.row {
+    margin-left: +4px;
   }
 </style>
 
 <script>
 import { mapActions, mapGetters } from 'vuex';
 import resizableTableMixin from '@/mixin/resizableTable';
+import GrantDetails from '@/components/Modals/GrantDetails.vue';
 
 export default {
-  components: {
-  },
+  components: { GrantDetails },
   data() {
     return {
+      yellowDate: null,
+      redDate: null,
+      perPage: 10,
+      currentPage: 1,
       sortBy: 'dateSort',
       sortAsc: true,
+      grantsAndIntAgens: [],
       upcomingFields: [
         {
           // col for Grants and interested agencies
-          key: 'agencyAndGrant',
+          key: 'title',
           label: '',
           thStyle: { width: '80%' },
         },
         {
           // col for when the grant will be closing
-          key: 'date',
+          key: 'close_date',
           label: '',
+          formatter: 'formatDate',
+          thStyle: { width: '20%' },
+          tdStyle: {
+            color: '#ae1818',
+            fontWeight: 'bold',
+          },
+          trStyle: {
+            color: '#aa8866',
+            fontWeight: 'bold',
+          },
+          fontWeight: 'bold',
+        },
+        {
+          key: 'interested_agencies',
+          label: '',
+          thClass: 'd-none',
+          tdClass: 'd-none',
           thStyle: { width: '20%' },
         },
       ],
-      upcomingItems: [
-        {
-          agencyAndGrant: 'FY21 Supplemental for the Northeast Corridor Cooperative Agreement to the National Railroad Passenger Corporation',
-          interestedAgencies: 'Dept of Admin, State of Nevada,',
-          date: '12/12/12',
-          dateColor: 2, // 2 corresponds to red, 1 corresponds to yellow, 0 corresponds to gray
-        },
-        {
-          agencyAndGrant: 'Environmental Justice Collaborative Problem-Solving (EJCPS) Cooperative Agreement Program',
-          interestedAgencies: 'GO, AP, SNV',
-          date: '12/12/12',
-          dateColor: 1,
-        },
-        {
-          agencyAndGrant: 'Strengthening Public Health Research and Implementation Science (Operations Research) to Control and Eliminate Infectious Diseases Globally',
-          interestedAgencies: 'SHRAB, SNV',
-          date: '12/20/12',
-          dateColor: 0,
-        },
-      ],
+      selectedGrant: null,
     };
   },
-
   mixins: [resizableTableMixin],
   mounted() {
     this.setup();
   },
   computed: {
     ...mapGetters({
-    //  Things will need to go here when backend func is added
+      grants: 'grants/grants',
+      grantsInterested: 'grants/grantsInterested',
+      currentGrant: 'grants/currentGrant',
+      totalGrants: 'dashboard/totalGrants',
+      totalGrantsMatchingAgencyCriteria: 'dashboard/totalGrantsMatchingAgencyCriteria',
+      totalViewedGrants: 'dashboard/totalViewedGrants',
+      totalInterestedGrants: 'dashboard/totalInterestedGrants',
+      grantsCreatedInTimeframe: 'dashboard/grantsCreatedInTimeframe',
+      grantsCreatedInTimeframeMatchingCriteria: 'dashboard/grantsCreatedInTimeframeMatchingCriteria',
+      grantsUpdatedInTimeframe: 'dashboard/grantsUpdatedInTimeframe',
+      grantsUpdatedInTimeframeMatchingCriteria: 'dashboard/grantsUpdatedInTimeframeMatchingCriteria',
+      totalInterestedGrantsByAgencies: 'dashboard/totalInterestedGrantsByAgencies',
+      selectedAgency: 'users/selectedAgency',
+      getClosestGrants: 'dashboard/getClosestGrants',
+      agency: 'users/agency',
     }),
+    upcomingItems() {
+      // https://stackoverflow.com/a/48643055
+      return this.getClosestGrants;
+    },
+    totalRows() {
+      return this.totalInterestedGrants;
+    },
+  },
+  watch: {
+    async selectedAgency() {
+      await this.setup();
+    },
+    upcomingItems() {
+      // https://lukashermann.dev/writing/how-to-use-async-await-with-vuejs-components/
+      this.formatUpcoming();
+    },
+    async selectedGrant() {
+      if (!this.selectedGrant) {
+        await this.fetchGrantsInterested();
+      }
+    },
+    currentGrant() {
+      if (this.selectedGrant && this.currentGrant) {
+        this.onRowSelected([this.currentGrant]);
+      }
+    },
+    currentPage() {
+      this.setup();
+    },
   },
   methods: {
     ...mapActions({
-    //  Things will need to go here when backend func is added
-    //   fetchDashboard: 'dashboard/fetchDashboard',
-    //   fetchGrantsInterested: 'grants/fetchGrantsInterested',
+      fetchDashboard: 'dashboard/fetchDashboard',
+      fetchGrantsInterested: 'grants/fetchGrantsInterested',
+      fetchGrantDetails: 'grants/fetchGrantDetails',
+      getInterestedAgenciesAction: 'grants/getInterestedAgencies',
+      getAgency: 'agencies/getAgency',
+      fetchInterestedAgencies: 'grants/fetchInterestedAgencies',
     }),
     setup() {
-    //  Things will need to go here when backend func is added
-    //   this.fetchDashboard();
-    //   this.fetchGrantsInterested();
+      this.fetchDashboard();
+      this.fetchGrantsInterested({ perPage: this.perPage, currentPage: this.currentPage });
+    },
+    async onRowSelected(items) {
+      const [row] = items;
+      if (row) {
+        await this.fetchGrantDetails({ grantId: row.grant_id }).then(() => {
+          this.selectedGrant = this.currentGrant;
+        });
+      }
+    },
+    formatDate(value) {
+      //                  get threshold of agency
+      // console.log(`format date:  ${value}`);
+      const warn = this.agency.warning_threshold;
+      const danger = this.agency.danger_threshold;
+      //                    current date + danger threshold
+      // const dangerDate = new Date(new Date().setDate(new Date().getDate() + danger));
+      // console.log(`dangerDate  ${dangerDate}`);
+      //                grant close date + danger thresh
+      const dangerDate2 = new Date(new Date().setDate(new Date(value).getDate() + danger));
+      // console.log(`dangerDate2  ${dangerDate2}`);
+      //                grant close date + warn thresh
+      const warnDate = new Date(new Date().setDate(new Date(value).getDate() + warn));
+      // console.log(`warnDate  ${warnDate}`);
+      // console.log(`close date format for comp  ${new Date(value)}`);
+      //          if the grant close date is <= danger date
+      if (new Date(value) <= warnDate && new Date(value) > dangerDate2) {
+        this.yellowDate = true;
+      } else if ((new Date(value) <= dangerDate2) || (new Date(value) === new Date())) {
+        this.redDate = true;
+      }
+      //                      format date in MM/DD/YY
+      const year = value.slice(2, 4);
+      const month = value.slice(5, 7);
+      const day = value.slice(8, 10);
+      const finalDate = [month, day, year].join('/');
+      return (`${finalDate}`);
+    },
+    async formatUpcoming() {
+      // https://stackoverflow.com/a/67219279
+      this.getClosestGrants.map(async (grant, idx) => {
+        const arr = await this.getInterestedAgenciesAction({ grantId: grant.grant_id });
+        const updateGrant = {
+          ...grant,
+          interested_agencies: arr.map((agency) => agency.agency_abbreviation).join(', '),
+        };
+        // https://v2.vuejs.org/v2/guide/reactivity.html#For-Arrays
+        // https://stackoverflow.com/a/45336400
+        this.$set(this.grantsAndIntAgens, idx, updateGrant);
+      });
     },
   },
 };
-
 </script>

--- a/packages/client/src/views/UpcomingClosingDates.vue
+++ b/packages/client/src/views/UpcomingClosingDates.vue
@@ -28,7 +28,7 @@
       <b-pagination class="m-0" v-model="currentPage" :per-page="perPage" first-number :total-rows="rows"
         last-number first-text="First" prev-text="Prev" next-text="Next" last-text="Last" :current-page="currentPage"
         aria-controls="upcomingGrants" />
-      <b-button class="ml-2" variant="outline-primary disabled">{{ grantsAndIntAgens.length }} of {{ upcomingItems.length }}</b-button>
+      <b-button class="ml-2" variant="outline-primary disabled">{{ totalOnPage }} of {{ upcomingItems.length }}</b-button>
     </b-row>
     <GrantDetails :selected-grant.sync="selectedGrant" />
   </section>
@@ -130,9 +130,16 @@ export default {
     rows() {
       return this.upcomingItems.length;
     },
-    // loopAgens() {
-
-    // },
+    totalOnPage() {
+      if (this.grantsAndIntAgens.length < this.perPage) {
+        return this.grantsAndIntAgens.length;
+      }
+      // if current page is not last, 10
+      if (this.currentPage !== 9) {
+        return this.perPage;
+      }
+      return 2;
+    },
   },
   watch: {
     async selectedAgency() {

--- a/packages/client/src/views/UpcomingClosingDates.vue
+++ b/packages/client/src/views/UpcomingClosingDates.vue
@@ -131,14 +131,24 @@ export default {
       return this.upcomingItems.length;
     },
     totalOnPage() {
+      // max # of items that can be on a given page
+      const maxItemsOnPage = this.currentPage * this.perPage;
+      // if there are less grants than # to be displayed
       if (this.grantsAndIntAgens.length < this.perPage) {
         return this.grantsAndIntAgens.length;
       }
-      // if current page is not last, 10
-      if (this.currentPage !== 9) {
-        return this.perPage;
+      // if total grants # is divisible by per page
+      if (this.grantsAndIntAgens.length % this.perPage === 0) {
+        return maxItemsOnPage;
       }
-      return 2;
+      // if current page isn't 1 and the max items is > total grants
+      if ((this.currentPage > 1) && (maxItemsOnPage > this.grantsAndIntAgens.length)) {
+        // sub total grants from max items
+        const res = maxItemsOnPage - this.grantsAndIntAgens.length;
+        // sub res from # of grants to be displayed on page
+        return this.perPage - res;
+      }
+      return maxItemsOnPage;
     },
   },
   watch: {

--- a/packages/client/src/views/UpcomingClosingDates.vue
+++ b/packages/client/src/views/UpcomingClosingDates.vue
@@ -24,10 +24,10 @@
     </b-table>
     </b-card>
     <b-row align-v="center">
-      <b-pagination class="m-0" v-model="currentPage" :total-rows="totalRows" :per-page="perPage" first-number
+      <b-pagination class="m-0" v-model="currentPage" :total-rows="upcomingItems" :per-page="perPage" first-number
         last-number first-text="First" prev-text="Prev" next-text="Next" last-text="Last"
         aria-controls="grants-table" />
-      <b-button class="ml-2" variant="outline-primary disabled">{{ grantsInterested.length }} of {{ totalRows }}</b-button>
+      <b-button class="ml-2" variant="outline-primary disabled">{{ grantsAndIntAgens.length }} of {{ upcomingItems.length }}</b-button>
     </b-row>
     <GrantDetails :selected-grant.sync="selectedGrant" />
   </section>

--- a/packages/server/src/db/index.js
+++ b/packages/server/src/db/index.js
@@ -378,6 +378,7 @@ async function getSingleGrantDetails({ grantId, agencies }) {
 }
 
 async function getClosestGrants(agency) {
+    //updated to no longer limit result # & specify user association
     const userAgencies = await getAgencies(agency);
     const timestamp = new Date().toLocaleDateString('en-US');
     const query = await knex(TABLES.grants)

--- a/packages/server/src/db/index.js
+++ b/packages/server/src/db/index.js
@@ -386,7 +386,6 @@ async function getClosestGrants() {
             this.select('grant_id').from('grants_interested');
         })
         .orderBy('close_date', 'asc')
-        .limit(3)
         .then((data) => data)
         .catch((err) => console.log(err));
     const query1 = query;

--- a/packages/server/src/db/index.js
+++ b/packages/server/src/db/index.js
@@ -378,7 +378,7 @@ async function getSingleGrantDetails({ grantId, agencies }) {
 }
 
 async function getClosestGrants(agency) {
-    //updated to no longer limit result # & specify user association
+    // updated to no longer limit result # & specify user association
     const userAgencies = await getAgencies(agency);
     const timestamp = new Date().toLocaleDateString('en-US');
     const query = await knex(TABLES.grants)


### PR DESCRIPTION
Issue: #232 

Issue Solution:
Changed getClosestGrants query to list all grants that fit the requirements but still limiting it on the dashboard card.
Used b-pagination for easy table navigation.

Screenshots:
1.) Full Page view of Upcoming Closing Grants Table with 11 grants. Date colors are being fixed in a separate issue.
<img width="819" alt="Screen Shot 2022-08-14 at 1 00 12 PM" src="https://user-images.githubusercontent.com/31491718/184549113-7766368c-75f7-4613-9ef9-e7bc021214c8.png">

Testing:
Changed number of grants with interest to see how it would be displayed. 