### PR TITLE
fix: Change double quotes to single quotes in knex query

### DIFF
--- a/packages/server/src/db/index.js
+++ b/packages/server/src/db/index.js
@@ -436,11 +436,11 @@ async function getTotalInterestedGrantsByAgencies(agencyId) {
     const agencies = await getAgencyTree(agencyId);
     const rows = await knex(TABLES.grants_interested)
         .select(`${TABLES.grants_interested}.agency_id`, `${TABLES.agencies}.name`, `${TABLES.agencies}.abbreviation`,
-            knex.raw('SUM(CASE WHEN status_code = "Rejected" THEN 1 ELSE 0 END) rejections'),
-            knex.raw('SUM(CASE WHEN status_code = "Interested" THEN 1 ELSE 0 END) interested'),
+            knex.raw(`SUM(CASE WHEN status_code = 'Rejected' THEN 1 ELSE 0 END) rejections`),
+            knex.raw(`SUM(CASE WHEN status_code = 'Interested' THEN 1 ELSE 0 END) interested`),
             knex.raw('SUM(award_ceiling::numeric) total_grant_money'),
-            knex.raw('SUM(CASE WHEN status_code = "Rejected" THEN award_ceiling::numeric ELSE 0 END) total_interested_grant_money'),
-            knex.raw('SUM(CASE WHEN status_code = "Interested" THEN award_ceiling::numeric ELSE 0 END) total_rejected_grant_money'))
+            knex.raw(`SUM(CASE WHEN status_code = 'Rejected' THEN award_ceiling::numeric ELSE 0 END) total_interested_grant_money`),
+            knex.raw(`SUM(CASE WHEN status_code = 'Interested' THEN award_ceiling::numeric ELSE 0 END) total_rejected_grant_money`))
         .join(TABLES.agencies, `${TABLES.grants_interested}.agency_id`, `${TABLES.agencies}.id`)
         .join(TABLES.interested_codes, `${TABLES.grants_interested}.interested_code_id`, `${TABLES.interested_codes}.id`)
         .join(TABLES.grants, `${TABLES.grants_interested}.grant_id`, `${TABLES.grants}.grant_id`)


### PR DESCRIPTION
In https://github.com/usdigitalresponse/usdr-gost/pull/470, we made changes to an endpoint where we updated a knex raw query to query based on a new column. However, in doing so, we used double quotations to designate column value whereas in postgres double quotations designate a column name instead.

This fix changes the quotations to the appropriate single quotations.