### PR TITLE
585: Read column IDs directly from upload sheets

### DIFF
--- a/packages/server/src/arpa_reporter/services/records.js
+++ b/packages/server/src/arpa_reporter/services/records.js
@@ -93,18 +93,25 @@ async function loadRecordsForUpload (upload) {
     }
 
     const rulesForCurrentType = rules[type]
-    // header is based on the columns we have in the rules
-    const header = Object.values(rulesForCurrentType)
-      .sort((a, b) => a.index - b.index)
-      .map(rule => rule.key)
 
     // entire sheet
     const sheetRange = XLSX.utils.decode_range(sheet['!ref'])
+
+    // range B3:3
+    const headerRange = merge({}, sheetRange, {
+      s: { c: 1, r: 2 },
+      e: { r: 2 }
+    })
 
     // TODO: How can we safely get the row number in which data starts
     // across template versions?
     // range B13:
     const contentRange = merge({}, sheetRange, { s: { c: 2, r: 12 } })
+
+    const [header] = XLSX.utils.sheet_to_json(sheet, {
+      header: 1, // ask for array-of-arrays
+      range: XLSX.utils.encode_range(headerRange)
+    })
 
     // actually read the rows
     const rows = XLSX.utils.sheet_to_json(sheet, {


### PR DESCRIPTION
### Ticket #585

### Description

Reads column IDs directly from the upload file.  This is effectively a revert of https://github.com/usdigitalresponse/arpa-reporter/commit/169e03cdaad4cbcaa1d8afc1264214c5ae7f5073.

### Screenshots / Demo Video

### Testing

There are a few things worth validating in this change:

1. Validation rules are keyed on treasury ID, so they should continue to function.  However, the column indexes are based on the generated validation rules, so they may mismatch with the latest upload template.  Is this okay?
2. If treasury IDs themselves have changed in the past, this may cause some issues when reading records out of old spreadsheets for (e.g.) audit report generation.

### Checklist
- [x] Provided ticket and description
- [x] Your PR title contains the ISSUE ticket number e.g "86: ..."
- [ ] Provided screenshots/demo
- [x] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [x] Run automated tests (docker compose exec app yarn test)
- [x] Added PR reviewers
- [ ] Ensure at least 1 review before merging
