### PR TITLE
ARPA integration: Bugbash fixes for user/agency creation

### DIFF
--- a/packages/server/src/db/arpa_reporter_db_shims/users.js
+++ b/packages/server/src/db/arpa_reporter_db_shims/users.js
@@ -2,6 +2,7 @@
 // Eventually, the functions in this file should have callsites updated to use GOST's existing methods
 // and this file can be deleted.
 
+const _ = require('lodash');
 const knex = require('../connection');
 const gostDb = require('..');
 
@@ -23,7 +24,7 @@ async function users() {
 
 function createUser(u) {
     const tenantId = useTenantId();
-    return gostDb.createUser({ ...u, tenant_id: tenantId });
+    return gostDb.createUser({ ..._.omit(u, 'role'), role_id: u.role.id, tenant_id: tenantId });
 }
 
 function updateUser(u) {

--- a/packages/server/src/db/index.js
+++ b/packages/server/src/db/index.js
@@ -542,8 +542,7 @@ function getInterestedCodes() {
 }
 
 async function getAgency(agencyId) {
-    const query = `SELECT id, name, abbreviation, parent, warning_threshold, danger_threshold, code
-    FROM agencies WHERE id = ?;`;
+    const query = `SELECT * FROM agencies WHERE id = ?;`;
     const result = await knex.raw(query, agencyId);
 
     return result.rows;
@@ -608,7 +607,7 @@ async function createAgency(agency, creatorId) {
 
     // Enforce tenant isolation by using the tenant_id from the user
     // and the main_agency_id from the tenant.
-    return knex.raw(`
+    const result = await knex.raw(`
         WITH upd AS (
             SELECT
               :parent::integer,
@@ -628,10 +627,12 @@ async function createAgency(agency, creatorId) {
             abbreviation,
             warning_threshold,
             danger_threshold,
+            code,
             tenant_id,
-            main_agency_id,
-            code
-        ) (SELECT * FROM upd)`, update);
+            main_agency_id
+        ) (SELECT * FROM upd) RETURNING *`, update);
+
+    return result.rows[0];
 }
 
 async function deleteAgency(


### PR DESCRIPTION
Various fixes to unbreak users/agencies tabs of ARPA when integrated into GOST:
 - Correct return types on several of the DB shims
 - Add defaults for required `parent`, `abbreviation`, `warning_threshold`, `danger_threshold` columns when creating agencies
 - Correctly handle ARPA's role object format in DB shim when creating a user
 - Return all columns (including crucially `tenant_id` in `getAgency`, called by a shim that assumed this was already the case)
 - Fix column order in `createAgency` (broken in #296, oops); make sure this also returns the full row.
 - Plus one fix in ARPA repo: https://github.com/usdigitalresponse/arpa-reporter/pull/520