### PR TITLE
185 add getSingleGrantDetails tests

### DIFF
--- a/packages/server/__tests__/db/db.test.js
+++ b/packages/server/__tests__/db/db.test.js
@@ -24,7 +24,6 @@ describe('db', () => {
             // console.log(fixtures.grantsInterested.entry2);
             expect(result.rows[0]).to.have.property('grant_id').with.lengthOf(6);
             expect(result.rows[0].grant_id).to.equal(fixtures.grantsInterested.entry2.grant_id);
-            expect(result.rows[0].user_id).to.equal(fixtures.grantsInterested.entry2.user_id);
             // in the grants interested table the grant with the most recent created_at has the grant id of 335255
             expect(result.rows[0]).to.have.property('grant_id').equal('335255');
         });
@@ -37,7 +36,7 @@ describe('db', () => {
     context('getTotalInterestedGrants', () => {
         it('gets total interested grants count', async () => {
             const result = await db.getTotalInterestedGrants();
-            expect(result).to.equal(+'3');
+            expect(result).to.equal(+'4');
         });
     });
 
@@ -116,6 +115,21 @@ describe('db', () => {
                 .to.equal(fixtures.agencyEligibilityCodes.accountancyNative.code);
             expect(result).to.have.property('keywords').with.lengthOf(1);
             expect(result.keywords[0]).to.equal(fixtures.keywords.accountancyCovid.search_term);
+        });
+    });
+
+    context('getSingleGrantDetails', () => {
+        it('gets the desired grant', async () => {
+            const grantId = '335255';
+            const agencies = [];
+            const result = await db.getSingleGrantDetails({ grantId, agencies });
+            expect(result.grant_id).to.equal('335255');
+        });
+        it('gets the interested agencies', async () => {
+            const grantId = '335255';
+            const agencies = [0];
+            const result = await db.getSingleGrantDetails({ grantId, agencies });
+            expect(result.interested_agencies.length).to.equal(1);
         });
     });
 

--- a/packages/server/__tests__/db/seeds/fixtures.js
+++ b/packages/server/__tests__/db/seeds/fixtures.js
@@ -27,12 +27,14 @@ const users = {
         name: 'Admin User',
         agency_id: agencies.accountancy.id,
         role_id: roles.adminRole.id,
+        id: roles.adminRole.id,
     },
     staffUser: {
         email: 'staff.user@test.com',
         name: 'Staff User',
         agency_id: agencies.accountancy.id,
         role_id: roles.staffRole.id,
+        id: roles.staffRole.id,
     },
 };
 


### PR DESCRIPTION
### Ticket #185 

### Description

Adds testing for the getSingleGrantDetails db function. Adds slight edits to some grants interested tests to account for adding the the user id value.

### Screenshots / Demo Video

![image](https://user-images.githubusercontent.com/56096100/184968202-696c6066-b225-460f-ae72-45f5caaf624a.png)


### Testing

run yarn test:db, see expected output in screenshot above

### Checklist
- [x] Provided ticket and description
- [x] Your PR title contains the ISSUE ticket number e.g "86: ..."
- [x] Provided screenshots/demo
- [x] Provided testing information
- [x] Provided adequate test coverage for all new code
- [x] Added PR reviewers
- [ ] Ensure at least 1 review before merging