### PR TITLE
477: Fix permissions issue in Dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/dependabot-auto-approve.yml
+++ b/.github/workflows/dependabot-auto-approve.yml
@@ -6,6 +6,7 @@ on: pull_request
 
 permissions:
   pull-requests: write
+  contents: write
 
 jobs:
   dependabot:


### PR DESCRIPTION
### Ticket #477

### Description

The `gh pr merge` command executed in the "Enable auto-merge" step of the `dependabot-auto-approve.yml` workflow requires that the workflow have the `contents: write` permission enabled. This PR adds the missing permission to the workflow definition.

### Checklist
- [X] Provided ticket and description
- [X] Your PR title contains the ISSUE ticket number e.g "86: ..."
- [ ] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [X] Added PR reviewers
- [ ] Ensure at least 1 review before merging