### PR TITLE
ARPA integration: Database shims for ARPA Reporter code

### DIFF
--- a/packages/server/src/db/arpa_reporter_db_shims/agencies.js
+++ b/packages/server/src/db/arpa_reporter_db_shims/agencies.js
@@ -1,0 +1,59 @@
+// This file exists as a shim to replace ARPA Reporter's db/users.js
+// Eventually, the functions in this file should have callsites updated to use GOST's existing methods
+// and this file can be deleted.
+
+const knex = require('../connection');
+const gostDb = require('..');
+
+// TODO(mbroussard): after merge, replace with an import to ARPA's use-request module
+function useTenantId() {
+    throw new Error('import missing -- need to update after ARPA merge');
+}
+function useUser() {
+    throw new Error('import missing -- need to update after ARPA merge');
+}
+
+async function agencies() {
+    const tenantId = useTenantId();
+    const tenant = await knex('tenants')
+        .where('id', tenantId)
+        .select('*')
+        .then((rows) => rows[0]);
+    const mainAgencyId = tenant.main_agency_id;
+
+    return gostDb.getAgencies(mainAgencyId);
+}
+
+function agencyById(id) {
+    return gostDb.getAgency(id);
+}
+
+function agencyByCode(code) {
+    const tenantId = useTenantId();
+    return knex('agencies')
+        .select('*')
+        .where({ tenant_id: tenantId, code });
+}
+
+function createAgency(agency) {
+    const tenantId = useTenantId();
+    const creator = useUser();
+    return gostDb.createAgency({ ...agency, tenant_id: tenantId }, creator.id);
+}
+
+async function updateAgency(agency) {
+    await gostDb.setAgencyName(agency.name);
+    await knex('agencies')
+        .where('id', agency.id)
+        .update({ code: agency.code });
+
+    return gostDb.getAgency(agency.id);
+}
+
+module.exports = {
+    agencies,
+    agencyById,
+    agencyByCode,
+    createAgency,
+    updateAgency,
+};

--- a/packages/server/src/db/arpa_reporter_db_shims/users.js
+++ b/packages/server/src/db/arpa_reporter_db_shims/users.js
@@ -1,0 +1,83 @@
+// This file exists as a shim to replace ARPA Reporter's db/users.js
+// Eventually, the functions in this file should have callsites updated to use GOST's existing methods
+// and this file can be deleted.
+
+const knex = require('../connection');
+const gostDb = require('..');
+
+// TODO(mbroussard): after merge, replace with an import to ARPA's use-request module
+function useTenantId() {
+    throw new Error('import missing -- need to update after ARPA merge');
+}
+
+async function users() {
+    const tenantId = useTenantId();
+    const tenant = await knex('tenants')
+        .where('id', tenantId)
+        .select('*')
+        .then((rows) => rows[0]);
+    const mainAgencyId = tenant.main_agency_id;
+
+    return gostDb.getUsers(mainAgencyId);
+}
+
+function createUser(u) {
+    const tenantId = useTenantId();
+    return gostDb.createUser({ ...u, tenant_id: tenantId });
+}
+
+function updateUser(u) {
+    // TODO(mbroussard): should we make this throw instead? GOST doesn't currently allow any of these
+    // to be modified.
+
+    const update = {
+        email: u.email,
+        name: u.name,
+        agency_id: u.agency_id,
+    };
+    if (u.role && u.role.id) {
+        update.role_id = u.role.id;
+    }
+
+    return knex('users')
+        .where('id', u.id)
+        .update(update)
+        .returning('*')
+        .then((rows) => rows[0]);
+}
+
+async function userAndRole(id) {
+    return gostDb.getUser(id);
+}
+
+function user(id) {
+    return userAndRole(id);
+}
+
+function roles() {
+    return gostDb.getRoles();
+}
+
+function accessToken() {
+    throw new Error('this should not be called; use GOST access-helpers/sessions instead');
+}
+
+function markAccessTokenUsed() {
+    throw new Error('this should not be called; use GOST access-helpers/sessions instead');
+}
+
+function createAccessToken() {
+    throw new Error('this should not be called; use GOST access-helpers/sessions instead');
+}
+
+module.exports = {
+    accessToken,
+    createAccessToken,
+    createUser,
+    markAccessTokenUsed,
+    roles,
+    updateUser,
+    user,
+    userAndRole,
+    users,
+};


### PR DESCRIPTION
These two files are intended as drop-in replacements for the ARPA Reporter's equivalent database accessor modules for the tables that will be shared. They will be designated as an import rewrite in my copy_and_rewrite script (see draft PR #297) The intent is to eventually remove these by updating callsites in ARPA Reporter to use the GOST database accessors directly.

This PR is a sister to https://github.com/usdigitalresponse/arpa-reporter/pull/505 in the arpa-reporter repo which modifies the usage of these tables there to more closely match their shape in GOST (particularly with respect to the `role`/`role_id` fields and joins to `agencies` in the `users` accessors.

This covers tables `users`, `roles`, and `agencies`. The `access_tokens` table will not be used directly in any ARPA reporter code (instead, ARPA reporter code will use GOST's `routes/sessions` and `access-helper` modules directly, which already have nearly identical API).

Overall design doc for integration project: https://www.notion.so/usdr/GOST-ARPA-integration-technical-plan-cffc5800c0414660816a0920b959da82