### PR TITLE
413: Separate Keywords Functionality from Grants Store

### DIFF
--- a/packages/client/src/components/Modals/AddKeyword.vue
+++ b/packages/client/src/components/Modals/AddKeyword.vue
@@ -81,7 +81,7 @@ export default {
   },
   methods: {
     ...mapActions({
-      createKeyword: 'grants/createKeyword',
+      createKeyword: 'keywords/createKeyword',
     }),
     resetModal() {
       this.formData = {};

--- a/packages/client/src/store/index.js
+++ b/packages/client/src/store/index.js
@@ -9,6 +9,7 @@ import dashboard from './modules/dashboard';
 import organization from './modules/organization';
 import tenants from './modules/tenants';
 import alerts from './modules/alerts';
+import keywords from './modules/keywords';
 
 Vue.use(Vuex);
 
@@ -25,5 +26,6 @@ export default new Vuex.Store({
     organization,
     tenants,
     alerts,
+    keywords,
   },
 });

--- a/packages/client/src/store/modules/grants.js
+++ b/packages/client/src/store/modules/grants.js
@@ -4,7 +4,6 @@ function initialState() {
   return {
     grantsPaginated: {},
     eligibilityCodes: [],
-    keywords: [],
     interestedCodes: [],
     grantsInterested: [],
     closestGrants: [],
@@ -29,7 +28,6 @@ export default {
       result: state.interestedCodes.filter((c) => c.status_code === 'Result'),
       interested: state.interestedCodes.filter((c) => c.status_code === 'Interested'),
     }),
-    keywords: (state) => state.keywords,
   },
   actions: {
     fetchGrants({ commit }, {
@@ -116,18 +114,6 @@ export default {
     async setEligibilityCodeEnabled(context, { code, enabled }) {
       await fetchApi.put(`/api/organizations/:organizationId/eligibility-codes/${code}/enable/${enabled}`);
     },
-    fetchKeywords({ commit }) {
-      fetchApi.get('/api/organizations/:organizationId/keywords')
-        .then((data) => commit('SET_KEYWORDS', data));
-    },
-    async createKeyword({ dispatch }, keyword) {
-      await fetchApi.post('/api/organizations/:organizationId/keywords', keyword);
-      dispatch('fetchKeywords');
-    },
-    async deleteKeyword({ dispatch }, keywordId) {
-      await fetchApi.deleteRequest(`/api/organizations/:organizationId/keywords/${keywordId}`);
-      dispatch('fetchKeywords');
-    },
     exportCSV(context, queryParams) {
       const query = Object.entries(queryParams)
         // filter out undefined and nulls since api expects parameters not present as undefined
@@ -162,9 +148,6 @@ export default {
     },
     SET_INTERESTED_CODES(state, interestedCodes) {
       state.interestedCodes = interestedCodes;
-    },
-    SET_KEYWORDS(state, keywords) {
-      state.keywords = keywords;
     },
     SET_GRANTS_INTERESTED(state, grantsInterested) {
       state.grantsInterested = grantsInterested;

--- a/packages/client/src/store/modules/keywords.js
+++ b/packages/client/src/store/modules/keywords.js
@@ -1,0 +1,34 @@
+const fetchApi = require('@/helpers/fetchApi');
+
+function initialState() {
+  return {
+    keywords: [],
+  };
+}
+
+export default {
+  namespaced: true,
+  state: initialState,
+  getters: {
+    keywords: (state) => state.keywords,
+  },
+  actions: {
+    fetchKeywords({ commit }) {
+      fetchApi.get('/api/organizations/:organizationId/keywords')
+        .then((data) => commit('SET_KEYWORDS', data));
+    },
+    async createKeyword({ dispatch }, keyword) {
+      await fetchApi.post('/api/organizations/:organizationId/keywords', keyword);
+      dispatch('fetchKeywords');
+    },
+    async deleteKeyword({ dispatch }, keywordId) {
+      await fetchApi.deleteRequest(`/api/organizations/:organizationId/keywords/${keywordId}`);
+      dispatch('fetchKeywords');
+    },
+  },
+  mutations: {
+    SET_KEYWORDS(state, keywords) {
+      state.keywords = keywords;
+    },
+  },
+};

--- a/packages/client/src/views/Keywords.vue
+++ b/packages/client/src/views/Keywords.vue
@@ -49,7 +49,7 @@ export default {
   },
   computed: {
     ...mapGetters({
-      keywords: 'grants/keywords',
+      keywords: 'keywords/keywords',
       userRole: 'users/userRole',
       selectedAgency: 'users/selectedAgency',
     }),
@@ -61,8 +61,8 @@ export default {
   },
   methods: {
     ...mapActions({
-      fetchKeywords: 'grants/fetchKeywords',
-      deleteKeyword: 'grants/deleteKeyword',
+      fetchKeywords: 'keywords/fetchKeywords',
+      deleteKeyword: 'keywords/deleteKeyword',
     }),
     setup() {
       this.fetchKeywords();


### PR DESCRIPTION
As we look to add new `anti-keywords` as a part of #413, I motion to separate the `keywords` store module from the larger `grants` module. While keywords themselves are intrinsically tied to grants - they assist in the grant name search process - I believe adding the new `anti-keywords` pattern could overload the `grants` module which already handles grants lookup and adding, agencies related to grants, marking grants as interested, exporting grant CSVs and more.

Also, the `keywords` functionality is more or less already distinct - the API endpoints are already namedspaced appropriately for keywords - and given how small of a task it is to separate the two, I choose to do so here.