### PR TITLE
fix: temporary fix that allows grants to be marked uninterested

### DIFF
--- a/packages/server/__tests__/api/grants.test.js
+++ b/packages/server/__tests__/api/grants.test.js
@@ -362,7 +362,7 @@ describe('`/api/grants` endpoint', () => {
                 });
                 expect(response.statusText).to.equal('OK');
             });
-            it('forbids removing grant interest when one of the agencies is not this user\'s agency', async () => {
+            it('forbids removing grant interest when one of the agencies is not in this user\'s tenant', async () => {
                 const response = await fetchApi(`/grants/${interestEndpoint}/${agencies.own}`, agencies.own, {
                     ...fetchOptions.staff,
                     method: 'delete',
@@ -370,7 +370,7 @@ describe('`/api/grants` endpoint', () => {
                 });
                 expect(response.statusText).to.equal('Forbidden');
             });
-            it('forbids removing grant interest when the agency is not this user\'s agency', async () => {
+            it('forbids removing grant interest when the agency is not in this user\'s tenant', async () => {
                 const response = await fetchApi(`/grants/${interestEndpoint}/${agencies.offLimits}`, agencies.own, {
                     ...fetchOptions.staff,
                     method: 'delete',

--- a/packages/server/__tests__/api/grants.test.js
+++ b/packages/server/__tests__/api/grants.test.js
@@ -327,13 +327,56 @@ describe('`/api/grants` endpoint', () => {
     context('DELETE /api/grants/:grantId/interested/:agencyId', () => {
         context('by an admin user', () => {
             const interestEndpoint = `335255/interested`;
-            it('records this admin\'s ability to delete a grant', async () => {
+            it('allows removing grant interest for a single agency', async () => {
                 const response = await fetchApi(`/grants/${interestEndpoint}/undefined`, agencies.own, {
                     ...fetchOptions.admin,
                     method: 'delete',
                     body: JSON.stringify({ agencyIds: [agencies.own], interestedCode: null }),
                 });
                 expect(response.statusText).to.equal('OK');
+            });
+            it('allows removing grant interest for multiple authorized agencies', async () => {
+                const response = await fetchApi(`/grants/${interestEndpoint}/undefined`, agencies.own, {
+                    ...fetchOptions.staff,
+                    method: 'delete',
+                    body: JSON.stringify({ agencyIds: [agencies.own, agencies.ownSub], interestedCode: null }),
+                });
+                expect(response.statusText).to.equal('OK');
+            });
+        });
+        context('by a user with a staff role', () => {
+            const interestEndpoint = `335255/interested`;
+            it('allows removing grant interest for a single agency', async () => {
+                const response = await fetchApi(`/grants/${interestEndpoint}/${agencies.own}`, agencies.own, {
+                    ...fetchOptions.staff,
+                    method: 'delete',
+                    body: JSON.stringify({ agencyIds: [agencies.own], interestedCode: null }),
+                });
+                expect(response.statusText).to.equal('OK');
+            });
+            it('allows removing grant interest for a multiple authorized agencies', async () => {
+                const response = await fetchApi(`/grants/${interestEndpoint}/${agencies.own}`, agencies.own, {
+                    ...fetchOptions.staff,
+                    method: 'delete',
+                    body: JSON.stringify({ agencyIds: [agencies.own, agencies.ownSub], interestedCode: null }),
+                });
+                expect(response.statusText).to.equal('OK');
+            });
+            it('forbids removing grant interest when one of the agencies is not this user\'s agency', async () => {
+                const response = await fetchApi(`/grants/${interestEndpoint}/${agencies.own}`, agencies.own, {
+                    ...fetchOptions.staff,
+                    method: 'delete',
+                    body: JSON.stringify({ agencyIds: [agencies.offLimits, agencies.own], interestedCode: null }),
+                });
+                expect(response.statusText).to.equal('Forbidden');
+            });
+            it('forbids removing grant interest when the agency is not this user\'s agency', async () => {
+                const response = await fetchApi(`/grants/${interestEndpoint}/${agencies.offLimits}`, agencies.own, {
+                    ...fetchOptions.staff,
+                    method: 'delete',
+                    body: JSON.stringify({ interestedCode: null }),
+                });
+                expect(response.statusText).to.equal('Forbidden');
             });
         });
     });

--- a/packages/server/__tests__/api/grants.test.js
+++ b/packages/server/__tests__/api/grants.test.js
@@ -327,7 +327,7 @@ describe('`/api/grants` endpoint', () => {
     context('DELETE /api/grants/:grantId/interested/:agencyId', () => {
         context('by an admin user', () => {
             const interestEndpoint = `335255/interested`;
-            it("records this admin's ability to delete a grant", async () => {
+            it('records this admin\'s ability to delete a grant', async () => {
                 const response = await fetchApi(`/grants/${interestEndpoint}/undefined`, agencies.own, {
                     ...fetchOptions.admin,
                     method: 'delete',

--- a/packages/server/__tests__/api/grants.test.js
+++ b/packages/server/__tests__/api/grants.test.js
@@ -327,7 +327,7 @@ describe('`/api/grants` endpoint', () => {
     context('DELETE /api/grants/:grantId/interested/:agencyId', () => {
         context('by an admin user', () => {
             const interestEndpoint = `335255/interested`;
-            it('records this admin\'s ability to delete a grant', async () => {
+            it("records this admin's ability to delete a grant", async () => {
                 const response = await fetchApi(`/grants/${interestEndpoint}/undefined`, agencies.own, {
                     ...fetchOptions.admin,
                     method: 'delete',

--- a/packages/server/__tests__/api/grants.test.js
+++ b/packages/server/__tests__/api/grants.test.js
@@ -324,6 +324,19 @@ describe('`/api/grants` endpoint', () => {
             });
         });
     });
+    context('DELETE /api/grants/:grantId/interested/:agencyId', () => {
+        context('by an admin user', () => {
+            const interestEndpoint = `335255/interested`;
+            it('records this admin\'s ability to delete a grant', async () => {
+                const response = await fetchApi(`/grants/${interestEndpoint}/undefined`, agencies.own, {
+                    ...fetchOptions.admin,
+                    method: 'delete',
+                    body: JSON.stringify({ agencyIds: [agencies.own], interestedCode: null }),
+                });
+                expect(response.statusText).to.equal('OK');
+            });
+        });
+    });
     context('PUT /api/grants/:grantId/interested/:agencyId', () => {
         context('by a user with admin role', () => {
             const interestEndpoint = `0/interested`;

--- a/packages/server/src/db/index.js
+++ b/packages/server/src/db/index.js
@@ -790,31 +790,28 @@ async function sync(tableName, syncKey, updateCols, newRows) {
 }
 
 /**
- * Determines if a user's tenant is the same as the agency's tenant
+ * Determines if all given agencies belong to the same given tenant
  * @param  int        userId
  * @param  int        tenantId
  * @parm   Array[int] agencyIds
  * @return boolean
  * */
-async function inTenant(userId, tenantId, agencyIds) {
-    const q = knex(TABLES.users)
-        .select('users.id as user_id', 'agencies.id as agency_id')
-        .leftJoin('agencies', 'users.tenant_id', 'agencies.tenant_id')
-        .leftJoin('tenants', 'tenants.id', 'users.tenant_id')
-        .where('users.id', userId)
-        .andWhere('users.tenant_id', tenantId);
+ async function inTenant(userId, tenantId, agencyIds) {
+    const uniqueAgencyIds = Array.from(new Set(agencyIds))
 
-    if (agencyIds.length > 1) {
-        q.whereIn('agencies.id', agencyIds);
-    } else if (agencyIds.length === 1) {
-        q.andWhere('agencies.id', agencyIds[0]);
-    } else {
-        throw new Error('inTenant() called with empty agencyIds list');
-    }
+    const result = await knex(
+        knex('agencies')
+            .select('id as agency_id')
+            .where('tenant_id', tenantId)
+            .whereIn('id', uniqueAgencyIds)
+            .as('agencies_in_tenant')
+    ).select(
+        knex.raw(
+            'coalesce(? <@ array_agg(agencies_in_tenant.agency_id), false) as same_tenant',
+            [uniqueAgencyIds]),
+    ).first()
 
-    const [user] = await q;
-
-    return !!user;
+    return result.same_tenant === true;
 }
 
 function close() {

--- a/packages/server/src/db/index.js
+++ b/packages/server/src/db/index.js
@@ -797,7 +797,7 @@ async function sync(tableName, syncKey, updateCols, newRows) {
  * @return boolean
  * */
  async function inTenant(userId, tenantId, agencyIds) {
-    const uniqueAgencyIds = Array.from(new Set(agencyIds))
+    const uniqueAgencyIds = Array.from(new Set(agencyIds));
 
     const result = await knex(
         knex('agencies')
@@ -809,7 +809,7 @@ async function sync(tableName, syncKey, updateCols, newRows) {
         knex.raw(
             'coalesce(? <@ array_agg(agencies_in_tenant.agency_id), false) as same_tenant',
             [uniqueAgencyIds]),
-    ).first()
+    ).first();
 
     return result.same_tenant === true;
 }

--- a/packages/server/src/db/index.js
+++ b/packages/server/src/db/index.js
@@ -796,7 +796,7 @@ async function sync(tableName, syncKey, updateCols, newRows) {
  * @parm   Array[int] agencyIds
  * @return boolean
  * */
- async function inTenant(userId, tenantId, agencyIds) {
+async function inTenant(userId, tenantId, agencyIds) {
     const uniqueAgencyIds = Array.from(new Set(agencyIds));
 
     const result = await knex(
@@ -804,11 +804,12 @@ async function sync(tableName, syncKey, updateCols, newRows) {
             .select('id as agency_id')
             .where('tenant_id', tenantId)
             .whereIn('id', uniqueAgencyIds)
-            .as('agencies_in_tenant')
+            .as('agencies_in_tenant'),
     ).select(
         knex.raw(
             'coalesce(? <@ array_agg(agencies_in_tenant.agency_id), false) as same_tenant',
-            [uniqueAgencyIds]),
+            [uniqueAgencyIds],
+        ),
     ).first();
 
     return result.same_tenant === true;

--- a/packages/server/src/db/index.js
+++ b/packages/server/src/db/index.js
@@ -791,12 +791,11 @@ async function sync(tableName, syncKey, updateCols, newRows) {
 
 /**
  * Determines if all given agencies belong to the same given tenant
- * @param  int        userId
  * @param  int        tenantId
  * @parm   Array[int] agencyIds
  * @return boolean
  * */
-async function inTenant(userId, tenantId, agencyIds) {
+async function inTenant(tenantId, agencyIds) {
     const uniqueAgencyIds = Array.from(new Set(agencyIds));
 
     const result = await knex(
@@ -806,6 +805,9 @@ async function inTenant(userId, tenantId, agencyIds) {
             .whereIn('id', uniqueAgencyIds)
             .as('agencies_in_tenant'),
     ).select(
+        // Aggregate the results of the subquery into an array, and check that
+        // all our expected agencyIds member values are contained by the aggregation.
+        // Coalesce the result of the check so that it always returns boolean.
         knex.raw(
             'coalesce(? <@ array_agg(agencies_in_tenant.agency_id), false) as same_tenant',
             [uniqueAgencyIds],

--- a/packages/server/src/lib/access-helpers.js
+++ b/packages/server/src/lib/access-helpers.js
@@ -20,11 +20,11 @@ function isUSDRSuperAdmin(user) {
  * Determine if a user is authorized for an agency.
  *
  * @param {Object} user
- * @param {Number} agencyId
+ * @param {...Number} agencyIds
  * @returns {Boolean} true if the agency is in the same tenant as the user
  * */
-async function isUserAuthorized(user, agencyId) {
-    return inTenant(user.id, user.tenant_id, [agencyId]);
+async function isUserAuthorized(user, ...agencyIds) {
+    return inTenant(user.id, user.tenant_id, agencyIds);
 }
 
 async function isAuthorized(userId, agencyId) {

--- a/packages/server/src/lib/access-helpers.js
+++ b/packages/server/src/lib/access-helpers.js
@@ -24,7 +24,7 @@ function isUSDRSuperAdmin(user) {
  * @returns {Boolean} true if the agency is in the same tenant as the user
  * */
 async function isUserAuthorized(user, ...agencyIds) {
-    return inTenant(user.id, user.tenant_id, agencyIds);
+    return inTenant(user.tenant_id, agencyIds);
 }
 
 async function isAuthorized(userId, agencyId) {

--- a/packages/server/src/routes/grants.js
+++ b/packages/server/src/routes/grants.js
@@ -236,15 +236,15 @@ router.delete('/:grantId/interested/:agencyId', requireUser, async (req, res) =>
     const { grantId, agencyId } = req.params;
     const { agencyIds } = req.body;
     // If agencyIds is not empty, use that. Otherwise, use the single agencyId value.
-    const considerAgencyIds = agencyIds.length ? agencyIds : [agencyId];
+    const selectedAgencyIds = agencyIds.length > 0 ? agencyIds : [agencyId];
 
-    const allowed = await isUserAuthorized(user, ...considerAgencyIds);
+    const allowed = await isUserAuthorized(user, ...selectedAgencyIds);
     if (!allowed) {
         res.sendStatus(403);
         return;
     }
 
-    await db.unmarkGrantAsInterested({ grantId, considerAgencyIds, userId: user.id });
+    await db.unmarkGrantAsInterested({ grantId, agencyIds: selectedAgencyIds, userId: user.id });
     res.json({});
 });
 

--- a/packages/server/src/routes/grants.js
+++ b/packages/server/src/routes/grants.js
@@ -236,7 +236,7 @@ router.delete('/:grantId/interested/:agencyId', requireUser, async (req, res) =>
     const { grantId, agencyId } = req.params;
     const { agencyIds } = req.body;
     // If agencyIds is not empty, use that. Otherwise, use the single agencyId value.
-    const submittedAgencyIds = agencyIds.length > 0 ? agencyIds : [agencyId];
+    const submittedAgencyIds = (agencyIds || []).length > 0 ? agencyIds : [agencyId];
 
     const allowed = await isUserAuthorized(user, ...submittedAgencyIds);
     if (!allowed) {

--- a/packages/server/src/routes/grants.js
+++ b/packages/server/src/routes/grants.js
@@ -167,7 +167,7 @@ router.put('/:grantId/assign/agencies', requireUser, async (req, res) => {
     const { grantId } = req.params;
     const { agencyIds } = req.body;
 
-    const inSameTenant = await db.inTenant(user.id, user.tenant_id, agencyIds);
+    const inSameTenant = await db.inTenant(user.tenant_id, agencyIds);
     if (!inSameTenant) {
         res.sendStatus(403);
         return;
@@ -182,7 +182,7 @@ router.delete('/:grantId/assign/agencies', requireUser, async (req, res) => {
     const { grantId } = req.params;
     const { agencyIds } = req.body;
 
-    const inSameTenant = await db.inTenant(user.id, user.tenant_id, agencyIds);
+    const inSameTenant = await db.inTenant(user.tenant_id, agencyIds);
     if (!inSameTenant) {
         res.sendStatus(403);
         return;

--- a/packages/server/src/routes/grants.js
+++ b/packages/server/src/routes/grants.js
@@ -235,8 +235,15 @@ router.delete('/:grantId/interested/:agencyId', requireUser, async (req, res) =>
     const { user } = req.session;
     const { grantId, agencyId } = req.params;
     const { agencyIds } = req.body;
-    console.log(agencyIds);
-    const allowed = await isUserAuthorized(user, agencyIds || agencyId);
+    let authorizedAgencyId = agencyId;
+    if (agencyIds.length > 0) {
+        // Note: ran into a ES lint error so had to declare the variable first
+        // and then assign it to authorizedAgencyId.
+        const [firstAgency] = agencyIds[0];
+        authorizedAgencyId = firstAgency;
+    }
+    const allowed = await isUserAuthorized(user, authorizedAgencyId);
+
     if (!allowed) {
         res.sendStatus(403);
         return;

--- a/packages/server/src/routes/grants.js
+++ b/packages/server/src/routes/grants.js
@@ -235,14 +235,16 @@ router.delete('/:grantId/interested/:agencyId', requireUser, async (req, res) =>
     const { user } = req.session;
     const { grantId, agencyId } = req.params;
     const { agencyIds } = req.body;
-    const allowed = await isUserAuthorized(user, ...(agencyIds.length ? agencyIds : [agencyId]));
+    // If agencyIds is not empty, use that. Otherwise, use the single agencyId value.
+    const considerAgencyIds = agencyIds.length ? agencyIds : [agencyId];
 
+    const allowed = await isUserAuthorized(user, ...considerAgencyIds);
     if (!allowed) {
         res.sendStatus(403);
         return;
     }
 
-    await db.unmarkGrantAsInterested({ grantId, agencyIds, userId: user.id });
+    await db.unmarkGrantAsInterested({ grantId, considerAgencyIds, userId: user.id });
     res.json({});
 });
 

--- a/packages/server/src/routes/grants.js
+++ b/packages/server/src/routes/grants.js
@@ -235,14 +235,7 @@ router.delete('/:grantId/interested/:agencyId', requireUser, async (req, res) =>
     const { user } = req.session;
     const { grantId, agencyId } = req.params;
     const { agencyIds } = req.body;
-    let authorizedAgencyId = agencyId;
-    if (agencyIds.length > 0) {
-        // Note: ran into a ES lint error so had to declare the variable first
-        // and then assign it to authorizedAgencyId.
-        const [firstAgency] = agencyIds;
-        authorizedAgencyId = firstAgency;
-    }
-    const allowed = await isUserAuthorized(user, authorizedAgencyId);
+    const allowed = await isUserAuthorized(user, ...(agencyIds.length ? agencyIds : [agencyId]));
 
     if (!allowed) {
         res.sendStatus(403);

--- a/packages/server/src/routes/grants.js
+++ b/packages/server/src/routes/grants.js
@@ -239,7 +239,7 @@ router.delete('/:grantId/interested/:agencyId', requireUser, async (req, res) =>
     if (agencyIds.length > 0) {
         // Note: ran into a ES lint error so had to declare the variable first
         // and then assign it to authorizedAgencyId.
-        const [firstAgency] = agencyIds[0];
+        const [firstAgency] = agencyIds;
         authorizedAgencyId = firstAgency;
     }
     const allowed = await isUserAuthorized(user, authorizedAgencyId);

--- a/packages/server/src/routes/grants.js
+++ b/packages/server/src/routes/grants.js
@@ -236,15 +236,15 @@ router.delete('/:grantId/interested/:agencyId', requireUser, async (req, res) =>
     const { grantId, agencyId } = req.params;
     const { agencyIds } = req.body;
     // If agencyIds is not empty, use that. Otherwise, use the single agencyId value.
-    const selectedAgencyIds = agencyIds.length > 0 ? agencyIds : [agencyId];
+    const submittedAgencyIds = agencyIds.length > 0 ? agencyIds : [agencyId];
 
-    const allowed = await isUserAuthorized(user, ...selectedAgencyIds);
+    const allowed = await isUserAuthorized(user, ...submittedAgencyIds);
     if (!allowed) {
         res.sendStatus(403);
         return;
     }
 
-    await db.unmarkGrantAsInterested({ grantId, agencyIds: selectedAgencyIds, userId: user.id });
+    await db.unmarkGrantAsInterested({ grantId, agencyIds: submittedAgencyIds, userId: user.id });
     res.json({});
 });
 


### PR DESCRIPTION
### Ticket #410 

### Description
The markGrantUninterested action seems to be broken after the implementation of an isAuthorized check which requires a single integer value to be passed in rather than an array.


**Note** - this is a temporary fix that ensures we don't 500 in these requests. A more permanent fix requires us to change the client-side code and clean up what the server should be expecting for this request. I put this up so our users will have the functionality and will plan to revisit this again when I'm back.

### Screenshots / Demo Video
- https://www.loom.com/share/92e6392256aa4c5980743e1d8ae64eae

### Testing
- Adds a happy-path unit test

### Checklist
- [x] Provided ticket and description
- [x] Your PR title contains the ISSUE ticket number e.g "86: ..."
- [x] Provided screenshots/demo
- [x] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [x] Added PR reviewers
- [ ] Ensure at least 1 review before merging