### PR TITLE
496 and 382 feat: add new validations for empty file and ref ids

### DIFF
--- a/packages/server/src/arpa_reporter/services/validate-upload.js
+++ b/packages/server/src/arpa_reporter/services/validate-upload.js
@@ -12,6 +12,15 @@ const { getRules } = require('./validation-rules')
 const { ecCodes } = require('../lib/arpa-ec-codes')
 
 const ValidationError = require('../lib/validation-error')
+const BETA_VALIDATION_MESSAGE = "[BETA] This is a new validation that is running in beta mode (as a warning instead of a blocking error). If you see anything incorrect about this validation, please report it at grants-helpdesk@usdigitalresponse.org"
+
+// This is a convenience wrapper that lets us use consistent behavior for new validation errors.
+// Specifically, all new validations should have a message explaining they are in beta and errors
+// should be reported to us. The validation should also be a warning (not a blocking error) until
+// it graduates out of beta
+function betaValidationWarning(message) {
+  return new ValidationError(`${message} -- ${BETA_VALIDATION_MESSAGE}`, { severity: 'warn' })
+}
 
 async function validateAgencyId ({ upload, records, trns }) {
   // grab agency id from the cover sheet
@@ -342,6 +351,121 @@ async function validateRules ({ upload, records, rules, trns }) {
 
   return errors
 }
+// Subrecipients can use either the uei, or the tin, or both as their identifier.
+// This helper takes those 2 nullable fields and converts it to a reliable format
+// so we can index and search by them.
+function subrecipientIdString(uei, tin) {
+  if (!uei && !tin) {
+    return '';
+  }
+  return JSON.stringify({ uei, tin })
+}
+
+async function validateReferences({ records }) {
+  const errors = []
+  // These 3 types need to search-able by their unique id so we can quickly verify they exist
+  const projects = {}
+  const subrecipients = {}
+  const awardsGT50k = {}
+
+  const awards = []
+  const expendituresGT50k = []
+  for (const record of records) {
+    switch (record.type) {
+      case 'ec1':
+      case 'ec2':
+      case 'ec3':
+      case 'ec4':
+      case 'ec5':
+      case 'ec7':
+        const projectID = record.content.Project_Identification_Number__c
+        if (projectID in projects) {
+          errors.push(betaValidationWarning(
+            `Project ids must be unique, but another row used the id ${projectID}`))
+        }
+        projects[projectID] = record.content;
+        break
+      case 'subrecipient':
+        const subRecipId = subrecipientIdString(
+          record.content.Unique_Entity_Identifier__c,
+          record.content.EIN__c)
+        if (subRecipId && subRecipId in subrecipients) {
+          errors.push(betaValidationWarning(
+            `Subrecipient ids must be unique, but another row used the id ${subRecipId}`))
+        }
+        subrecipients[subRecipId] = record.content
+        break
+      case 'awards50k':
+        const awardNumber = record.content.Award_No__c
+        if (awardNumber && awardNumber in awardsGT50k) {
+          errors.push(betaValidationWarning(
+            `Award numbers must be unique, but another row used the number ${awardNumber}`))
+        }
+        awardsGT50k[awardNumber] = record.content
+        break
+      case 'awards':
+        awards.push(record.content)
+        break
+      case 'expenditures50k':
+        expendituresGT50k.push(record.content)
+        break
+      case 'certification':
+      case 'cover':
+      case 'logic':
+        // Skip these sheets, they don't include records
+        continue
+      default:
+        console.log(`Unexpected record type: ${record.type}`)
+    }
+  }
+
+  // Must include at least 1 project in the upload
+  if (Object.keys(projects).length === 0) {
+    errors.push(
+      new ValidationError(
+        `Upload doesn't include any project records`,
+        { severity: 'err' })
+    )
+  }
+
+  // Any subawards must reference valid projects and subrecipients.
+  // Track the subrecipient ids that were referenced, since we'll need them later
+  const usedSubrecipients = new Set()
+  for ([awardNumber, subaward] of Object.entries(awardsGT50k)) {
+    const projectRef = subaward.Project_Identification_Number__c
+    if (!(projectRef in projects)) {
+      errors.push(betaValidationWarning(
+        `Subaward number ${awardNumber} referenced a non-existent projectId ${projectRef}`))
+    }
+    const subRecipRef = subrecipientIdString(
+      subaward.Recipient_UEI__c,
+      subaward.Recipient_EIN__c)
+    if (!(subRecipRef in subrecipients)) {
+      errors.push(betaValidationWarning(
+        `Subaward number ${awardNumber} referenced a non-existent subrecipient with id ${subRecipRef}`))
+    }
+    usedSubrecipients.add(subRecipRef)
+  }
+
+  // Make sure that every subrecip included in this upload was referenced by at least one subaward
+  for(const subRecipId of Object.keys(subrecipients)) {
+    if (!(subRecipId && usedSubrecipients.has(subRecipId))) {
+      errors.push(betaValidationWarning(
+        `Subrecipient with id ${subRecipId} has no related subawards and can be ommitted.`))
+    }
+  }
+
+  // Make sure each expenditure references a valid subward
+  for (const expenditure of expendituresGT50k) {
+    const awardRef = expenditure.Sub_Award_Lookup__c;
+    if (!(awardRef in awardsGT50k)) {
+      errors.push(betaValidationWarning(
+        `An expenditure referenced an unknown award number ${awardRef}`))
+    }
+  }
+
+  return errors;
+}
 
 async function validateUpload (upload, user, trns = null) {
   // holder for our validation errors
@@ -361,7 +485,8 @@ async function validateUpload (upload, user, trns = null) {
     validateAgencyId,
     validateEcCode,
     validateReportingPeriod,
-    validateRules
+    validateRules,
+    validateReferences,
   ]
 
   // we should do this in a transaction, unless someone is doing it for us


### PR DESCRIPTION
### Ticket #
#496 
#382 

### Description
This PR adds a bunch of new validations that have been requested by our partners. Most of them are added in a new "beta" mode, where the validation shows as a warning instead of an error. This is a low-risk way to introduce these new features without potentially accidentally blocking partners from finishing this quarter's reports on time.

One new validation is added as an actual error: If the uploaded workbook doesn't include any project records, it will now fail validation

The beta validations that have been added are:
- Warn if there are multiple projects with the same id within the file
- Warn if there are multiple subrecipients with the same UEI/TIN pair in the file
- Warn if there are multiple subwards with the same subward number
- Warn if a sub-award includes a project id that doesn't exist in this file
- Warn if a sub-award includes a subrecipient UEI/TIN pair that doesn't exist in this file
- Warn if a expenditure includes an award number that doesn't exist in this file
- Warn if a subrecipient in the file doesn't have any subawards referencing it



### Screenshots / Demo Video

### Testing
I manually created test workbooks with these errors, by editing a valid workbook uploaded in a previous quarter.
I verified the previous quarter upload showed no errors, but my created test cases showed the appropriate warnings/error (ignore the date-range and workbook version warnings)

### Checklist


![Screen Shot 2022-10-20 at 6 28 16 PM](https://user-images.githubusercontent.com/3675290/197092394-57654c69-f289-4fc4-90c3-a1c8f6b7cfff.png)
![Screen Shot 2022-10-20 at 6 27 51 PM](https://user-images.githubusercontent.com/3675290/197092396-f853f4cd-3be5-4511-b233-57ffed1e9d36.png)
<img width="604" alt="Screen Shot 2022-10-20 at 6 27 30 PM" src="https://user-images.githubusercontent.com/3675290/197092399-03f5dd75-646e-437b-a231-d90b0a686260.png">

- [x] Provided ticket and description
- [x] Your PR title contains the ISSUE ticket number e.g "86: ..."
- [x] Provided screenshots/demo
- [x] Provided testing information
- [x] Added PR reviewers
- [ ] Ensure at least 1 review before merging