### PR TITLE
268 fix upcoming grants full screen bug, add backend pagination

### DIFF
--- a/packages/client/src/store/modules/dashboard.js
+++ b/packages/client/src/store/modules/dashboard.js
@@ -12,7 +12,6 @@ function initialState() {
     grantsUpdatedInTimeframe: null,
     grantsUpdatedInTimeframeMatchingCriteria: null,
     totalInterestedGrantsByAgencies: null,
-    getClosestGrants: null,
   };
 }
 
@@ -30,13 +29,12 @@ export default {
     grantsUpdatedInTimeframe: (state) => state.grantsUpdatedInTimeframe,
     grantsUpdatedInTimeframeMatchingCriteria: (state) => state.grantsUpdatedInTimeframeMatchingCriteria,
     totalInterestedGrantsByAgencies: (state) => state.totalInterestedGrantsByAgencies,
-    getClosestGrants: (state) => state.getClosestGrants,
   },
   actions: {
     async fetchDashboard({ commit }) {
       const twentyFourHoursAgo = new Date(Date.now() - 24 * 60 * 60 * 1000);
       const timestampQueryString = twentyFourHoursAgo.toISOString();
-      const result = await fetchApi.get(`/api/organizations/:organizationId/dashboard?totalGrants=true&totalViewedGrants=true&totalInterestedGrants=true&grantsCreatedFromTs=${timestampQueryString}&grantsUpdatedFromTs=${timestampQueryString}&totalInterestedGrantsByAgencies=true&getClosestGrants=true`);
+      const result = await fetchApi.get(`/api/organizations/:organizationId/dashboard?totalGrants=true&totalViewedGrants=true&totalInterestedGrants=true&grantsCreatedFromTs=${timestampQueryString}&grantsUpdatedFromTs=${timestampQueryString}&totalInterestedGrantsByAgencies=true`);
       if (result.totalGrants) {
         commit('SET_TOTAL_GRANTS', result.totalGrants);
       }
@@ -63,9 +61,6 @@ export default {
       }
       if (result.totalInterestedGrantsByAgencies) {
         commit('SET_TOTAL_TOTAL_INTERESTED_GRANTS_BY_AGENCIES', result.totalInterestedGrantsByAgencies);
-      }
-      if (result.getClosestGrants) {
-        commit('SET_GRANTS_UPCOMING_CLOSING_DATES', result.getClosestGrants);
       }
     },
   },
@@ -96,9 +91,6 @@ export default {
     },
     SET_TOTAL_TOTAL_INTERESTED_GRANTS_BY_AGENCIES(state, data) {
       state.totalInterestedGrantsByAgencies = data;
-    },
-    SET_GRANTS_UPCOMING_CLOSING_DATES(state, data) {
-      state.getClosestGrants = data;
     },
     SET_DASHBOARD(state, dashboard) {
       state.dashboard = dashboard;

--- a/packages/client/src/store/modules/grants.js
+++ b/packages/client/src/store/modules/grants.js
@@ -7,6 +7,8 @@ function initialState() {
     keywords: [],
     interestedCodes: [],
     grantsInterested: [],
+    closestGrants: [],
+    totalUpcomingGrants: 0,
     currentGrant: {},
   };
 }
@@ -18,6 +20,8 @@ export default {
     grants: (state) => state.grantsPaginated.data || [],
     grantsPagination: (state) => state.grantsPaginated.pagination,
     grantsInterested: (state) => state.grantsInterested,
+    closestGrants: (state) => state.closestGrants,
+    totalUpcomingGrants: (state) => state.totalUpcomingGrants,
     currentGrant: (state) => state.currentGrant,
     eligibilityCodes: (state) => state.eligibilityCodes,
     interestedCodes: (state) => ({
@@ -44,6 +48,10 @@ export default {
     fetchGrantsInterested({ commit }, { perPage, currentPage }) {
       return fetchApi.get(`/api/organizations/:organizationId/grants/grantsInterested/${perPage}/${currentPage}`)
         .then((data) => commit('SET_GRANTS_INTERESTED', data));
+    },
+    fetchClosestGrants({ commit }, { perPage, currentPage }) {
+      return fetchApi.get(`/api/organizations/:organizationId/grants/closestGrants/${perPage}/${currentPage}`)
+        .then((data) => commit('SET_CLOSEST_GRANTS', data));
     },
     fetchGrantDetails({ commit }, { grantId }) {
       return fetchApi.get(`/api/organizations/:organizationId/grants/${grantId}/grantDetails`)
@@ -157,6 +165,10 @@ export default {
     },
     SET_GRANT_CURRENT(state, currentGrant) {
       state.currentGrant = currentGrant;
+    },
+    SET_CLOSEST_GRANTS(state, closestGrants) {
+      state.closestGrants = closestGrants.data;
+      state.totalUpcomingGrants = closestGrants.pagination.total;
     },
   },
 };

--- a/packages/client/src/views/Dashboard.vue
+++ b/packages/client/src/views/Dashboard.vue
@@ -54,12 +54,10 @@
                 selectable
                 select-mode="single"
                 @row-selected="onRowSelected">
-                <template #cell()="{ field, value }">
+                <template #cell()="{ field, value, index }">
                   <div v-if="yellowDate == true" :style="field.trStyle" v-text="value"></div>
                   <div v-if="redDate == true" :style="field.tdStyle" v-text="value"></div>
-                  <div v-if="(grantsAndIntAgens[0]) && (field.key == 'title') && (value == grantsAndIntAgens[0].title)" :style="{color:'#757575'}">{{grantsAndIntAgens[0].interested_agencies}}</div>
-                  <div v-if="(grantsAndIntAgens[1]) && (field.key == 'title') && (value == grantsAndIntAgens[1].title)" :style="{color:'#757575'}">{{grantsAndIntAgens[1].interested_agencies}}</div>
-                  <div v-if="(grantsAndIntAgens[2]) && (field.key == 'title') && (value == grantsAndIntAgens[2].title)" :style="{color:'#757575'}">{{grantsAndIntAgens[2].interested_agencies}}</div>
+                  <div v-if="(grantsAndIntAgens[index]) && (field.key == 'title') && (value == grantsAndIntAgens[index].title)" :style="{color:'#757575'}">{{grantsAndIntAgens[index].interested_agencies}}</div>
                 </template>
               </b-table>
               <b-row align-v="center">
@@ -444,7 +442,7 @@ export default {
     async formatUpcoming() {
       this.grantsAndIntAgens = [];
       // https://stackoverflow.com/a/67219279
-      this.closestGrants.slice(0, 3).map(async (grant, idx) => {
+      this.closestGrants.map(async (grant, idx) => {
         const arr = await this.getInterestedAgenciesAction({ grantId: grant.grant_id });
         const updateGrant = {
           ...grant,

--- a/packages/client/src/views/Dashboard.vue
+++ b/packages/client/src/views/Dashboard.vue
@@ -57,7 +57,7 @@
                 <template #cell()="{ field, value }">
                   <div v-if="yellowDate == true" :style="field.trStyle" v-text="value"></div>
                   <div v-if="redDate == true" :style="field.tdStyle" v-text="value"></div>
-                  <div v-if="(field.key == 'title') && (value == grantsAndIntAgens[0].title)" :style="{color:'#757575'}">{{grantsAndIntAgens[0].interested_agencies}}</div>
+                  <div v-if="(grantsAndIntAgens[0]) && (field.key == 'title') && (value == grantsAndIntAgens[0].title)" :style="{color:'#757575'}">{{grantsAndIntAgens[0].interested_agencies}}</div>
                   <div v-if="(grantsAndIntAgens[1]) && (field.key == 'title') && (value == grantsAndIntAgens[1].title)" :style="{color:'#757575'}">{{grantsAndIntAgens[1].interested_agencies}}</div>
                   <div v-if="(grantsAndIntAgens[2]) && (field.key == 'title') && (value == grantsAndIntAgens[2].title)" :style="{color:'#757575'}">{{grantsAndIntAgens[2].interested_agencies}}</div>
                 </template>
@@ -161,6 +161,7 @@ export default {
       sortBy: 'dateSort',
       sortAsc: true,
       perPage: 4,
+      perPageClosest: 3,
       currentPage: 1,
       grantsAndIntAgens: [],
       activityFields: [
@@ -322,7 +323,7 @@ export default {
       grantsUpdatedInTimeframeMatchingCriteria: 'dashboard/grantsUpdatedInTimeframeMatchingCriteria',
       totalInterestedGrantsByAgencies: 'dashboard/totalInterestedGrantsByAgencies',
       selectedAgency: 'users/selectedAgency',
-      getClosestGrants: 'dashboard/getClosestGrants',
+      closestGrants: 'grants/closestGrants',
       grants: 'grants/grants',
       grantsInterested: 'grants/grantsInterested',
       agency: 'users/agency',
@@ -365,7 +366,7 @@ export default {
     },
     upcomingItems() {
       // https://stackoverflow.com/a/48643055
-      return this.getClosestGrants;
+      return this.closestGrants;
     },
   },
   watch: {
@@ -379,6 +380,7 @@ export default {
     async selectedGrant() {
       if (!this.selectedGrant) {
         await this.fetchGrantsInterested();
+        await this.fetchClosestGrants();
       }
     },
     currentGrant() {
@@ -394,11 +396,13 @@ export default {
       getAgency: 'agencies/getAgency',
       fetchInterestedAgencies: 'grants/fetchInterestedAgencies',
       fetchGrantsInterested: 'grants/fetchGrantsInterested',
+      fetchClosestGrants: 'grants/fetchClosestGrants',
       fetchGrantDetails: 'grants/fetchGrantDetails',
     }),
     async setup() {
       this.fetchDashboard();
       this.fetchGrantsInterested({ perPage: this.perPage, currentPage: this.currentPage });
+      this.fetchClosestGrants({ perPage: this.perPageClosest, currentPage: this.currentPage });
     },
     formatMoney(value) {
       const res = Number(value).toLocaleString('en-US', {
@@ -440,7 +444,7 @@ export default {
     async formatUpcoming() {
       this.grantsAndIntAgens = [];
       // https://stackoverflow.com/a/67219279
-      this.getClosestGrants.slice(0, 3).map(async (grant, idx) => {
+      this.closestGrants.slice(0, 3).map(async (grant, idx) => {
         const arr = await this.getInterestedAgenciesAction({ grantId: grant.grant_id });
         const updateGrant = {
           ...grant,

--- a/packages/client/src/views/UpcomingClosingDates.vue
+++ b/packages/client/src/views/UpcomingClosingDates.vue
@@ -14,21 +14,19 @@
       selectable
       select-mode="single"
       @row-selected="onRowSelected"
-      :per-page="perPage"
-      :current-page="currentPage"
     >
       <template #cell()="{ field, value, index }">
         <div v-if="yellowDate == true" :style="field.trStyle" v-text="value"></div>
         <div v-if="redDate == true" :style="field.tdStyle" v-text="value"></div>
-        <div v-if="(field.key == 'title') && (value == grantsAndIntAgens[index].title)" :style="{color:'#757575'}">{{grantsAndIntAgens[index].interested_agencies}}</div>
+        <div v-if="grantsAndIntAgens[index] && (field.key == 'title') && (value == grantsAndIntAgens[index].title)" :style="{color:'#757575'}">{{grantsAndIntAgens[index].interested_agencies}}</div>
       </template>
     </b-table>
     </b-card>
     <b-row align-v="center">
-      <b-pagination class="m-0" v-model="currentPage" :per-page="perPage" first-number :total-rows="rows"
+      <b-pagination class="m-0" v-model="currentPage" :per-page="perPage" first-number :total-rows="totalRows"
         last-number first-text="First" prev-text="Prev" next-text="Next" last-text="Last" :current-page="currentPage"
         aria-controls="upcomingGrants" />
-      <b-button class="ml-2" variant="outline-primary disabled">{{ totalOnPage }} of {{ upcomingItems.length }}</b-button>
+      <b-button class="ml-2" variant="outline-primary disabled">{{ upcomingItems.length }} of {{ totalRows }}</b-button>
     </b-row>
     <GrantDetails :selected-grant.sync="selectedGrant" />
   </section>
@@ -113,6 +111,7 @@ export default {
       grantsInterested: 'grants/grantsInterested',
       currentGrant: 'grants/currentGrant',
       totalGrants: 'dashboard/totalGrants',
+      totalUpcomingGrants: 'grants/totalUpcomingGrants',
       totalGrantsMatchingAgencyCriteria: 'dashboard/totalGrantsMatchingAgencyCriteria',
       totalViewedGrants: 'dashboard/totalViewedGrants',
       grantsCreatedInTimeframe: 'dashboard/grantsCreatedInTimeframe',
@@ -120,35 +119,15 @@ export default {
       grantsUpdatedInTimeframe: 'dashboard/grantsUpdatedInTimeframe',
       grantsUpdatedInTimeframeMatchingCriteria: 'dashboard/grantsUpdatedInTimeframeMatchingCriteria',
       selectedAgency: 'users/selectedAgency',
-      getClosestGrants: 'dashboard/getClosestGrants',
+      closestGrants: 'grants/closestGrants',
       agency: 'users/agency',
     }),
     upcomingItems() {
       // https://stackoverflow.com/a/48643055
-      return this.getClosestGrants;
+      return this.closestGrants;
     },
-    rows() {
-      return this.upcomingItems.length;
-    },
-    totalOnPage() {
-      // max # of items that can be on a given page
-      const maxItemsOnPage = this.currentPage * this.perPage;
-      // if there are less grants than # to be displayed
-      if (this.grantsAndIntAgens.length < this.perPage) {
-        return this.grantsAndIntAgens.length;
-      }
-      // if total grants # is divisible by per page
-      if (this.grantsAndIntAgens.length % this.perPage === 0) {
-        return maxItemsOnPage;
-      }
-      // if current page isn't 1 and the max items is > total grants
-      if ((this.currentPage > 1) && (maxItemsOnPage > this.grantsAndIntAgens.length)) {
-        // sub total grants from max items
-        const res = maxItemsOnPage - this.grantsAndIntAgens.length;
-        // sub res from # of grants to be displayed on page
-        return this.perPage - res;
-      }
-      return maxItemsOnPage;
+    totalRows() {
+      return this.totalUpcomingGrants;
     },
   },
   watch: {
@@ -161,7 +140,7 @@ export default {
     },
     async selectedGrant() {
       if (!this.selectedGrant) {
-        await this.fetchGrantsInterested();
+        await this.fetchClosestGrants();
       }
     },
     currentGrant() {
@@ -180,9 +159,11 @@ export default {
       getInterestedAgenciesAction: 'grants/getInterestedAgencies',
       getAgency: 'agencies/getAgency',
       fetchInterestedAgencies: 'grants/fetchInterestedAgencies',
+      fetchClosestGrants: 'grants/fetchClosestGrants',
     }),
     setup() {
       this.fetchDashboard();
+      this.fetchClosestGrants({ perPage: this.perPage, currentPage: this.currentPage });
     },
     async onRowSelected(items) {
       const [row] = items;
@@ -221,7 +202,8 @@ export default {
       return (`${finalDate}`);
     },
     async formatUpcoming() {
-      this.getClosestGrants.map(async (grant, idx) => {
+      this.grantsAndIntAgens = [];
+      this.closestGrants.map(async (grant, idx) => {
         const arr = await this.getInterestedAgenciesAction({ grantId: grant.grant_id });
         const updateGrant = {
           ...grant,

--- a/packages/server/__tests__/db/db.test.js
+++ b/packages/server/__tests__/db/db.test.js
@@ -100,9 +100,9 @@ describe('db', () => {
         it('gets closest grants', async () => {
             // arrange  #done in fixtures
             // act
-            const result = await db.getClosestGrants(0);
+            const result = await db.getClosestGrants({ agency: 0, perPage: 10, currentPage: 1 });
             // assert
-            expect(result.length).to.equal(1);
+            expect(result.data.length).to.equal(1);
         });
     });
 

--- a/packages/server/src/db/index.js
+++ b/packages/server/src/db/index.js
@@ -377,7 +377,7 @@ async function getSingleGrantDetails({ grantId, agencies }) {
     };
 }
 
-async function getClosestGrants(agency) {
+async function getClosestGrants({ agency, perPage, currentPage }) {
     // updated to no longer limit result # & specify user association
     const userAgencies = await getAgencies(agency);
     const timestamp = new Date().toLocaleDateString('en-US');
@@ -389,10 +389,10 @@ async function getClosestGrants(agency) {
                 .where('agency_id', 'IN', userAgencies.map((subAgency) => subAgency.id));
         })
         .orderBy('close_date', 'asc')
+        .paginate({ currentPage, perPage, isLengthAware: true })
         .then((data) => data)
         .catch((err) => console.log(err));
-    const query1 = query;
-    return query1;
+    return query;
 }
 
 async function getTotalGrants({ agencyCriteria, createdTsBounds, updatedTsBounds } = {}) {

--- a/packages/server/src/routes/dashboard.js
+++ b/packages/server/src/routes/dashboard.js
@@ -22,9 +22,6 @@ router.get('/', requireUser, async (req, res) => {
     if (req.query.totalInterestedGrants) {
         result.totalInterestedGrants = await db.getTotalInterestedGrants();
     }
-    if (req.query.getClosestGrants) {
-        result.getClosestGrants = await db.getClosestGrants(req.session.selectedAgency);
-    }
     if (req.query.totalInterestedGrantsByAgencies) {
         result.totalInterestedGrantsByAgencies = await db.getTotalInterestedGrantsByAgencies();
     }

--- a/packages/server/src/routes/grants.js
+++ b/packages/server/src/routes/grants.js
@@ -85,6 +85,12 @@ router.get('/:grantId/grantDetails', requireUser, async (req, res) => {
     res.json(response);
 });
 
+router.get('/closestGrants/:perPage/:currentPage', requireUser, async (req, res) => {
+    const { perPage, currentPage } = req.params;
+    const rows = await db.getClosestGrants({ agency: req.session.selectedAgency, perPage, currentPage });
+    res.json(rows);
+});
+
 // For API tests, reduce the limit to 100 -- this is so we can test the logic around the limit
 // without the test having to insert 10k rows, which slows down the test.
 const MAX_CSV_EXPORT_ROWS = process.env.NODE_ENV !== 'test' ? 10000 : 100;


### PR DESCRIPTION
### Ticket #268 

### Description

Fixed a bug where interested lists on entries after the first page would not show on the upcoming grants full screen view. Also adds backend pagination to getClosestGrants and moves the closestGrants functionality from the dashboard route to the grants route to make passing perPage and currentPage a bit easier.

### Screenshots / Demo Video

Before 
![b481522](https://user-images.githubusercontent.com/56096100/184715002-db2e72e2-045b-451a-ba79-1881ffdbcb38.png)

After (data in the table had changed at this point, but shows that the second page works, 00 indicates 2100)
![image](https://user-images.githubusercontent.com/56096100/184715030-c382e520-048f-4486-9149-eb9b271cd34b.png)

### Testing

Check the upcoming grants feed full page view, add enough grants to get more than one page, check that all functionality and info is present and correct on all pages.

### Checklist
- [x] Provided ticket and description
- [x] Your PR title contains the ISSUE ticket number e.g "86: ..."
- [x] Provided screenshots/demo
- [x] Provided testing information
- [x] Provided adequate test coverage for all new code
- [x] Added PR reviewers
- [x] Ensure at least 1 review before merging