### PR TITLE
add back the fix for upcoming closing dates not showing when less than three items are in the list

### DIFF
--- a/packages/client/src/views/Dashboard.vue
+++ b/packages/client/src/views/Dashboard.vue
@@ -48,7 +48,7 @@
               <div class="card-block text-left">
                 <h4 class="card-title gutter-title2 row">Upcoming Closing Dates</h4>
               </div>
-              <b-table v-if="(grantsAndIntAgens.length >= 3)" sticky-header='350px' hover :items='grantsAndIntAgens' :fields='upcomingFields'
+              <b-table sticky-header='350px' hover :items='grantsAndIntAgens' :fields='upcomingFields'
                 class='table table-borderless' thead-class="d-none"
                 selectable
                 select-mode="single"


### PR DESCRIPTION
### Description

Adds back the fix that stopped upcoming closing dates from not showing when there are less than 3 entries. (no ticket, last minute fix)

### Screenshots / Demo Video

before (list not actually empty)
![image](https://user-images.githubusercontent.com/56096100/185450447-904299fd-1e58-4947-a8f5-c71abcd33f9b.png)

after will show the feed

### Testing

select agency with less than 3 grants upcoming and verify that they show on the dashboard feed.

### Checklist
- [x] Provided ticket and description
- [x] Your PR title contains the ISSUE ticket number e.g "86: ..."
- [x] Provided screenshots/demo
- [x] Provided testing information
- [x] Provided adequate test coverage for all new code
- [x] Added PR reviewers
- [x] Ensure at least 1 review before merging