### PR TITLE
477: Run Dependabot auto-merge workflow on pull_request_target

### DIFF
--- a/.github/workflows/dependabot-auto-approve.yml
+++ b/.github/workflows/dependabot-auto-approve.yml
@@ -2,7 +2,7 @@
 #   1. The PR was opened by Dependabot
 #   2. The dependency's semantic versioning change is either minor or patch (not major)
 name: Dependabot auto-approve
-on: pull_request
+on: pull_request_target
 
 permissions:
   pull-requests: write


### PR DESCRIPTION
### Ticket #477 

### Description

This PR modifies the "Dependabot auto-approve" workflow's triggering event to `pull_request_target` instead of `pull_request`. The TL;DR reason is that `pull_request_target` should provide sufficient access for the workflow to mark a PR as approved for auto-merge.

The differences between the two events are a bit nuanced; for those interested in the details, see [this article](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/) as well as the documentation for [pull_request](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request) and [pull_request_target](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target). Meanwhile, [here's the most succinct explanation I could find](https://www.reddit.com/r/github/comments/ur7v95/comment/i8ydnk4/?utm_source=reddit&utm_medium=web2x&context=3):
> The difference between `pull_request` and `pull_request_target` is that `pull_request` runs in the context of the PR's code changes, and `pull_request_target` runs in the context of the base of the PR (the branch that it wants to be merged into, e.g. main).
It's primarily for safety. If there was a malicious PR that was trying to use Actions to do something, `pull_request_target` would provide protection because it wouldn't use the code that was part of the PR.

In particular, there are more security implications involved in `pull_request_target` because its access is more broadly-scoped than the alternative, and so workflows that check out and/or execute untrusted (potentially malicious) code should _not_ make use of it. However, in this case, the risk level seems reasonable because:
1. This workflow does not check out any code.
2. The only executions are either written within the workflow itself, or else written by [GitHub](https://github.com/dependabot/fetch-metadata).
3. This workflow only runs in the first place when Dependabot is the PR author.
4. The write access that `pull_request_target` affords is precisely the reason we're using it. The alternative would be creating a personal access token (PAT) that _also_ grants write access.

All long-windedness aside, it's still possible that the auto-merge functionality continues to fail after this PR is merged, as I can't find clear consensus on whether `pull_request_target` is sufficient for avoiding the need for a PAT. I'd prefer to avoid using a PAT if at all possible, so I went with this approach first, but in the case that it still doesn't work, the solution at that point would be to simply create a repository secret with a properly-scoped PAT and update the workflow (yet again) to reference the secret, as well as revert the changes in this branch.


### Testing

That'd be nice. If I could test this locally, we would have been done last week and @as1729 would have had so many one-liner PRs to review 😛 

### Checklist
- [x] Provided ticket and description
- [x] Your PR title contains the ISSUE ticket number e.g "86: ..."
- [ ] Provided screenshots/demo
- [x] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [x] Added PR reviewers
- [ ] Ensure at least 1 review before merging