### PR TITLE
ARPA Integration: GOST-side changes to allow running ARPA Reporter tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,6 +46,9 @@ jobs:
       - name: Run unit tests
         env:
           POSTGRES_TEST_URL: "postgresql://postgres:password@localhost:${{ job.services.postgres.ports[5432] }}/usdr_grants_test"
+          # This is intentional to set POSTGRES_URL=POSTGRES_TEST_URL; ARPA Reporter test runner gates
+          # dev vs. CI differences based on whether these are the same.
+          POSTGRES_URL: "postgresql://postgres:password@localhost:${{ job.services.postgres.ports[5432] }}/usdr_grants_test"
           AWS_ACCESS_KEY_ID: "Fake AWS Key"
           AWS_SECRET_ACCESS_KEY: "Fake AWS Secret"
           NOTIFICATIONS_EMAIL: grants-identification@usdigitalresponse.org

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,5 +53,4 @@ jobs:
           # The .env file needs to be present; the example file is good enough.
           cp packages/server/.env.example packages/server/.env
           cp packages/client/.env.example packages/client/.env
-          cd packages/server/; yarn test:apis
           export CI=true; yarn test

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -11,7 +11,7 @@
     "start": "yarn run serve",
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build",
-    "test": "vue-cli-service test:unit --passWithNoTests",
+    "test": "vue-cli-service test:unit",
     "lint": "vue-cli-service lint"
   },
   "dependencies": {

--- a/packages/server/__tests__/run_arpa_reporter_tests.sh
+++ b/packages/server/__tests__/run_arpa_reporter_tests.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -o errexit
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+if [[ -e $DIR/arpa_reporter ]]
+then
+  NODE_ENV=test $DIR/arpa_reporter/server/mocha_wrapper.sh
+else
+  echo "Skipping ARPA Reporter tests because directory does not exist"
+fi

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -23,6 +23,7 @@
     "test:email": "NODE_ENV=test mocha __tests__/email/*.test.js",
     "test:db": "NODE_ENV=test mocha --timeout 10000 __tests__/db/*.test.js",
     "test:apis": "NODE_ENV=test SUPPRESS_EMAIL=TRUE node src > test.log & TEST_SERVER_PID=$!; NODE_ENV=test mocha --exit --bail --require __tests__/api/fixtures.js __tests__/api/*.test.js; TEST_RET_VAL=$?; kill $TEST_SERVER_PID; exit $TEST_RET_VAL",
+    "test:arpa": "NODE_ENV=test __tests__/arpa_reporter/server/mocha_wrapper.sh",
     "lint": "eslint '**/*.js'",
     "pre-commit": "yarn lint"
   },

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -19,11 +19,11 @@
     "migrate:make": "knex migrate:make",
     "env": "export $(cat .env)",
     "db:seed": "yarn db:migrate && knex seed:run",
-    "test": "yarn test:db && yarn test:email",
+    "test": "yarn test:apis && yarn test:arpa && yarn test:db && yarn test:email",
     "test:email": "NODE_ENV=test mocha __tests__/email/*.test.js",
     "test:db": "NODE_ENV=test mocha --timeout 10000 __tests__/db/*.test.js",
     "test:apis": "NODE_ENV=test SUPPRESS_EMAIL=TRUE node src > test.log & TEST_SERVER_PID=$!; NODE_ENV=test mocha --exit --bail --require __tests__/api/fixtures.js __tests__/api/*.test.js; TEST_RET_VAL=$?; kill $TEST_SERVER_PID; exit $TEST_RET_VAL",
-    "test:arpa": "NODE_ENV=test __tests__/arpa_reporter/server/mocha_wrapper.sh",
+    "test:arpa": "NODE_ENV=test __tests__/run_arpa_reporter_tests.sh",
     "lint": "eslint '**/*.js'",
     "pre-commit": "yarn lint"
   },


### PR DESCRIPTION
This will accompany changes in the ARPA repo to make the ARPA Reporter unit tests that will eventually be copied in by the script in #297 possible to run in GOST (and automatically run by CI).

#308 (not for review) is a branch that includes these changes, the copied files, plus some ARPA-side changes that will shortly be put up in a sister PR, validating that the tests can run and pass on CI.

Without those other changes, the new test script added here no-ops.