### PR TITLE
508: Fix: Bump paambaati/codeclimate-action v3.1.0 -> v3.2.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,7 +53,7 @@ jobs:
           cp packages/client/.env.example packages/client/.env
           export CI=true; yarn coverage
       - name: Publish coverage report to CodeClimate
-        uses: paambaati/codeclimate-action@v3.1.0
+        uses: paambaati/codeclimate-action@v3.2.0
         env:
           CC_TEST_REPORTER_ID: c0ab87c312e9ca57ec34d55ebec07ed396f96f039b3c725221918a75be71a0eb
         with:


### PR DESCRIPTION
### Ticket #508

### Description

The paambaati/codeclimate-action GithHub Actions workflow runner v3.1.0 suddenly broke (which maybe means that its maintainers are not pushing immutable tags?). From the README as of today:
> **Warning**
>
> Please upgrade to v3.1.1 (or higher) immediately. v3.1.0 was recently broken inadverdently, and the only fix is to upgrade your action to v3.1.1 or higher. Please see [#626](https://github.com/paambaati/codeclimate-action/issues/626) for more details.

This PR bumps the runner from the breaking v3.1.0 tag to v3.2.0 accordingly.

### Screenshots / Demo Video

### Testing

The new version will be tested once this PR is opened.

### Checklist
- [X] Provided ticket and description
- [X] Your PR title contains the ISSUE ticket number e.g "86: ..."
- [ ] Provided screenshots/demo
- [X] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [X] Added PR reviewers
- [ ] Ensure at least 1 review before merging