### PR TITLE
fix: don't throw in getAwardFloor if raw_body null

### DIFF
--- a/packages/client/src/components/GrantsTable.vue
+++ b/packages/client/src/components/GrantsTable.vue
@@ -249,6 +249,13 @@ export default {
         // Some seeded test data has invalid JSON in raw_body field
         return undefined;
       }
+
+      // For some reason, some grants rows have null raw_body.
+      // TODO: investigate how this can happen
+      if (!body) {
+        return undefined;
+      }
+
       const floor = parseInt(body.synopsis && body.synopsis.awardFloor, 10);
       if (Number.isNaN(floor)) {
         return undefined;

--- a/packages/server/src/routes/grants.js
+++ b/packages/server/src/routes/grants.js
@@ -18,6 +18,12 @@ function getAwardFloor(grant) {
         return undefined;
     }
 
+    // For some reason, some grants rows have null raw_body.
+    // TODO: investigate how this can happen
+    if (!body) {
+        return undefined;
+    }
+
     const floor = parseInt(body.synopsis && body.synopsis.awardFloor, 10);
     if (Number.isNaN(floor)) {
         return undefined;


### PR DESCRIPTION
See [Slack context](https://usdigitalresponse.slack.com/archives/C0473BJ7HGE/p1667434061485569?thread_ts=1667432845.972789&cid=C0473BJ7HGE).

Note: I have not investigated why/how grants rows get null `raw_body`, this is just a quick fix to stop CSV export from 500ing.