### PR TITLE
feat: adds function to manage grant email sends

### DIFF
--- a/packages/server/__tests__/api/grants.test.js
+++ b/packages/server/__tests__/api/grants.test.js
@@ -1,7 +1,8 @@
 const { expect } = require('chai');
-
+const sinon = require('sinon');
 const { getSessionCookie, makeTestServer, knex } = require('./utils');
 const { TABLES } = require('../../src/db/constants');
+const email = require('../../src/lib/email');
 
 /*
     In general, these tests ...
@@ -52,6 +53,11 @@ describe('`/api/grants` endpoint', () => {
     });
     after(() => {
         testServer.stop();
+    });
+
+    const sandbox = sinon.createSandbox();
+    afterEach(() => {
+        sandbox.restore();
     });
 
     context('PUT api/grants/:grantId/view/:agencyId', () => {
@@ -172,28 +178,36 @@ describe('`/api/grants` endpoint', () => {
         const assignEndpoint = `333816/assign/agencies`;
         context('by a user with admin role', () => {
             it('assigns this user\'s own agency to a grant', async () => {
+                const emailSpy = sandbox.spy(email, 'sendGrantAssignedEmail');
                 const response = await fetchApi(`/grants/${assignEndpoint}`, agencies.own, {
                     ...fetchOptions.admin,
                     method: 'put',
                     body: JSON.stringify({ agencyIds: [agencies.own] }),
                 });
                 expect(response.statusText).to.equal('OK');
+                expect(emailSpy.calledOnceWith({ grantId: '333816', agencyIds: [agencies.own], userId: 13 })).to.equal(true);
+                expect(emailSpy.called).to.equal(true);
             });
             it('assigns subagencies of this user\'s own agency to a grant', async () => {
+                const emailSpy = sandbox.spy(email, 'sendGrantAssignedEmail');
                 const response = await fetchApi(`/grants/${assignEndpoint}`, agencies.ownSub, {
                     ...fetchOptions.admin,
                     method: 'put',
                     body: JSON.stringify({ agencyIds: [agencies.ownSub] }),
                 });
                 expect(response.statusText).to.equal('OK');
+                expect(emailSpy.calledOnceWith({ grantId: '333816', agencyIds: [agencies.ownSub], userId: 13 })).to.equal(true);
+                expect(emailSpy.called).to.equal(true);
             });
             it('forbids requests for any agency outside this user\'s hierarchy', async () => {
+                const emailSpy = sandbox.spy(email, 'sendGrantAssignedEmail');
                 const response = await fetchApi(`/grants/${assignEndpoint}`, agencies.offLimits, {
                     ...fetchOptions.admin,
                     method: 'put',
                     body: JSON.stringify({ agencyIds: [agencies.offLimits] }),
                 });
                 expect(response.statusText).to.equal('Forbidden');
+                expect(emailSpy.notCalled).to.equal(true);
             });
         });
         context('by a user with staff role', () => {

--- a/packages/server/src/lib/email.js
+++ b/packages/server/src/lib/email.js
@@ -36,4 +36,8 @@ function sendWelcomeEmail(email, httpOrigin) {
     });
 }
 
-module.exports = { sendPassCode, sendWelcomeEmail };
+async function sendGrantAssignedEmail({ grantId, agencyIds, userId }) {
+    console.log(`SendGrantAssignedEmail is called with arguments ${grantId}, ${agencyIds}, ${userId}`);
+}
+
+module.exports = { sendPassCode, sendWelcomeEmail, sendGrantAssignedEmail };

--- a/packages/server/src/routes/grants.js
+++ b/packages/server/src/routes/grants.js
@@ -2,6 +2,7 @@ const express = require('express');
 // eslint-disable-next-line import/no-unresolved
 const { stringify: csvStringify } = require('csv-stringify/sync');
 const db = require('../db');
+const email = require('../lib/email');
 const pdf = require('../lib/pdf');
 const { requireUser, isUserAuthorized } = require('../lib/access-helpers');
 
@@ -184,6 +185,8 @@ router.put('/:grantId/assign/agencies', requireUser, async (req, res) => {
     }
 
     await db.assignGrantsToAgencies({ grantId, agencyIds, userId: user.id });
+    email.sendGrantAssignedEmail({ grantId, agencyIds, userId: user.id });
+
     res.json({});
 });
 


### PR DESCRIPTION
### Ticket #19

### Description
- Adds a helper function to send grant assigned email notifications
- Ensures grant PUT endpoint calls the new function.

Note: the new function doesn't do any work at the moment. However, the functionality and tests for this will be added in subsequent PRs.

### Screenshots / Demo Video

### Testing

### Checklist
- [ ] Provided ticket and description
- [ ] Your PR title contains the ISSUE ticket number e.g "86: ..."
- [ ] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Run automated tests (docker compose exec app yarn test)
- [ ] Added PR reviewers
- [ ] Ensure at least 1 review before merging
