### PR TITLE
Misc fixes after ARPA Reporter merge

### DIFF
--- a/packages/server/src/db/index.js
+++ b/packages/server/src/db/index.js
@@ -563,12 +563,7 @@ async function getAgency(agencyId) {
 
 async function getTenantAgencies(tenantId) {
     return knex(TABLES.agencies)
-        .select('id',
-            'name',
-            'abbreviation',
-            'parent',
-            'warning_threshold',
-            'danger_threshold')
+        .select('*')
         .where('tenant_id', tenantId)
         .orderBy('name');
 }

--- a/packages/server/src/scripts/import_arpa_reporter_dump.js
+++ b/packages/server/src/scripts/import_arpa_reporter_dump.js
@@ -46,6 +46,7 @@ const foreignKeyNames = {
     validated_by: "users",
     tenant_id: "tenants",
     parent: "agencies",
+    certified_by: "users",
 };
 
 function rekeyForeignKeys(tableName, row, idLookupByTable, ignoreKeys = []) {

--- a/packages/server/src/scripts/import_arpa_reporter_dump.js
+++ b/packages/server/src/scripts/import_arpa_reporter_dump.js
@@ -26,7 +26,7 @@ const TABLES = [
     "users",
 
     // Purely ARPA Reporter tables
-    "reporting_periods",
+    "reporting_periods", // has FK to users
     "uploads", // has FK to reporting_periods
     "arpa_subrecipients", // has FK to uploads
     "application_settings", // has FK to reporting_periods


### PR DESCRIPTION
1. #309 changed the `getTenantAgencies` accessor and didn't fetch `code` column used by ARPA Reporter; now we fetch all columns (Fixes #364)
2. `reporting_periods.certified_by` (FK to `users.id`) was not listed in import_arpa_reporter_dump.js, causing import to fail if any reporting periods had been certified (somehow we didn't catch this in bugbash; I guess ARPA staging had no certified periods)