### PR TITLE
Disable func-names linter

### DIFF
--- a/packages/server/.eslintrc.js
+++ b/packages/server/.eslintrc.js
@@ -45,5 +45,6 @@ module.exports = {
         'no-unused-expressions': 'off',
         'import/no-dynamic-require': 'off',
         'no-param-reassign': 'off',
+        'func-names': 'off',
     },
 };


### PR DESCRIPTION
This was causing warnings on several PRs for things that are usually unnamed by convention and doesn't feel that useful anyway.