### PR TITLE
426: Add tooling for docker-based development environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,6 @@ packages/server/src/static/forms/generated
 
 # ARPA Reporter uploads
 packages/server/data
+
+# Locally-persisted postgres development data
+docker/postgres/persistence

--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ Each folder inside packages/ is considered a workspace. To see a list of all wor
 
 These steps are for an install on a Mac. The Windows instructions are [here](https://github.com/usdigitalresponse/usdr-gost/wiki/Setting-up-a-development-environment-on-Windows-(native)).
 
+Instructions for using Docker to manage development environments can be found
+[here](docker/README.md).
+
 1). Ensure using the correct version of NODE Version
 
 First, check the [`.nvmrc` file](./.nvmrc) to make sure you have the correct version of Node.js installed. If you are using [Nodenv](https://github.com/nodenv/nodenv) or [NVM](https://nvm.sh/), it should pick up on the correct version.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,64 @@
+services:
+  app:
+    container_name: gost-app
+    build:
+      context: .
+      dockerfile: ./docker/Dockerfile
+      target: api
+    volumes:
+      - ./:/app
+      - type: volume
+        source: node_modules
+        target: /app/node_modules
+    networks:
+      - app
+      - postgres
+    ports:
+      - 3000:3000
+    depends_on:
+      - postgres
+    env_file:
+      - ./packages/server/.env
+
+  frontend:
+    container_name: gost-frontend
+    build:
+      context: .
+      dockerfile: ./docker/Dockerfile
+      target: client
+    volumes:
+      - ./:/app
+      - type: volume
+        source: node_modules
+        target: /app/node_modules
+    networks:
+      - app
+    ports:
+      - 8080:8080
+    environment:
+      - VUE_APP_API_URL=http://app:3000/
+    env_file:
+      - ./packages/client/.env
+
+  postgres:
+    container_name: gost-postgres
+    hostname: postgres
+    image: 'bitnami/postgresql:14.4.0'
+    networks:
+      - postgres
+    environment:
+      - POSTGRESQL_PASSWORD=password123
+      - POSTGRESQL_DATABASE=usdr_grants
+      - POSTGRESQL_USER=postgres
+    volumes:
+      - ./docker/postgres/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d
+      - ./docker/postgres/docker-entrypoint-preinitdb.d:/docker-entrypoint-preinitdb.d
+      # - ./docker/postgres/persistence:/bitnami/postgresql
+
+networks:
+  app:
+    driver: bridge
+  postgres:
+
+volumes:
+  node_modules:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ services:
     ports:
       - 8080:8080
     environment:
-      - VUE_APP_API_URL=http://app:3000/
+      - GOST_API_URL=http://app:3000/
     env_file:
       - ./packages/client/.env
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,17 @@
+FROM node:16.14.0-alpine as app_base
+WORKDIR /app
+COPY . .
+RUN ["mkdir", "-p", "/root/.config/yarn"]
+RUN ["chmod", "-R", "777", "/root"]
+RUN ["apk", "--update", "add", "bash"]
+RUN ["yarn", "run", "setup"]
+
+FROM app_base as client
+CMD ["yarn", "start:client"]
+
+FROM app_base as api
+RUN ["apk", "--update", "add", "postgresql-client"]
+WORKDIR /app/packages/server
+RUN ["yarn", "install"]
+WORKDIR /app
+CMD ["yarn", "start:server"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -15,7 +15,7 @@ steps to prepare your environment:
   - `POSTGRES_URL=postgresql://postgres:password123@postgres:5432/usdr_grants`
   - `POSTGRES_TEST_URL=postgresql://postgres:password123@postgres:5432/usdr_grants_test`
   - You may also have to set the `WEBSITE_DOMAIN` hostname if you are not developing on `localhost`
-  ([More info](#cookbook-non-localhost)).
+  ([more info](#cookbook-non-localhost)).
 3. Run `docker compose up -d` to start the services.
 
 
@@ -26,19 +26,19 @@ via `docker compose <subcommand>` in your command-line environment, but your sys
 that you invoke it by running `docker-compose <subcommand>`.
 
 
-### Development Cookbook
+## Development Cookbook
 
 Refer to this section for common scenarios and their solutions when using Docker
 for development.
 
 
-#### Seed and apply migrations to the database
+### Seed and apply migrations to the database
 
 - To apply database migrations, run: `docker compose exec app yarn db:migrate`
 - To seed the database, run: `docker compose exec app yarn db:seed`
 
 
-#### Run tests
+### Run tests
 
 To execute a test suite, use `docker compose exec` to run the test command in the container.
 A few examples:
@@ -55,7 +55,7 @@ A few examples:
 ```
 
 
-#### Docker runs on something other than `localhost`<a name="cookbook-non-localhost"></a>
+### Docker runs on something other than `localhost`<a name="cookbook-non-localhost"></a>
 
 When the client and server containers run on a remote machine, the remote hostname must be
 specified by setting the appropriate environment variables in the container runtime.
@@ -69,7 +69,7 @@ Hint: In the above examples, remember to substitute `<remote-hostname>` for the 
 that applies to your development environment.
 
 
-#### Customize Postgres databases or container environment at startup
+### Customize Postgres databases or container environment at startup
 
 The Postgres container environment can be customized by placing scripts in dedicated mounted
 volumes before the container is executed.
@@ -87,7 +87,7 @@ For more information, see the "Configuration" section of the `bitnami/postgresql
 documentation: https://hub.docker.com/r/bitnami/postgresql
 
 
-#### Persist data across postgres containers
+### Persist data across postgres containers
 
 By default, postgres container databases and their data will be lost when the container
 is removed/rebuilt, which helps ensure a clean and consistent database state in newly-created

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,101 @@
+# Using Docker for Development
+
+You can use Docker to run the database, API server, and Vue frontend during development,
+which should help ensure consistent development environments and avoid workstation clutter.
+
+
+## Setup
+
+With Docker and Docker Compose installed on your workstation, complete the following
+steps to prepare your environment:
+
+1. If you have not already done so, copy the file at `packages/server/.env.example`
+  to `packages/server/.env`.
+2. Set the following environment variables in `packages/server/.env` accordingly:
+  - `POSTGRES_URL=postgresql://postgres:password123@postgres:5432/usdr_grants`
+  - `POSTGRES_TEST_URL=postgresql://postgres:password123@postgres:5432/usdr_grants_test`
+  - You may also have to set the `WEBSITE_DOMAIN` hostname if you are not developing on `localhost`
+  ([More info](#cookbook-non-localhost)).
+3. Run `docker compose up -d` to start the services.
+
+
+**Note:** Some systems may have Docker Compose installed as an integrated plugin for Docker,
+while others may have it installed as a standalone executable (e.g. via `pip install`).
+The example commands in this documentation assume the plugin is installed and is invoked
+via `docker compose <subcommand>` in your command-line environment, but your system may require
+that you invoke it by running `docker-compose <subcommand>`.
+
+
+### Development Cookbook
+
+Refer to this section for common scenarios and their solutions when using Docker
+for development.
+
+
+#### Seed and apply migrations to the database
+
+- To apply database migrations, run: `docker compose exec app yarn db:migrate`
+- To seed the database, run: `docker compose exec app yarn db:seed`
+
+
+#### Run tests
+
+To execute a test suite, use `docker compose exec` to run the test command in the container.
+A few examples:
+
+```shell
+# Run all test suites for both the client and the server
+> docker compose exec yarn test
+
+# Run all test suites for the server
+> docker compose exec yarn test:server
+
+# Run just the "apis" test suite for the server
+> docker compose exec --workdir /app/packages/server yarn test:apis
+```
+
+
+#### Docker runs on something other than `localhost`<a name="cookbook-non-localhost"></a>
+
+When the client and server containers run on a remote machine, the remote hostname must be
+specified by setting the appropriate environment variables in the container runtime.
+The easiest way to do this is to set the appropriate variables in the respective `.env` file:
+
+- In `packages/server/.env`: add `WEBSITE_DOMAIN=http://<remote-hostname>:8080`
+- In `packages/client/.env`: add either `VUE_ALLOWED_HOSTS=all` *or*
+  `VUE_ALLOWED_HOSTS=<remote-hostname>`
+
+Hint: In the above examples, remember to substitute `<remote-hostname>` for the actual hostname
+that applies to your development environment.
+
+
+#### Customize Postgres databases or container environment at startup
+
+The Postgres container environment can be customized by placing scripts in dedicated mounted
+volumes before the container is executed.
+
+- `docker/postgres/docker-entrypoint-preinitdb.d`: Any files with a `.sh` extension
+  placed in this directory will be executed within the container *before* postgresql
+  is initialized or started. Therefore, you can use these scripts to customize configuration
+  of the containerized environment.
+- `docker/postgres/docker-entrypoint-initdb.d`: Any files with `.sh`, `.sql`, or `.sql.gz`
+  extensions placed in this directory will be executed when the container is started for the first
+  time. You can use these scripts to automatically create postgresql databases, users, and other
+  resources.
+
+For more information, see the "Configuration" section of the `bitnami/postgresql` Docker image
+documentation: https://hub.docker.com/r/bitnami/postgresql
+
+
+#### Persist data across postgres containers
+
+By default, postgres container databases and their data will be lost when the container
+is removed/rebuilt, which helps ensure a clean and consistent database state in newly-created
+development environments (e.g. you can nuke everything and start fresh). However, if you would
+like to persist the state of your databases across rebuilds, you can mount a local directory
+from your workstation at the `/bitnami/postgresql` path within the container. For your convenience,
+this repository contains a directory at `docker/postgres/persistence` to use for this purpose;
+any files within this directory will be ignored by git. Simply update the `postgres` service
+definition in the `docker-compose.yml` file to mount this volume – you can do so
+by adding/uncommenting the corresponding `services.postgres.volumes` item in that file so that
+the `./docker/postgres/persistence:/bitnami/postgresql` volume mount is enabled.

--- a/docker/README.md
+++ b/docker/README.md
@@ -45,14 +45,16 @@ A few examples:
 
 ```shell
 # Run all test suites for both the client and the server
-> docker compose exec yarn test
+> docker compose exec app yarn test
 
 # Run all test suites for the server
-> docker compose exec yarn test:server
+> docker compose exec app yarn test:server
 
 # Run just the "apis" test suite for the server
-> docker compose exec --workdir /app/packages/server yarn test:apis
+> docker compose exec --workdir /app/packages/server app yarn test:apis
 ```
+
+Note: The above examples will execute in the `app` container.
 
 
 ### Docker runs on something other than `localhost`<a name="cookbook-non-localhost"></a>

--- a/docker/README.md
+++ b/docker/README.md
@@ -57,7 +57,7 @@ A few examples:
 Note: The above examples will execute in the `app` container.
 
 
-### Start an interactive shell within a docker container
+### Access an interactive shell within a docker container
 
 You can shell into a running container's linux environment by running
 `docker compose exec <service> bash`, where `service` is one of the service names defined

--- a/docker/README.md
+++ b/docker/README.md
@@ -57,6 +57,16 @@ A few examples:
 Note: The above examples will execute in the `app` container.
 
 
+### Start an interactive shell within a docker container
+
+You can shell into a running container's linux environment by running
+`docker compose exec <service> bash`, where `service` is one of the service names defined
+in `docker-compose.yml` (e.g. `app`, `frontend`, or `postgres`). This is akin to accessing
+a remote host using SSH.
+
+To end the interactive session, use the commmand, `exit`.
+
+
 ### Docker runs on something other than `localhost`<a name="cookbook-non-localhost"></a>
 
 When the client and server containers run on a remote machine, the remote hostname must be

--- a/docker/postgres/docker-entrypoint-initdb.d/create_dbs.sql
+++ b/docker/postgres/docker-entrypoint-initdb.d/create_dbs.sql
@@ -1,0 +1,2 @@
+CREATE DATABASE usdr_grants;
+CREATE DATABASE usdr_grants_test;

--- a/docker/postgres/docker-entrypoint-preinitdb.d/example.sh
+++ b/docker/postgres/docker-entrypoint-preinitdb.d/example.sh
@@ -1,0 +1,4 @@
+# Any file in this directory with a .sh extension will be executed within the postgres
+# container before postgresql is initialized or started.
+#
+# This file is simply a placeholder and does not do anything.

--- a/packages/client/vue.config.js
+++ b/packages/client/vue.config.js
@@ -16,12 +16,13 @@ module.exports = {
     },
   },
   devServer: {
+    allowedHosts: process.env.VUE_ALLOWED_HOSTS || 'auto',
     client: {
       progress: false,
     },
     proxy: {
       '/api': {
-        target: 'http://localhost:3000',
+        target: process.env.VUE_APP_API_URL || 'http://localhost:3000',
       },
     },
     historyApiFallback: {

--- a/packages/client/vue.config.js
+++ b/packages/client/vue.config.js
@@ -22,7 +22,7 @@ module.exports = {
     },
     proxy: {
       '/api': {
-        target: process.env.VUE_APP_API_URL || 'http://localhost:3000',
+        target: process.env.GOST_API_URL || 'http://localhost:3000',
       },
     },
     historyApiFallback: {


### PR DESCRIPTION
### Ticket #426 

### Description

This PR adds support for using Docker to create and manage development environments. 

In particular, it includes the following changes:
- Defines container image build instructions for backend and frontend containers (see `docker/Dockerfile`)
- Defines container service dependencies for managing containerized development environments with Docker Compose (see `docker-compose.yml`)
- Adds automation for Postgres setup when using Docker Compose (see `docker/postgres/`, `docker-compose.yml`, and `.gitignore`)
- Add documentation for using Docker and Docker Compose for development (see `docker/README.md`)
- Conditionally sets Vue development server's config options at `devServer. allowedHosts` and `devServer.proxy['/api'].target` with values derived from `VUE_ALLOWED_HOSTS` and `VUE_APP_API_URL` env vars, respectively (see `packages/client/vue.config.js`)

#### Notes for reviewers

- The `app_base` image defined in `docker/Dockerfile` recursively sets permissions on the `/root` directory to `777` within the container. I don't love this, but it was the only way that I could ensure that `lerna`/`npx` wouldn't run into permissions issues, and I wasn't able to find a definitive set of best practices that demonstrated an alternative approach. If you know of a better way to handle configuring Node in Docker environments, I'd love to hear it!
- Pretty much everyone on the internet has decided that [this StackOverflow answer](https://stackoverflow.com/a/32785014) is the canonical recommendation for mounting `node_modules/` in Docker containers that install dependencies during image build. I can't see a problem with the approach, but something does feel a bit "off" about it to me. Again, please enlighten me if you know better :) 
- Probably obvious, but just in case it isn't: this does not (should not) change anything related to Production! If you see anything that you think _would_ impact anything other than dev environments, please let me know.
- I noticed another Docker Compose file at `packages/server/docker-compose.yml`. I left it alone for this PR because I didn't want to break anyone's workflow, but it would be nice to clean this up if we're confident its usefulness is covered by the new `docker-compose.yml` file added in the repository root.

### Screenshots / Demo Video

N/A

### Testing

Follow the instructions documented in the newly-added `docker/README.md` file. 

### Checklist
- [x] Provided ticket and description
- [x] Your PR title contains the ISSUE ticket number e.g "86: ..."
- [ ] Provided screenshots/demo
- [x] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [x] Added PR reviewers
- [ ] Ensure at least 1 review before merging