### PR TITLE
456: use existing parameters to detect query from My Grants

### DIFF
--- a/packages/server/src/db/index.js
+++ b/packages/server/src/db/index.js
@@ -298,7 +298,13 @@ async function getGrants({
                 }
                 queryBuilder.andWhere(
                     (qb) => {
-                        helpers.whereAgencyCriteriaMatch(qb, filters.agencyCriteria);
+                        const isMyGrantsQuery = filters.interestedByAgency !== null
+                                                || filters.assignedToAgency !== null
+                                                || filters.rejected !== null
+                                                || filters.result !== null;
+                        if (!isMyGrantsQuery) {
+                            helpers.whereAgencyCriteriaMatch(qb, filters.agencyCriteria);
+                        }
 
                         if (filters.interestedByAgency != null) {
                             qb.where('grants_interested.agency_id', filters.interestedByAgency);


### PR DESCRIPTION
### Ticket #
https://github.com/usdigitalresponse/usdr-gost/issues/456

### Description
I debated between:
- Adding yet another parameter (e.g., something like “ignoreAgencyCriteria”) to 
    - packages/client/src/views/MyGrants.vue/MyGrants.vue (perhaps a hidden tab?)
    - packages/client/src/components/GrantsTable.vue
    - packages/client/src/store/modules/grants.js
    - Etc…
- Or using the existing parameters to packages/server/src/db/index.js:myGrants() to figure out if the query came from the “My Grants” tab

I chose the second option because:
- The code in getGrants() in packages/server/src/db/index.js is somewhat complex since it has to deal with various combinations of the filter parameters passed in. I felt adding another parameter would make it even harder to understand (and possibly more brittle).
- I didn’t have to pass an additional parameter all the way down the stack.

### Screenshots / Demo Video
n/a

### Testing
I started writing an automated test (for the server side), but it quickly got out of hand (e.g., long). I would have needed to add code to create a keyword, as well as assign the grant, etc. I felt that >50 lines of test code (that would need to be debugged themselves) weren’t worth the effort. I am, however, open to discussing this with any reviewer.

Here is a series of manual steps to test:
- Pick a grant from “Browse Grants”
- Assign it to USDR
- Set “Interest” to “Will Apply”
- Submit
- Verify the grant is visible in “My Grants”
- Create a keyword that will filter out that grant (e.g., ‘fubar’)
- View “My Grants”
- Verify the grant is still visible in “My Grants”
- Verify the grant is not visible in "Browse Grants"
- Perform similar tests for 'assigned but not interested' and "Rejected"

### Checklist
- [x] Provided ticket and description
- [x] Your PR title contains the ISSUE ticket number e.g "86: ..."
- [x] Provided screenshots/demo
- [x] Provided testing information
- [x] Provided adequate test coverage for all new code
- [x] Added PR reviewers
- [ ] Ensure at least 1 review before merging