### PR TITLE
Fix incorrect cron syntax for grants scraper and PDF cleaner

### DIFF
--- a/packages/server/src/index.js
+++ b/packages/server/src/index.js
@@ -13,14 +13,16 @@ const server = app.listen(PORT, () => console.log(`App running on port ${PORT}!`
 
 if (process.env.ENABLE_GRANTS_SCRAPER === 'true') {
     const job = new CronJob(
-        '* 30 * * * *',
+        // once per hour at :30
+        '30 * * * *',
         grantscraper.run,
     );
     job.start();
 }
 
 const cleanGeneratedPdfCron = new CronJob(
-    '* 1 * * *',
+    // once per day at 01:00
+    '0 1 * * *',
     async () => {
         const generatedPath = path.resolve(__dirname, './static/forms/generated');
         try {


### PR DESCRIPTION
In looking at [this](https://usdigitalresponse.slack.com/archives/C0324KDQSCR/p1664404901738039?thread_ts=1664404009.254059&cid=C0324KDQSCR) I incidentally noticed that this cron syntax seemed to be wrong:

- Grants scraper cron
  - old: `* 30 * * * *` = every 1 second during minute 30 of every hour
  - new: `30 * * * *` = [once per hour at minute 30](https://crontab.guru/#30_*_*_*_*)
- "Clean generated PDFs" cron
  - old: `* 1 * * *` = [every 1 minute from 01:00 to 01:59](https://crontab.guru/#*_1_*_*_*)
  - new: `0 1 * * *` = [once per day at 01:00](https://crontab.guru/#0_1_*_*_*)