### PR TITLE
feat: adds ability to serve a digest email

### DIFF
--- a/packages/client/src/components/Modals/ProfileSettings.vue
+++ b/packages/client/src/components/Modals/ProfileSettings.vue
@@ -21,6 +21,19 @@
           </template>
         </v-select>
       </b-form>
+      <!--
+      <hr />
+      <h6>Email Notifications (Coming soon): </h6>
+      <b-form-group label="" v-slot="{ ariaDescribedby }">
+      <b-form-checkbox-group
+        v-model="selected"
+        :options="options"
+        :aria-describedby="ariaDescribedby"
+        switches
+        stacked
+      ></b-form-checkbox-group>
+      </b-form-group>
+      -->
     </b-modal>
   </div>
 </template>
@@ -35,6 +48,12 @@ export default {
   },
   data() {
     return {
+      selected: [], // Must be an array reference!
+      options: [
+        { text: 'Grant Assignment', value: 'grant_assigned', disabled: true },
+        { text: 'Grant marked as interested or rejected', value: 'grant_interest', disabled: true },
+        { text: 'New Grants', value: 'grant_digest', disabled: true },
+      ],
       formData: {
         selectedAgency: null,
       },

--- a/packages/server/__tests__/db/db.test.js
+++ b/packages/server/__tests__/db/db.test.js
@@ -213,4 +213,14 @@ describe('db', () => {
             expect(result).to.have.lengthOf(0);
         });
     });
+
+    context('getAgenciesSubscribedToDigest', () => {
+        it('returns agencies with keywords setup', async () => {
+            const result = await db.getAgenciesSubscribedToDigest();
+            expect(result.length).to.equal(2);
+            // Ensures 'State Board of Sub Accountancy' is not part of the list since it does not have keywords.
+            expect(result[0].name).to.equal('State Board of Accountancy');
+            expect(result[1].name).to.equal('Administration: Fleet Services Division');
+        });
+    });
 });

--- a/packages/server/__tests__/db/seeds/fixtures.js
+++ b/packages/server/__tests__/db/seeds/fixtures.js
@@ -250,6 +250,7 @@ module.exports = {
     keywords,
     assignedAgencyGrants,
     grantsInterested,
+    grants,
     interestedCodes,
 };
 

--- a/packages/server/__tests__/email/email.test.js
+++ b/packages/server/__tests__/email/email.test.js
@@ -218,16 +218,16 @@ describe('Email sender', () => {
     });
 
     context('grant assigned email', () => {
-        it('deliverGrantAssigntmentToAssignee calls the transport function with appropriate parameters', async () => {
+        it('deliverEmail calls the transport function with appropriate parameters', async () => {
             const sendFake = sinon.fake.returns('foo');
             sinon.replace(emailService, 'getTransport', sinon.fake.returns({ send: sendFake }));
 
-            email.deliverGrantAssigntmentToAssignee(
-                'foo@bar.com',
-                '<p>foo</p>',
-                'foo',
-                'test foo email',
-            );
+            email.deliverEmail({
+                toAddress: 'foo@bar.com',
+                emailHTML: '<p>foo</p>',
+                emailPlain: 'foo',
+                subject: 'test foo email',
+            });
 
             expect(sendFake.calledOnce).to.equal(true);
             expect(sendFake.firstCall.args).to.deep.equal([{
@@ -255,21 +255,21 @@ describe('Email sender', () => {
         });
         it('sendGrantAssignedNotficationForAgency delivers email for all users within agency', async () => {
             const sendFake = sinon.fake.returns('foo');
-            sinon.replace(email, 'deliverGrantAssigntmentToAssignee', sendFake);
+            sinon.replace(email, 'deliverEmail', sendFake);
 
             await email.sendGrantAssignedNotficationForAgency(fixtures.agencies.accountancy, '<p>sample html</p>', fixtures.users.adminUser.id);
 
             expect(sendFake.calledTwice).to.equal(true);
 
-            expect(sendFake.firstCall.args.length).to.equal(4);
-            expect(sendFake.firstCall.args[0]).to.equal(fixtures.users.adminUser.email);
-            expect(sendFake.firstCall.args[1].includes('<table')).to.equal(true);
-            expect(sendFake.firstCall.args[3]).to.equal('Grant Assigned to State Board of Accountancy');
+            expect(sendFake.firstCall.args.length).to.equal(1);
+            expect(sendFake.firstCall.args[0].toAddress).to.equal(fixtures.users.adminUser.email);
+            expect(sendFake.firstCall.args[0].emailHTML.includes('<table')).to.equal(true);
+            expect(sendFake.firstCall.args[0].subject).to.equal('Grant Assigned to State Board of Accountancy');
 
-            expect(sendFake.secondCall.args.length).to.equal(4);
-            expect(sendFake.secondCall.args[0]).to.equal(fixtures.users.staffUser.email);
-            expect(sendFake.secondCall.args[1].includes('<table')).to.equal(true);
-            expect(sendFake.secondCall.args[3]).to.equal('Grant Assigned to State Board of Accountancy');
+            expect(sendFake.secondCall.args.length).to.equal(1);
+            expect(sendFake.secondCall.args[0].toAddress).to.equal(fixtures.users.staffUser.email);
+            expect(sendFake.secondCall.args[0].emailHTML.includes('<table')).to.equal(true);
+            expect(sendFake.secondCall.args[0].subject).to.equal('Grant Assigned to State Board of Accountancy');
         });
     });
 });

--- a/packages/server/src/db/index.js
+++ b/packages/server/src/db/index.js
@@ -285,7 +285,7 @@ function deleteKeyword(id) {
 }
 
 async function getNewGrantsForAgency(agency) {
-    console.log(`${agency.name}`);
+    console.log(`Getting grants for ${agency.name}`);
     const query = knex(TABLES.grants)
         .limit(5);
     const result = await query;

--- a/packages/server/src/db/index.js
+++ b/packages/server/src/db/index.js
@@ -289,10 +289,12 @@ async function getNewGrantsForAgency(agency) {
     const agencyCriteria = await getAgencyCriteriaForAgency(agency.id);
 
     const rows = await knex(TABLES.grants)
+        .select(knex.raw(`${TABLES.grants}.*, count(*) OVER() AS total_grants`))
         .modify(helpers.whereAgencyCriteriaMatch, agencyCriteria)
         .modify((qb) => {
             qb.where({ open_date: moment().subtract(1, 'day').format('YYYY-MM-DD') });
-        });
+        })
+        .limit(3);
 
     return rows;
 }
@@ -633,8 +635,8 @@ async function getAgenciesSubscribedToDigest() {
             'agencies.abbreviation',
             'agencies.code',
         )
-        .from(TABLES.agencies)
-        .join(TABLES.keywords, 'keywords.agency_id', '=', 'agencies.id')
+        .from('agencies')
+        .join('keywords', 'keywords.agency_id', '=', 'agencies.id')
         .orderBy('agencies.id')
         .groupBy(
             'agencies.id',

--- a/packages/server/src/db/index.js
+++ b/packages/server/src/db/index.js
@@ -622,7 +622,7 @@ async function getAgenciesByIds(agencyIds) {
 
 async function getAgenciesSubscribedToDigest() {
     const query = knex.select('agencies.*')
-        .from(TABLES.agencies);
+        .from(TABLES.agencies).join(TABLES.keywords, 'keywords.agency_id', '=', 'agencies.id');
     const result = await query;
 
     return result;

--- a/packages/server/src/db/index.js
+++ b/packages/server/src/db/index.js
@@ -621,8 +621,22 @@ async function getAgenciesByIds(agencyIds) {
 }
 
 async function getAgenciesSubscribedToDigest() {
-    const query = knex.select('agencies.*')
-        .from(TABLES.agencies).join(TABLES.keywords, 'keywords.agency_id', '=', 'agencies.id');
+    const query = knex
+        .select(
+            'agencies.id',
+            'agencies.name',
+            'agencies.abbreviation',
+            'agencies.code',
+        )
+        .from(TABLES.agencies)
+        .join(TABLES.keywords, 'keywords.agency_id', '=', 'agencies.id')
+        .orderBy('agencies.id')
+        .groupBy(
+            'agencies.id',
+            'agencies.name',
+            'agencies.abbreviation',
+            'agencies.code',
+        );
     const result = await query;
 
     return result;

--- a/packages/server/src/db/index.js
+++ b/packages/server/src/db/index.js
@@ -284,6 +284,14 @@ function deleteKeyword(id) {
         .del();
 }
 
+async function getNewGrantsForAgency(agency) {
+    console.log(`${agency.name}`);
+    const query = knex(TABLES.grants)
+        .limit(5);
+    const result = await query;
+    return result;
+}
+
 async function getGrants({
     currentPage, perPage, tenantId, filters, orderBy, searchTerm, orderDesc,
 } = {}) {
@@ -612,6 +620,14 @@ async function getAgenciesByIds(agencyIds) {
     return result;
 }
 
+async function getAgenciesSubscribedToDigest() {
+    const query = knex.select('agencies.*')
+        .from(TABLES.agencies);
+    const result = await query;
+
+    return result;
+}
+
 async function getTenantAgencies(tenantId) {
     return knex(TABLES.agencies)
         .select('*')
@@ -891,6 +907,7 @@ module.exports = {
     getAgency,
     getAgenciesByIds,
     getAgencyTree,
+    getAgenciesSubscribedToDigest,
     getTenantAgencies,
     getTenant,
     getTenants,
@@ -909,6 +926,7 @@ module.exports = {
     createKeyword,
     deleteKeyword,
     getGrants,
+    getNewGrantsForAgency,
     getSingleGrantDetails,
     getClosestGrants,
     getGrant,

--- a/packages/server/src/db/index.js
+++ b/packages/server/src/db/index.js
@@ -17,6 +17,7 @@ try {
     ({ v4 } = require('uuid'));
 }
 
+const moment = require('moment');
 const knex = require('./connection');
 const { TABLES } = require('./constants');
 const helpers = require('./helpers');
@@ -285,11 +286,15 @@ function deleteKeyword(id) {
 }
 
 async function getNewGrantsForAgency(agency) {
-    console.log(`Getting grants for ${agency.name}`);
-    const query = knex(TABLES.grants)
-        .limit(5);
-    const result = await query;
-    return result;
+    const agencyCriteria = await getAgencyCriteriaForAgency(agency.id);
+
+    const rows = await knex(TABLES.grants)
+        .modify(helpers.whereAgencyCriteriaMatch, agencyCriteria)
+        .modify((qb) => {
+            qb.where({ open_date: moment().subtract(1, 'day').format('YYYY-MM-DD') });
+        });
+
+    return rows;
 }
 
 async function getGrants({

--- a/packages/server/src/index.js
+++ b/packages/server/src/index.js
@@ -5,6 +5,7 @@ const path = require('path');
 
 const { configureApp } = require('./configure');
 const grantscraper = require('./lib/grantscraper');
+const emailService = require('./lib/email');
 
 const { PORT = 3000 } = process.env;
 const app = express();
@@ -19,6 +20,12 @@ if (process.env.ENABLE_GRANTS_SCRAPER === 'true') {
     );
     job.start();
 }
+
+const generateGrantDigest = new CronJob(
+    // once per day at 01:00
+    '0 1 * * *', emailService.buildAndSendGrantDigest,
+);
+generateGrantDigest.start();
 
 const cleanGeneratedPdfCron = new CronJob(
     // once per day at 01:00

--- a/packages/server/src/index.js
+++ b/packages/server/src/index.js
@@ -22,11 +22,11 @@ if (process.env.ENABLE_GRANTS_SCRAPER === 'true') {
     job.start();
 }
 
-const generateGrantDigest = new CronJob(
-    // once per day at 01:00
-    '0 1 * * *', emailService.buildAndSendGrantDigest,
+const generateGrantDigestCron = new CronJob(
+    // once per day at 12:00 UTC
+    '0 0 12 * * *', emailService.buildAndSendGrantDigest,
 );
-generateGrantDigest.start();
+generateGrantDigestCron.start();
 
 const cleanGeneratedPdfCron = new CronJob(
     // once per day at 01:00

--- a/packages/server/src/lib/email.js
+++ b/packages/server/src/lib/email.js
@@ -220,9 +220,7 @@ async function sendGrantDigestForAgency(agency) {
     });
     const emailPlain = emailHTML;
 
-    fileSystem.writeFileSync('rendered.html', emailHTML);
     const recipients = await db.getUsersByAgency(agency.id);
-    console.log(recipients.length);
     recipients.forEach(
         (recipient) => module.exports.deliverEmail(
             {

--- a/packages/server/src/lib/email.js
+++ b/packages/server/src/lib/email.js
@@ -7,6 +7,40 @@ const db = require('../db');
 
 const expiryMinutes = 30;
 
+async function deliverEmail({
+    toAddress,
+    emailHTML,
+    emailPlain,
+    subject,
+}) {
+    return emailService.getTransport().send({
+        toAddress,
+        subject,
+        body: emailHTML,
+        text: emailPlain,
+    });
+}
+
+function addBaseBranding(emailHTML, brandDetails) {
+    const { tool_name, title, notifications_url } = brandDetails;
+    const baseBrandedTemplate = fileSystem.readFileSync(path.join(__dirname, '../static/email_templates/base.html'));
+    const brandedHTML = mustache.render(baseBrandedTemplate.toString(), {
+        tool_name,
+        title,
+        webview_available: false, // Preheader and webview are not setup for Grant notification email.
+        // preheader: 'Test preheader',
+        // webview_url: 'http://localhost:8080',
+        usdr_url: 'http://usdigitalresponse.org',
+        usdr_logo_url: 'https://grants.usdigitalresponse.org/usdr_logo_transparent.png',
+        // Manually send an email to Mindy for now to change notification preferences.
+        notifications_url,
+    }, {
+        email_body: emailHTML,
+    });
+
+    return brandedHTML;
+}
+
 function sendPassCode(email, passcode, httpOrigin, redirectTo) {
     if (!httpOrigin) {
         throw new Error('must specify httpOrigin in sendPassCode');
@@ -19,12 +53,21 @@ function sendPassCode(email, passcode, httpOrigin, redirectTo) {
     }
     const href = url.toString();
 
-    return emailService.getTransport().send({
+    const emailHTML = module.exports.addBaseBranding(
+        `<p>Your link to access USDR's Grants Tool is <a href=${href}>${href}</a>.
+        It expires in ${expiryMinutes} minutes</p>`,
+        {
+            tool_name: 'Grants Identification Tool',
+            title: 'Login Passcode',
+            notifications_url: 'mailto:mindy@usdigitalresponse.org?subject=Unsubscribe&body=Please unsubscribe me from the grant assigned notification email.',
+        },
+    );
+
+    return module.exports.deliverEmail({
         toAddress: email,
+        emailHTML,
+        emailPlain: `Your link to access USDR's Grants tool is ${href}. It expires in ${expiryMinutes} minutes`,
         subject: 'USDR Grants Tool Access Link',
-        body: `<p>Your link to access USDR's Grants Tool is <a href=${href}>${href}</a>.
-     It expires in ${expiryMinutes} minutes</p>`,
-        text: `Your link to access USDR's Grants tool is ${href}. It expires in ${expiryMinutes} minutes`,
     });
 }
 
@@ -33,17 +76,25 @@ function sendWelcomeEmail(email, httpOrigin) {
         throw new Error('must specify httpOrigin in sendWelcomeEmail');
     }
 
-    return emailService.getTransport().send({
+    const emailHTML = module.exports.addBaseBranding(
+        `<p>Visit USDR's Grants Tool at:
+        <a href="${httpOrigin}">${httpOrigin}</a>.`,
+        {
+            tool_name: 'Grants Identification Tool',
+            title: 'Welcome to the USDR Grants tool',
+            notifications_url: 'mailto:mindy@usdigitalresponse.org?subject=Unsubscribe&body=Please unsubscribe me from the grant assigned notification email.',
+        },
+    );
+
+    return module.exports.deliverEmail({
         toAddress: email,
+        emailHTML,
+        emailPlain: `Visit USDR's Grants Tool at: ${httpOrigin}.`,
         subject: 'Welcome to USDR Grants Tool',
-        body: `<p>Visit USDR's Grants Tool at:
-     <a href="${httpOrigin}">${httpOrigin}</a>.`,
-        text: `Visit USDR's Grants Tool at: ${httpOrigin}.`,
     });
 }
 
-async function buildGrantDetail(grantId) {
-    const grant = await db.getGrant({ grantId });
+function getGrantDetail(grant) {
     const grantDetailTemplate = fileSystem.readFileSync(path.join(__dirname, '../static/email_templates/_grant_detail.html'));
     const grantDetail = mustache.render(
         grantDetailTemplate.toString(), {
@@ -63,17 +114,14 @@ async function buildGrantDetail(grantId) {
     return grantDetail;
 }
 
-async function deliverGrantAssigntmentToAssignee(toAddress, emailHTML, emailPlain, subject) {
-    return emailService.getTransport().send({
-        toAddress,
-        subject,
-        body: emailHTML,
-        text: emailPlain,
-    });
+async function buildGrantDetail(grantId) {
+    // Add try catch here.
+    const grant = await db.getGrant({ grantId });
+    const grantDetail = module.exports.getGrantDetail(grant);
+    return grantDetail;
 }
 
 async function sendGrantAssignedNotficationForAgency(assignee_agency, grantDetail, assignorUserId) {
-    const baseTemplate = fileSystem.readFileSync(path.join(__dirname, '../static/email_templates/base.html'));
     const grantAssignedBodyTemplate = fileSystem.readFileSync(path.join(__dirname, '../static/email_templates/_grant_assigned_body.html'));
 
     const assignor = await db.getUser(assignorUserId);
@@ -85,24 +133,24 @@ async function sendGrantAssignedNotficationForAgency(assignee_agency, grantDetai
     }, {
         grant_detail: grantDetail,
     });
-    const emailHTML = mustache.render(baseTemplate.toString(), {
+
+    const emailHTML = module.exports.addBaseBranding(grantAssignedBody, {
         tool_name: 'Grants Identification Tool',
         title: 'Grants Assigned Notification',
-        webview_available: false, // Preheader and webview are not setup for Grant notification email.
-        // preheader: 'Test preheader',
-        // webview_url: 'http://localhost:8080',
-        usdr_url: 'http://usdigitalresponse.org',
-        usdr_logo_url: 'https://grants.usdigitalresponse.org/usdr_logo_transparent.png',
-        // Manually send an email to Mindy for now to change notification preferences.
         notifications_url: 'mailto:mindy@usdigitalresponse.org?subject=Unsubscribe&body=Please unsubscribe me from the grant assigned notification email.',
-    }, {
-        email_body: grantAssignedBody,
     });
     const emailPlain = emailHTML;
     const emailSubject = `Grant Assigned to ${assignee_agency.name}`;
     const assginees = await db.getUsersByAgency(assignee_agency.id);
 
-    assginees.forEach((assignee) => module.exports.deliverGrantAssigntmentToAssignee(assignee.email, emailHTML, emailPlain, emailSubject));
+    assginees.forEach((assignee) => module.exports.deliverEmail(
+        {
+            toAddress: assignee.email,
+            emailHTML,
+            emailPlain,
+            subject: emailSubject,
+        },
+    ));
 }
 
 async function sendGrantAssignedEmail({ grantId, agencyIds, userId }) {
@@ -118,11 +166,55 @@ async function sendGrantAssignedEmail({ grantId, agencyIds, userId }) {
     agencies.forEach((agency) => module.exports.sendGrantAssignedNotficationForAgency(agency, grantDetail, userId));
 }
 
+async function sendGrantDigestForAgency(agency) {
+    const newGrants = await db.getNewGrantsForAgency(agency);
+
+    if (newGrants.length === 0) {
+        return undefined;
+    }
+
+    const grantDetails = [];
+    newGrants.forEach((grant) => grantDetails.push(module.exports.getGrantDetail(grant)));
+    const emailHTML = module.exports.addBaseBranding(grantDetails.join('\n'), {
+        tool_name: 'Grants Identification Tool',
+        title: 'New Grants Digest',
+        notifications_url: 'mailto:mindy@usdigitalresponse.org?subject=Unsubscribe&body=Please unsubscribe me from the grant assigned notification email.',
+    });
+    const emailPlain = emailHTML;
+    const recipients = await db.getUsersByAgency(agency.id);
+    recipients.forEach(
+        (recipient) => module.exports.deliverEmail(
+            {
+                toAddress: recipient.email,
+                emailHTML,
+                emailPlain,
+                subject: `New Grants published for ${agency.name}`,
+            },
+        ),
+    );
+
+    return undefined;
+}
+
+async function buildAndSendGrantDigest() {
+    /*
+    1. get all agencies with notificaiton turned on (temporarily get all agencies with a custom keyword)
+    2. for each agency
+        call sendGrantDigestForAgency
+    */
+    const agencies = await db.getAgenciesSubscribedToDigest();
+    agencies.forEach((agency) => module.exports.sendGrantDigestForAgency(agency));
+}
+
 module.exports = {
     sendPassCode,
     sendWelcomeEmail,
     sendGrantAssignedEmail,
-    deliverGrantAssigntmentToAssignee,
+    deliverEmail,
     buildGrantDetail,
     sendGrantAssignedNotficationForAgency,
+    buildAndSendGrantDigest,
+    sendGrantDigestForAgency,
+    getGrantDetail,
+    addBaseBranding,
 };

--- a/packages/server/src/lib/email.js
+++ b/packages/server/src/lib/email.js
@@ -191,16 +191,23 @@ async function sendGrantDigestForAgency(agency) {
     }
 
     const grantDetails = [];
-    newGrants.forEach((grant) => grantDetails.push(module.exports.getGrantDetail(grant)));
+    newGrants.slice(0, 3).forEach((grant) => grantDetails.push(module.exports.getGrantDetail(grant)));
 
     const formattedBodyTemplate = fileSystem.readFileSync(path.join(__dirname, '../static/email_templates/_formatted_body.html'));
     const contentSpacerTemplate = fileSystem.readFileSync(path.join(__dirname, '../static/email_templates/_content_spacer.html'));
     const contentSpacerStr = contentSpacerTemplate.toString();
 
+    let additionalBody = grantDetails.join(contentSpacerStr);
+
+    if (newGrants.length > 3) {
+        const additionalButtonTemplate = fileSystem.readFileSync(path.join(__dirname, '../static/email_templates/_additional_grants_button.html'));
+        additionalBody += mustache.render(additionalButtonTemplate.toString(), { additional_grants_url: process.env.WEBSITE_DOMAIN });
+    }
+
     const formattedBody = mustache.render(formattedBodyTemplate.toString(), {
         body_title: 'New grants have been posted',
         body_detail: `There are ${newGrants.length} new grants matching your agency's keywords and settings.`,
-        additional_body: grantDetails.join(contentSpacerStr),
+        additional_body: additionalBody,
     });
 
     const emailHTML = module.exports.addBaseBranding(formattedBody, {

--- a/packages/server/src/lib/email.js
+++ b/packages/server/src/lib/email.js
@@ -13,10 +13,13 @@ async function deliverEmail({
     emailPlain,
     subject,
 }) {
-    // Ensures grants-related emails are only sent in non-production environments.
-    if (subject.toLowerCase().includes('grant') && process.env.WEBSITE_DOMAIN === 'https://grants.usdigitalresponse.org') {
-        console.log(`Attempted to send an email to ${toAddress} with subject ${subject}.`);
-        return undefined;
+    // Ensures new grants-related emails are only sent in non-production environments.
+    const formattedSubject = subject.toLowerCase();
+    if (formattedSubject.includes('grant assigned') || formattedSubject.includes('new grants')) {
+        if (process.env.WEBSITE_DOMAIN === 'https://grants.usdigitalresponse.org' || !toAddress.endsWith('@usdigitalresponse.org')) {
+            console.log(`Attempted to send an email to ${toAddress} with subject ${subject}.`);
+            return undefined;
+        }
     }
 
     return emailService.getTransport().send({

--- a/packages/server/src/lib/email.js
+++ b/packages/server/src/lib/email.js
@@ -70,7 +70,7 @@ function sendPassCode(email, passcode, httpOrigin, redirectTo) {
     const emailHTML = module.exports.addBaseBranding(
         formattedBody,
         {
-            tool_name: 'Grants Identification Tool',
+            tool_name: href.includes('reporter') ? 'Grants Reporter Tool' : 'Grants Identification Tool',
             title: 'Login Passcode',
         },
     );
@@ -98,7 +98,7 @@ function sendWelcomeEmail(email, httpOrigin) {
     const emailHTML = module.exports.addBaseBranding(
         formattedBody,
         {
-            tool_name: 'Grants Identification Tool',
+            tool_name: httpOrigin.includes('reporter') ? 'Grants Reporter Tool' : 'Grants Identification Tool',
             title: 'Welcome to the USDR Grants tool',
         },
     );
@@ -154,7 +154,7 @@ async function sendGrantAssignedNotficationForAgency(assignee_agency, grantDetai
     const emailHTML = module.exports.addBaseBranding(grantAssignedBody, {
         tool_name: 'Grants Identification Tool',
         title: 'Grants Assigned Notification',
-        notifications_url: 'mailto:mindy@usdigitalresponse.org?subject=Unsubscribe&body=Please unsubscribe me from the grant assigned notification email.',
+        notifications_url: 'mailto:grants-helpdesk@usdigitalresponse.org?subject=Unsubscribe&body=Please unsubscribe me from the grant assigned notification email.',
     });
     const emailPlain = emailHTML;
     const emailSubject = `Grant Assigned to ${assignee_agency.name}`;
@@ -213,7 +213,7 @@ async function sendGrantDigestForAgency(agency) {
     const emailHTML = module.exports.addBaseBranding(formattedBody, {
         tool_name: 'Grants Identification Tool',
         title: 'New Grants Digest',
-        notifications_url: 'mailto:mindy@usdigitalresponse.org?subject=Unsubscribe&body=Please unsubscribe me from the grant assigned notification email.',
+        notifications_url: 'mailto:grants-helpdesk@usdigitalresponse.org?subject=Unsubscribe&body=Please unsubscribe me from the grant digest notification email.',
     });
     const emailPlain = emailHTML;
 

--- a/packages/server/src/static/email_templates/_additional_grants_button.html
+++ b/packages/server/src/static/email_templates/_additional_grants_button.html
@@ -1,0 +1,46 @@
+<table class="es-content" cellspacing="0" cellpadding="0" align="center"
+style="mso-table-lspace:0pt;mso-table-rspace:0pt;border-collapse:collapse;border-spacing:0px;table-layout:fixed !important;width:100%">
+<tr style="border-collapse:collapse">
+    <td align="center" bgcolor="#FFFFFF" style="padding:0;Margin:0;background-color:#ffffff">
+        <table class="es-content-body"
+            style="mso-table-lspace:0pt;mso-table-rspace:0pt;border-collapse:collapse;border-spacing:0px;background-color:#ffffff;width:640px"
+            cellspacing="0" cellpadding="0" bgcolor="#FFFFFF" align="center">
+            <tr style="border-collapse:collapse">
+                <td align="left"
+                    style="padding:0;Margin:0;padding-top:10px;padding-left:20px;padding-right:20px">
+                    <table width="100%" cellspacing="0" cellpadding="0"
+                        style="mso-table-lspace:0pt;mso-table-rspace:0pt;border-collapse:collapse;border-spacing:0px">
+                        <tr style="border-collapse:collapse">
+                            <td valign="top" align="center"
+                                style="padding:0;Margin:0;width:600px">
+                                <table width="100%" cellspacing="0" cellpadding="0"
+                                    role="presentation"
+                                    style="mso-table-lspace:0pt;mso-table-rspace:0pt;border-collapse:collapse;border-spacing:0px">
+                                    <tr style="border-collapse:collapse">
+                                        <td align="center" style="padding:0;Margin:0">
+                                            <!--[if mso]><a href="" target="_blank" hidden>
+<v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="urn:schemas-microsoft-com:office:word" esdevVmlButton href=""
+style="height:49px; v-text-anchor:middle; width:187px" arcsize="0%" strokecolor="#75b6c9" strokeweight="1px" fillcolor="#007bff">
+<w:anchorlock></w:anchorlock>
+<center style='color:#ffffff; font-family:"open sans", "helvetica neue", helvetica, arial, sans-serif; font-size:16px; font-weight:400; line-height:16px; mso-text-raise:1px'>See all new grants</center>
+</v:roundrect></a>
+<![endif]-->
+                                            <!--[if !mso]><!-- --><span
+                                                class="msohide es-button-border"
+                                                style="border-style:solid;border-color:#75B6C9;background:#007bff;border-width:1px;display:inline-block;border-radius:0px;width:auto;mso-hide:all"><a
+                                                    href="{{additional_grants_url}}" class="es-button" target="_blank"
+                                                    style="mso-style-priority:100 !important;text-decoration:none;-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;color:#FFFFFF;font-size:16px;border-style:solid;border-color:#007bff;border-width:15px 25px 15px 25px;display:inline-block;background:#007bff;border-radius:0px;font-family:'open sans', 'helvetica neue', helvetica, arial, sans-serif;font-weight:normal;font-style:normal;line-height:19px;width:auto;text-align:center">See
+                                                    all new grants</a></span>
+                                            <!--<![endif]-->
+                                        </td>
+                                    </tr>
+                                </table>
+                            </td>
+                        </tr>
+                    </table>
+                </td>
+            </tr>
+        </table>
+    </td>
+</tr>
+</table>

--- a/packages/server/src/static/email_templates/_content_spacer.html
+++ b/packages/server/src/static/email_templates/_content_spacer.html
@@ -1,0 +1,42 @@
+<table class="es-content" cellspacing="0" cellpadding="0" align="center"
+style="mso-table-lspace:0pt;mso-table-rspace:0pt;border-collapse:collapse;border-spacing:0px;table-layout:fixed !important;width:100%">
+<tr style="border-collapse:collapse">
+    <td align="center" bgcolor="#FFFFFF" style="padding:0;Margin:0;background-color:#ffffff">
+        <table class="es-content-body"
+            style="mso-table-lspace:0pt;mso-table-rspace:0pt;border-collapse:collapse;border-spacing:0px;background-color:#ffffff;width:640px"
+            cellspacing="0" cellpadding="0" bgcolor="#FFFFFF" align="center">
+            <tr style="border-collapse:collapse">
+                <td align="left"
+                    style="padding:0;Margin:0;padding-top:10px;padding-left:20px;padding-right:20px">
+                    <table width="100%" cellspacing="0" cellpadding="0"
+                        style="mso-table-lspace:0pt;mso-table-rspace:0pt;border-collapse:collapse;border-spacing:0px">
+                        <tr style="border-collapse:collapse">
+                            <td valign="top" align="center"
+                                style="padding:0;Margin:0;width:600px">
+                                <table width="100%" cellspacing="0" cellpadding="0"
+                                    role="presentation"
+                                    style="mso-table-lspace:0pt;mso-table-rspace:0pt;border-collapse:collapse;border-spacing:0px">
+                                    <tr style="border-collapse:collapse">
+                                        <td align="center"
+                                            style="padding:0;Margin:0;padding-bottom:15px;padding-top:20px;font-size:0">
+                                            <table width="100%" height="100%" cellspacing="0"
+                                                cellpadding="0" border="0" role="presentation"
+                                                style="mso-table-lspace:0pt;mso-table-rspace:0pt;border-collapse:collapse;border-spacing:0px">
+                                                <tr style="border-collapse:collapse">
+                                                    <td
+                                                        style="padding:0;Margin:0;border-bottom:1px solid #f6f6f6;background:#FFFFFF none repeat scroll 0% 0%;height:1px;width:100%;margin:0px">
+                                                    </td>
+                                                </tr>
+                                            </table>
+                                        </td>
+                                    </tr>
+                                </table>
+                            </td>
+                        </tr>
+                    </table>
+                </td>
+            </tr>
+        </table>
+    </td>
+</tr>
+</table>

--- a/packages/server/src/static/email_templates/_formatted_body.html
+++ b/packages/server/src/static/email_templates/_formatted_body.html
@@ -1,0 +1,46 @@
+<table class="es-content" cellspacing="0" cellpadding="0" align="center"
+    style="mso-table-lspace:0pt;mso-table-rspace:0pt;border-collapse:collapse;border-spacing:0px;table-layout:fixed !important;width:100%">
+    <tr style="border-collapse:collapse">
+        <td align="center" bgcolor="#FFFFFF" style="padding:0;Margin:0;background-color:#ffffff">
+            <table class="es-content-body"
+                style="mso-table-lspace:0pt;mso-table-rspace:0pt;border-collapse:collapse;border-spacing:0px;background-color:#f6f6f6;width:640px"
+                cellspacing="0" cellpadding="0" bgcolor="#f6f6f6" align="center">
+                <tr style="border-collapse:collapse">
+                    <td align="left" bgcolor="#FFFFFF" style="padding:20px;Margin:0;background-color:#ffffff">
+                        <table width="100%" cellspacing="0" cellpadding="0"
+                            style="mso-table-lspace:0pt;mso-table-rspace:0pt;border-collapse:collapse;border-spacing:0px">
+                            <tr style="border-collapse:collapse">
+                                <td valign="top" align="center" style="padding:0;Margin:0;width:600px">
+                                    <table width="100%" cellspacing="0" cellpadding="0" role="presentation"
+                                        style="mso-table-lspace:0pt;mso-table-rspace:0pt;border-collapse:collapse;border-spacing:0px">
+                                        {{#body_title}}
+                                        <tr style="border-collapse:collapse">
+                                            <td align="left" style="padding:0;Margin:0">
+                                                <p
+                                                    style="Margin:0;-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;font-family:arial, 'helvetica neue', helvetica, sans-serif;line-height:39px;color:#000000;font-size:26px">
+                                                    <strong>{{body_title}}</strong>
+                                                </p>
+                                            </td>
+                                        </tr>
+                                        {{/body_title}}
+                                        {{#body_detail}}
+                                        <tr style="border-collapse:collapse">
+                                            <td align="left" style="padding:0;Margin:0">
+                                                <p
+                                                    style="Margin:0;-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;font-family:arial, 'helvetica neue', helvetica, sans-serif;line-height:24px;color:#000000;font-size:16px">
+                                                    {{{body_detail}}}
+                                                </p>
+                                            </td>
+                                        </tr>
+                                        {{/body_detail}}
+                                    </table>
+                                </td>
+                            </tr>
+                        </table>
+                    </td>
+                </tr>
+            </table>
+        </td>
+    </tr>
+</table>
+{{{additional_body}}}

--- a/packages/server/src/static/email_templates/_grant_detail.html
+++ b/packages/server/src/static/email_templates/_grant_detail.html
@@ -29,7 +29,7 @@
                                                 style="Margin:0;padding-top:10px;padding-bottom:15px;padding-left:20px;padding-right:20px">
                                                 <p
                                                     style="Margin:0;-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;font-family:arial, 'helvetica neue', helvetica, sans-serif;line-height:24px;color:#000000;font-size:16px">
-                                                    <span class="product-description">{{description}}</span>
+                                                    <span class="product-description">{{{description}}}</span>
                                                 </p>
                                             </td>
                                         </tr>

--- a/packages/server/src/static/email_templates/base.html
+++ b/packages/server/src/static/email_templates/base.html
@@ -493,6 +493,7 @@
                                                             role="presentation"
                                                             style="mso-table-lspace:0pt;mso-table-rspace:0pt;border-collapse:collapse;border-spacing:0px">
                                                             <tr style="border-collapse:collapse">
+                                                                {{#notifications_url}}
                                                                 <td align="center" style="padding:0;Margin:0">
                                                                     <p
                                                                         style="Margin:0;-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;font-family:'open sans', 'helvetica neue', helvetica, arial, sans-serif;line-height:21px;color:#999999;font-size:14px">
@@ -500,6 +501,7 @@
                                                                                 Notification Preferences</a></u>
                                                                     </p>
                                                                 </td>
+                                                                {{/notifications_url}}
                                                             </tr>
                                                         </table>
                                                     </td>


### PR DESCRIPTION
### Ticket #19 

### Description
This PR does a few things: 
1. Adds the grants digest email
2. Re-uses components across multiple emails
3. Ensures all emails have consistent styling
4. Ensures there's a placeholder for the notification management changes in the front-end

### Screenshots / Demo Video
Demoed during show and tell
https://www.notion.so/usdr/Show-Tell-d4ba5e125d2b49df844eda046d298fd3

### Testing
- Added unit tests and integration tests

### Checklist
- [x] Provided ticket and description
- [x] Your PR title contains the ISSUE ticket number e.g "86: ..."
- [x] Provided screenshots/demo
- [x] Provided testing information
- [x] Provided adequate test coverage for all new code
- [x] Run automated tests (docker compose exec app yarn test)
- [x] Added PR reviewers
- [ ] Ensure at least 1 review before merging
