### PR TITLE
fix: respect new tab name in workbook when generating report

### DIFF
--- a/packages/server/src/lib/annualReports/reportBuilder.js
+++ b/packages/server/src/lib/annualReports/reportBuilder.js
@@ -1,4 +1,4 @@
-const PROJECT_DATA = 'Project Data';
+const PROJECT_DATA = 'Project Information';
 
 /**
  * @typedef ProjectData


### PR DESCRIPTION
### Ticket #
270

### Description
Bug-fix.
Ingested workbooks have changed a tab name from 'Project Data' to 'Project Information'. Need the ARPA reporter to reflect the new tab name on the workbook so it can generate a report from the data on that tab. 

### Screenshots / Demo Video

### Testing

### Checklist
- [ ] Provided ticket and description
- [ ] Your PR title contains the ISSUE ticket number e.g "86: ..."
- [ ] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers
- [ ] Ensure at least 1 review before merging