### PR TITLE
129 - fix: ensures rejected grants are filtered appropriately

### DIFF
--- a/packages/client/src/components/GrantsTable.vue
+++ b/packages/client/src/components/GrantsTable.vue
@@ -216,7 +216,7 @@ export default {
           currentPage: this.currentPage,
           orderBy: this.orderBy,
           searchTerm: this.debouncedSearchInput,
-          interestedByAgency: this.showInterested,
+          interestedByAgency: this.showInterested || this.showRejected,
           interestedByMe: this.showMyInterested,
           aging: this.showAging,
           assignedToAgency: this.showAssignedToAgency,


### PR DESCRIPTION
### Ticket #129 

### Description
- Rejected grants are currently not scoped to the agency. After this commit, users can only see rejected grants that are part of their agency.

### Screenshots / Demo Video
https://www.loom.com/share/21ea1fd0f1be491aaf7cd8be8bfacbb9

### Testing
- No unit-test coverage here. Adding Loom video.

### Checklist
- [x] Provided ticket and description
- [x] Your PR title contains the ISSUE ticket number e.g "86: ..."
- [x] Provided screenshots/demo
- [x] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [x] Added PR reviewers
- [ ] Ensure at least 1 review before merging