### PR TITLE
#497: Validate that currency types are formatted as numbers

### DIFF
--- a/packages/server/src/arpa_reporter/services/validate-upload.js
+++ b/packages/server/src/arpa_reporter/services/validate-upload.js
@@ -12,6 +12,11 @@ const { getRules } = require('./validation-rules')
 const { ecCodes } = require('../lib/arpa-ec-codes')
 
 const ValidationError = require('../lib/validation-error')
+
+// Currency strings are must be at least one digit long (\d+)
+// They can optionally have a decimal point followed by 1 or 2 more digits (?: \.\d{ 1, 2 })
+const CURRENCY_REGEX_PATTERN = /^\d+(?: \.\d{ 1, 2 })?$/g
+
 const BETA_VALIDATION_MESSAGE = "[BETA] This is a new validation that is running in beta mode (as a warning instead of a blocking error). If you see anything incorrect about this validation, please report it at grants-helpdesk@usdigitalresponse.org"
 
 // This is a convenience wrapper that lets us use consistent behavior for new validation errors.
@@ -283,6 +288,15 @@ async function validateRecord ({ upload, record, typeRules: rules }) {
               ))
             }
           }
+        }
+      }
+
+      if (rule.dataType === 'Currency') {
+        if (value && typeof value === 'string' && !value.match(CURRENCY_REGEX_PATTERN)) {
+          errors.push(new ValidationError(
+            `Data entered in cell is "${value}", but it must be a number with at most 2 decimals`,
+            { severity: 'err', col: rule.columnName }
+          ))
         }
       }
 


### PR DESCRIPTION
### Ticket #
https://github.com/usdigitalresponse/usdr-gost/issues/497

### Description
Partners have reported that some users have been subverting the workbook formatting to enter text explanations in some fields that are required to be currency amounts.

This change enforces that any field recorded in a 'Currency' type column that is read as a string must adhere to a proper currency format (some number of digits, with optional decimal point and following digits).

### Screenshots / Demo Video
<img width="724" alt="Screen Shot 2022-10-21 at 4 41 15 PM" src="https://user-images.githubusercontent.com/3675290/197305518-ce6aec98-1b6b-45b1-b6fc-967b5968007c.png">

### Testing
Partners provided me a workbook where they saw this bug. I can provide it for testing if anyone needs it.

### Checklist
- [x] Provided ticket and description
- [x] Your PR title contains the ISSUE ticket number e.g "86: ..."
- [x] Provided screenshots/demo
- [x] Provided testing information
- [x] Added PR reviewers
- [x] Ensure at least 1 review before merging