### PR TITLE
656: Fix off-by-one error in header column index!

### DIFF
--- a/packages/server/src/arpa_reporter/services/records.js
+++ b/packages/server/src/arpa_reporter/services/records.js
@@ -97,15 +97,15 @@ async function loadRecordsForUpload (upload) {
     // entire sheet
     const sheetRange = XLSX.utils.decode_range(sheet['!ref'])
 
-    // range B3:3
+    // range C3:3
     const headerRange = merge({}, sheetRange, {
-      s: { c: 1, r: 2 },
+      s: { c: 2, r: 2 },
       e: { r: 2 }
     })
 
     // TODO: How can we safely get the row number in which data starts
     // across template versions?
-    // range B13:
+    // range C13:
     const contentRange = merge({}, sheetRange, { s: { c: 2, r: 12 } })
 
     const [header] = XLSX.utils.sheet_to_json(sheet, {


### PR DESCRIPTION
### Ticket #656 

### Description

It looks like since the time this code was previously running and my re-introduction we introduced a blank column in the upload template.  My previous pull request didn't account for this, so the header and content ranges were one cell off from one another!

### Screenshots / Demo Video

Before fix:

<img width="834" alt="image" src="https://user-images.githubusercontent.com/11449340/205203010-7ba7c317-af42-4524-bcd4-aac2d5969218.png">

<img width="782" alt="image" src="https://user-images.githubusercontent.com/11449340/205203060-76548330-8dd9-4917-ba76-1caff70f1ea7.png">

After fix:

<img width="933" alt="image" src="https://user-images.githubusercontent.com/11449340/205202720-2f68e7df-6b18-4e88-ae02-80f82df85b7b.png">

I was able to reproduce this issue on a local ARPA report instance.  Applying the above fix restored meaningful validation feedback on the sample test report.

### Testing

Steps I took to verify this change:

- Log into wisconsin reporter tenant
- Open details view for most recent upload
- Attempt to re-validate upload, observe errors
- Download upload .xlsm file
- Launch local usdr-gost service
- Attempt to upload .xlsm file, observe same validation errors
- Apply this fix, re-run validations

### Checklist
- [x] Provided ticket and description
- [x] Your PR title contains the ISSUE ticket number e.g "86: ..."
- [x] Provided screenshots/demo
- [x] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [x] Run automated tests (docker compose exec app yarn test)
- [x] Added PR reviewers
- [ ] Ensure at least 1 review before merging
