### PR TITLE
Load environment variables from .env in knexfile.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,12 +88,6 @@ Then export the environment variables
 > cd packages/server && export $(cat .env)
 ```
 
-Set environment variable pointing to local postgres DB, this is used for migrations (knex does not load .env file)
-
-`export POSTGRES_URL=postgresql://localhost:5432/usdr_grants` (individual vars) or `export $(cat .env)` (whole file)
-
-**NOTE:** if using `export $(cat .env)` need to remove all comments from `.env` file.
-
 **_Note:_** In order to login, the server must be able to send email. Set the relevant environment variables under `# Email Server:` in .env to credentials for a personal email account (e.g. for Gmail, see (4.1)[here](https://support.google.com/mail/answer/7126229)).
 
 4.1). Setup Gmail

--- a/packages/server/knexfile.js
+++ b/packages/server/knexfile.js
@@ -1,4 +1,5 @@
 // Update with your config settings.
+require('dotenv').config();
 
 module.exports = {
     test: {


### PR DESCRIPTION
I was trying to set up a working GOST environment this evening, and was very confused that none of the variables I set in my .env file were respected.

Finally, I realized that this knexfile wasn't actually loading dotenv, and therefore the .env file is ignored.   I assume that's just an oversight?  Any reason not to remedy that here?