### PR TITLE
add back upcoming list clearing

### DIFF
--- a/packages/client/src/views/Dashboard.vue
+++ b/packages/client/src/views/Dashboard.vue
@@ -440,6 +440,7 @@ export default {
       return (`${finalDate}`);
     },
     async formatUpcoming() {
+      this.grantsAndIntAgens = [];
       // https://stackoverflow.com/a/67219279
       this.closestGrants.map(async (grant, idx) => {
         const arr = await this.getInterestedAgenciesAction({ grantId: grant.grant_id });


### PR DESCRIPTION
### Description

Adds back the ability for the upcoming closing dates feed to clear itself out when changing agencies so old values aren't left inside. (no ticket, last minute fix)

### Screenshots / Demo Video

before  (with test22 selected)
![image](https://user-images.githubusercontent.com/56096100/185447182-db679c8f-4b58-46cc-a615-2886889ba8db.png)

after will just show the test related grant

### Testing

change agencies when in dashboard -> make sure upcoming closing dates changes accordingly as well.

### Checklist
- [x] Provided ticket and description
- [x] Your PR title contains the ISSUE ticket number e.g "86: ..."
- [x] Provided screenshots/demo
- [x] Provided testing information
- [x] Provided adequate test coverage for all new code
- [x] Added PR reviewers
- [x] Ensure at least 1 review before merging