### PR TITLE
fix: bug with sending text email body

### DIFF
--- a/packages/server/src/lib/email/email-aws.js
+++ b/packages/server/src/lib/email/email-aws.js
@@ -51,10 +51,10 @@ function send(message) {
                     Charset: 'UTF-8',
                     Data: message.body,
                 },
-            },
-            Text: {
-                Charset: 'UTF-8',
-                Data: message.text,
+                Text: {
+                    Charset: 'UTF-8',
+                    Data: message.text,
+                },
             },
         },
     };


### PR DESCRIPTION
### Ticket #19

### Description
I noticed that Staging render was not sending emails. Here's what I found in the logs:
```
Dec 2 11:54:42 AM  server: ::ffff:10.104.140.119 - - [02/Dec/2022:16:54:42 +0000] "GET /favicon.ico HTTP/1.1" 304 -
Dec 2 11:54:48 AM  server: generatePasscode for : asridhar@usdigitalresponse.org
Dec 2 11:54:48 AM  server: ::ffff:10.104.105.35 - - [02/Dec/2022:16:54:48 +0000] "POST /api/sessions HTTP/1.1" 200 91
Dec 2 11:54:48 AM  server: node:internal/process/promises:265
Dec 2 11:54:48 AM  server:             triggerUncaughtException(err, true /* fromPromise */);
Dec 2 11:54:48 AM  server:             ^
Dec 2 11:54:48 AM  server: UnexpectedParameter: Unexpected key 'Text' found in params.Message
Dec 2 11:54:48 AM  server:     at ParamValidator.fail (/opt/render/project/src/node_modules/aws-sdk/lib/param_validator.js:50:37)
Dec 2 11:54:48 AM  server:     at ParamValidator.validateStructure (/opt/render/project/src/node_modules/aws-sdk/lib/param_validator.js:78:14)
Dec 2 11:54:48 AM  server:     at ParamValidator.validateMember (/opt/render/project/src/node_modules/aws-sdk/lib/param_validator.js:89:21)
Dec 2 11:54:48 AM  server:     at ParamValidator.validateStructure (/opt/render/project/src/node_modules/aws-sdk/lib/param_validator.js:76:14)
Dec 2 11:54:48 AM  server:     at ParamValidator.validateMember (/opt/render/project/src/node_modules/aws-sdk/lib/param_validator.js:89:21)
Dec 2 11:54:48 AM  server:     at ParamValidator.validate (/opt/render/project/src/node_modules/aws-sdk/lib/param_validator.js:34:10)
Dec 2 11:54:48 AM  server:     at Request.VALIDATE_PARAMETERS (/opt/render/project/src/node_modules/aws-sdk/lib/event_listeners.js:166:42)
Dec 2 11:54:48 AM  server:     at Request.callListeners (/opt/render/project/src/node_modules/aws-sdk/lib/sequential_executor.js:106:20)
Dec 2 11:54:48 AM  server:     at callNextListener (/opt/render/project/src/node_modules/aws-sdk/lib/sequential_executor.js:96:12)
Dec 2 11:54:48 AM  server:     at /opt/render/project/src/node_modules/aws-sdk/lib/event_listeners.js:120:11 {
Dec 2 11:54:48 AM  server:   code: 'UnexpectedParameter',
Dec 2 11:54:48 AM  server:   time: 2022-12-02T16:54:48.033Z
Dec 2 11:54:48 AM  server: }
Dec 2 11:54:48 AM  server: error Command failed with exit code 1.
```
- AWS SES requires the Text key to be a part of the Body key. However, I initially had it setup in the top level. This PR fixes it.


### Screenshots / Demo Video
N/A

### Testing
N/A

### Checklist
- [x] Provided ticket and description
- [x] Your PR title contains the ISSUE ticket number e.g "86: ..."
- [x] Provided screenshots/demo
- [x] Provided testing information
- [x] Provided adequate test coverage for all new code
- [x] Run automated tests (docker compose exec app yarn test)
- [x] Added PR reviewers
- [ ] Ensure at least 1 review before merging
