### PR TITLE
211: Measure and publish coverage in CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,20 +29,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-
       - name: Install Node.js
         uses: actions/setup-node@v2
         with:
           node-version: 16.14.0
           cache: yarn
-
       - name: Install dependencies
         run: yarn setup
-
       - name: Run Linter
-        run: |
-          yarn lint
-
+        run: yarn lint
       - name: Run unit tests
         env:
           POSTGRES_TEST_URL: "postgresql://postgres:password@localhost:${{ job.services.postgres.ports[5432] }}/usdr_grants_test"
@@ -56,4 +51,8 @@ jobs:
           # The .env file needs to be present; the example file is good enough.
           cp packages/server/.env.example packages/server/.env
           cp packages/client/.env.example packages/client/.env
-          export CI=true; yarn test
+          export CI=true; yarn coverage
+      - name: Publish coverage report to CodeClimate
+        uses: paambaati/codeclimate-action@v2.2.4
+        env:
+          CC_TEST_REPORTER_ID: c0ab87c312e9ca57ec34d55ebec07ed396f96f039b3c725221918a75be71a0eb

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "serve": "lerna run serve --stream",
     "serve:server": "lerna run start --stream --scope server",
     "test": "lerna run test --stream",
+    "coverage": "nyc --reporter=lcov --reporter=text-summary yarn test",
     "lint": "lerna run lint",
     "pre-commit": "yarn lint",
     "psql": "psql opportunities pg",

--- a/packages/arpa_integration_tools/package.json
+++ b/packages/arpa_integration_tools/package.json
@@ -9,6 +9,7 @@
     "@types/glob": "^7.2.0",
     "@types/mkdirp": "^1.0.2",
     "@types/node": "^18.7.13",
+    "nyc": "^15.1.0",
     "ts-node": "^10.9.1",
     "typescript": "^4.7.4"
   },

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -57,6 +57,7 @@
     "eslint-plugin-promise": "^5.2.0",
     "eslint-plugin-vue": "^8.5.0",
     "mocha": "^9.2.1",
+    "nyc": "^15.1.0",
     "prettier": "2.6.1",
     "sass": "1.52.1",
     "sass-loader": "13.0.0",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -12,6 +12,7 @@
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build",
     "test": "vue-cli-service test:unit",
+    "coverage": "nyc yarn test",
     "lint": "vue-cli-service lint"
   },
   "dependencies": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -86,6 +86,7 @@
     "mocha": "^9.2.1",
     "node-fetch": "^2.6.1",
     "nodemon": "2.0.15",
+    "nyc": "^15.1.0",
     "openapi-types": "^12.0.2",
     "prettier": "2.6.1",
     "sinon": "^14.0.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -25,6 +25,7 @@
     "test:db": "NODE_ENV=test mocha --timeout 10000 __tests__/db/*.test.js",
     "test:apis": "NODE_ENV=test SUPPRESS_EMAIL=true mocha --exit --bail --require __tests__/api/fixtures.js __tests__/api/*.test.js",
     "test:arpa": "NODE_ENV=test __tests__/run_arpa_reporter_tests.sh",
+    "coverage": "nyc yarn test",
     "lint": "eslint '**/*.js'",
     "pre-commit": "yarn lint",
     "import-arpa-dump": "node src/scripts/import_arpa_reporter_dump.js"


### PR DESCRIPTION
### Ticket #211 

### Description

This PR adds helpers for running tests with code coverage measurement and subsequent reporting, using [Istanbul](https://istanbul.js.org/). These helpers can be executed via the newly-added `yarn coverage` commands for various packages in this project. Additionally, the Continuous Integration workflow has been updated so that it makes use of `yarn coverage` to execute all unit tests; a new step has been added to this workflow so that the coverage report (in [`lcov` format](https://ltp.sourceforge.net/coverage/lcov.php)) is uploaded to the [CodeClimate project](https://codeclimate.com/github/usdigitalresponse/usdr-gost) for this repository.

Note on the linked issue: The impetus for these changes was not prompted by #211, but it seems to resolve what is being requested in that issue.

### Testing

Run `yarn coverage` in the following ways:
- From the project root: Runs `yarn test` (all test suites), prints a coverage summary report to the console, and generates an `lcov` coverage report in the `coverage/` directory.
- From `packages/server`: Runs `yarn test` (all test suites for the `server` and `arpa_reporter` packages) and prints a full coverage report to the console.
- From `packages/client`: Runs `yarn test` (all tests for the `client` package) and prints a full coverage report to the console.

### Checklist
- [X] Provided ticket and description
- [X] Your PR title contains the ISSUE ticket number e.g "86: ..."
- [ ] Provided screenshots/demo
- [X] Provided testing information
- [X] Provided adequate test coverage for all new code (and how! 😆 )
- [X] Added PR reviewers
- [ ] Ensure at least 1 review before merging