### PR TITLE
Enable auto-merge for Dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-auto-approve.yml
+++ b/.github/workflows/dependabot-auto-approve.yml
@@ -21,3 +21,12 @@ jobs:
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      - name: Enable auto-merge if dependency semver changes are minor or patch
+        if: ${{contains(fromJson('["version-update:semver-patch", "version-update:semver-minor"]'), steps.dependabot-metadata.outputs.update-type)}}
+        run: |
+          echo "Enabling auto-merge for Dependabot $UPDATE_TYPE"
+          gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          UPDATE_TYPE: ${{steps.dependabot-metadata.outputs.update-type}}


### PR DESCRIPTION
### Ticket #477 

### Description

This PR updates the workflow added in #478 with an additional step that enables auto-merge on Dependabot pull requests. The same semantic versioning constraints (must be patch or minor) apply to this behavior.

### Screenshots / Demo Video

### Testing

### Checklist
- [x] Provided ticket and description
- [x] Your PR title contains the ISSUE ticket number e.g "86: ..."
- [ ] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [x] Added PR reviewers
- [ ] Ensure at least 1 review before merging