### PR TITLE
272 upcoming closing dates feed fix

### DIFF
--- a/packages/client/src/views/Dashboard.vue
+++ b/packages/client/src/views/Dashboard.vue
@@ -55,8 +55,10 @@
                 select-mode="single"
                 @row-selected="onRowSelected">
                 <template #cell()="{ field, value, index }">
-                  <div v-if="yellowDate == true" :style="field.trStyle" v-text="value"></div>
-                  <div v-if="redDate == true" :style="field.tdStyle" v-text="value"></div>
+                  <div v-if="field.key == 'title'">{{value}}</div>
+                  <div v-if="field.key == 'close_date' && !(yellowDate || redDate)" v-text="value"></div>
+                  <div v-if="field.key == 'close_date' && yellowDate == true" :style="field.trStyle" v-text="value"></div>
+                  <div v-if="field.key == 'close_date' && redDate == true" :style="field.tdStyle" v-text="value"></div>
                   <div v-if="(grantsAndIntAgens[index]) && (field.key == 'title') && (value == grantsAndIntAgens[index].title)" :style="{color:'#757575'}">{{grantsAndIntAgens[index].interested_agencies}}</div>
                 </template>
               </b-table>

--- a/packages/client/src/views/UpcomingClosingDates.vue
+++ b/packages/client/src/views/UpcomingClosingDates.vue
@@ -16,9 +16,11 @@
       @row-selected="onRowSelected"
     >
       <template #cell()="{ field, value, index }">
-        <div v-if="yellowDate == true" :style="field.trStyle" v-text="value"></div>
-        <div v-if="redDate == true" :style="field.tdStyle" v-text="value"></div>
-        <div v-if="grantsAndIntAgens[index] && (field.key == 'title') && (value == grantsAndIntAgens[index].title)" :style="{color:'#757575'}">{{grantsAndIntAgens[index].interested_agencies}}</div>
+        <div v-if="field.key == 'title'">{{value}}</div>
+        <div v-if="field.key == 'close_date' && !(yellowDate || redDate)" v-text="value"></div>
+        <div v-if="field.key == 'close_date' && yellowDate == true" :style="field.trStyle" v-text="value"></div>
+        <div v-if="field.key == 'close_date' && redDate == true" :style="field.tdStyle" v-text="value"></div>
+        <div v-if="(grantsAndIntAgens[index]) && (field.key == 'title') && (value == grantsAndIntAgens[index].title)" :style="{color:'#757575'}">{{grantsAndIntAgens[index].interested_agencies}}</div>
       </template>
     </b-table>
     </b-card>


### PR DESCRIPTION
### Ticket #272

### Description

Upcoming closing dates was not working at times when certain grants were selected. These changes seem to make all information appear.

### Screenshots / Demo Video

Before

![image](https://user-images.githubusercontent.com/56096100/184950071-d97b3f2f-35bc-4144-8d30-1d4577a206f7.png)


After

![image](https://user-images.githubusercontent.com/56096100/184949943-3dbab5d8-1ceb-44b2-9638-ed5e3ccdcf0b.png)


### Testing

Check upcoming closing dates, make sure all data is visible. Check that grants are visible when less than three are in the feed and when the grant titles are multiple lines long.

### Checklist
- [x] Provided ticket and description
- [x] Your PR title contains the ISSUE ticket number e.g "86: ..."
- [x] Provided screenshots/demo
- [x] Provided testing information
- [x] Provided adequate test coverage for all new code
- [x] Added PR reviewers
- [ ] Ensure at least 1 review before merging