### PR TITLE
feat: ensure arpa_reporter users are redirected to ARPA tool upon user creation

### DIFF
--- a/packages/server/src/arpa_reporter/routes/users.js
+++ b/packages/server/src/arpa_reporter/routes/users.js
@@ -67,13 +67,7 @@ router.post('/', requireAdminUser, async function (req, res, next) {
       const updatedUser = await createUser(user)
       res.json({ user: updatedUser })
 
-      let origin = req.headers.origin;
-
-      if (req.headers.referer.indexOf('arpa_reporter')) {
-        origin += '/arpa_reporter'
-      }
-
-      void sendWelcomeEmail(updatedUser.email, origin)
+      void sendWelcomeEmail(updatedUser.email, req.headers.origin + '/arpa_reporter')
     }
   } catch (e) {
     console.dir(e)

--- a/packages/server/src/arpa_reporter/routes/users.js
+++ b/packages/server/src/arpa_reporter/routes/users.js
@@ -67,7 +67,13 @@ router.post('/', requireAdminUser, async function (req, res, next) {
       const updatedUser = await createUser(user)
       res.json({ user: updatedUser })
 
-      void sendWelcomeEmail(updatedUser.email, req.headers.origin)
+      let origin = req.headers.origin;
+
+      if (req.headers.referer.indexOf('arpa_reporter')) {
+        origin += '/arpa_reporter'
+      }
+
+      void sendWelcomeEmail(updatedUser.email, origin)
     }
   } catch (e) {
     console.dir(e)


### PR DESCRIPTION
### Ticket #404
https://github.com/usdigitalresponse/usdr-gost/issues/404

### Description
Currently the welcome email for all new users defaults to the ID tool. This PR ensures that when users are being created for the ARPA reporter tool-- then they receive an email redirecting them to the ARPA tool.

### Screenshots / Demo Video
https://www.loom.com/share/35eb95346f1448c38919660de7c9f951

### Testing
TODO: add unit test

### Checklist
- [x] Provided ticket and description
- [x] Your PR title contains the ISSUE ticket number e.g "86: ..."
- [x] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers
- [ ] Ensure at least 1 review before merging