### PR TITLE
#680 Fix null rules error that is blocking audit report generation

### DIFF
--- a/packages/server/__tests__/arpa_reporter/server/services/validation-rules.spec.js
+++ b/packages/server/__tests__/arpa_reporter/server/services/validation-rules.spec.js
@@ -1,0 +1,68 @@
+const _ = require('lodash');
+const assert = require('assert')
+const rewire = require('rewire');
+
+describe('validation rules', () => {
+  describe('record value formatters', () => {
+    const formatters = rewire('../../../../src/arpa_reporter/services/validation-rules').__get__(
+      'recordValueFormatters'
+    );
+
+    const testMatrix = {
+      // 'fnKey': [[input, expected], ...]
+      makeString: [
+        [1, '1'],
+        [{ foo: 'bar' }, '[object Object]'],
+        [[1, 3, 5, 7], '1,3,5,7'],
+        ['already a string', 'already a string'],
+      ],
+      trimWhitespace: [
+        ['no trim required', 'no trim required'],
+        ['   no whitespace on left side', 'no whitespace on left side'],
+        ['no whitespace on right side    ', 'no whitespace on right side'],
+        ['  no whitespace on either side  ', 'no whitespace on either side'],
+        [123, 123],
+        [[4, 5, 6], [4, 5, 6]],
+      ],
+      removeCommas: [
+        ['no,commas,here', 'nocommashere'],
+        ['spaces, still, remain', 'spaces still remain'],
+        ['no commas to remove', 'no commas to remove'],
+        [123, 123],
+        [[4, 5, 6], [4, 5, 6]],
+      ],
+      removeSepDashes: [
+        ['-one;-two;', 'one;two;'],
+        ['-option with spaces;-more spaces;', 'option with spaces;more spaces;'],
+        ['nothing to remove', 'nothing to remove'],
+        [123, 123],
+        [[4, 5, 6], [4, 5, 6]],
+      ],
+      toLowerCase: [
+        ['NO LONGER ALL CAPS', 'no longer all caps'],
+        ['No LoNgEr MiXeD cAsE', 'no longer mixed case'],
+        ['still lower case', 'still lower case'],
+        [123, 123],
+        [[4, 5, 6], [4, 5, 6]],
+      ]
+    };
+    for (const formatterName in testMatrix) {
+      describe(`${formatterName}`, () => {
+        const formatterFn = formatters[formatterName];
+        for (const [testInput, expected] of testMatrix[formatterName]) {
+          let testDescription = `${typeof testInput} with value \`${testInput}\``;
+          if (_.isEqual(testInput, expected)) {
+            testDescription = `${testDescription} unmodified`;
+          } else {
+            testDescription = `${testDescription} formatted to "${expected}"`;
+          }
+
+          it(testDescription, () => {
+            const actual = formatterFn(testInput);
+            assert.deepEqual(actual, expected);
+          });
+        }
+      });
+    }
+  });
+});

--- a/packages/server/src/arpa_reporter/routes/audit-report.js
+++ b/packages/server/src/arpa_reporter/routes/audit-report.js
@@ -13,7 +13,9 @@ router.get('/', requireUser, async function (req, res) {
   try {
     report = await generate(req.headers.host)
   } catch (error) {
+    // In addition to sending the error message in the 500 response, log the full error stacktrace
     return res.status(500).send(error.message)
+    console.log(`Audit report generation failed. Logging the thrown error.`, e)
   }
 
   res.header(

--- a/packages/server/src/arpa_reporter/services/records.js
+++ b/packages/server/src/arpa_reporter/services/records.js
@@ -125,6 +125,10 @@ async function loadRecordsForUpload (upload) {
       const formattedRow = {}
       Object.keys(row).forEach(fieldId => {
         let value = row[fieldId]
+        if (rulesForCurrentType[fieldId] === null) {
+          // No known rules for this type, so we can't format it.
+          return
+        }
         for (const formatter of rulesForCurrentType[fieldId].persistentFormatters) {
           try {
             value = formatter(value)

--- a/packages/server/src/arpa_reporter/services/validation-rules.js
+++ b/packages/server/src/arpa_reporter/services/validation-rules.js
@@ -1,12 +1,13 @@
 
 const srcRules = require('../lib/templateRules.json')
+const _ = require('lodash');
 
 const recordValueFormatters = {
   makeString: (val) => String(val),
-  trimWhitespace: (val) => val ? val.trim() : val,
-  removeCommas: (val) => val.replace(/,/g, ''),
-  removeSepDashes: (val) => val.replace(/^-/, '').replace(/;\s*-/g, ';'),
-  toLowerCase: (val) => val.toLowerCase()
+  trimWhitespace: (val) => _.isString(val) ? val.trim() : val,
+  removeCommas: (val) => _.isString(val) ? val.replace(/,/g, '') : val,
+  removeSepDashes: (val) => _.isString(val) ? val.replace(/^-/, '').replace(/;\s*-/g, ';'): val,
+  toLowerCase: (val) => _.isString(val) ? val.toLowerCase() : val
 }
 
 /*


### PR DESCRIPTION
### Ticket #
https://github.com/usdigitalresponse/usdr-gost/issues/680

### Description
Fix for a bug reported by RI saying they are unable to download the audit report currently.
I was able to repro the bug and saw an error message in the 500 response coming back from the audit_report endpoint:
![Screen Shot 2022-12-08 at 2 36 13 PM](https://user-images.githubusercontent.com/3675290/206581931-6a42041d-c321-42c8-aed4-05acb101d4ba.png)

I looked for anywhere in code that reads the persistentFormatters field in the audit report codepath, and made sure to handle null values more gracefully.

I also added logging to the endpoints error handing so that in addition to sending that error message, it will log the entire error (including the callstack) so that we can examine it more thoroughly.

I also cleaned up some issues with the formatter methods that were generating unnecessary logs that occurred when string methods were applied to values that were instead parsed as numbers (e.g. zipcodes). These errors were being caught, logged, and ignored, and they were making up an overwhelming majority of the log volume.


### Screenshots / Demo Video

### Testing

### Checklist
- [X] Provided ticket and description
- [X] Your PR title contains the ISSUE ticket number e.g "86: ..."
- [X] Provided screenshots/demo
- [ ] Added PR reviewers
- [ ] Ensure at least 1 review before merging
