### PR TITLE
bugfix: Handle undefined in addition to null rules for unrecognized fields

### DIFF
--- a/packages/server/src/arpa_reporter/services/records.js
+++ b/packages/server/src/arpa_reporter/services/records.js
@@ -125,7 +125,7 @@ async function loadRecordsForUpload (upload) {
       const formattedRow = {}
       Object.keys(row).forEach(fieldId => {
         let value = row[fieldId]
-        if (rulesForCurrentType[fieldId] === null) {
+        if (!rulesForCurrentType[fieldId]) {
           // No known rules for this type, so we can't format it.
           return
         }


### PR DESCRIPTION
### Ticket #
None (reported by Dan in our Thursday meeting).

### Description
Turns out this PR (https://github.com/usdigitalresponse/usdr-gost/pull/687) was a little incomplete and only handled some cases where the rules didn't exist for a certain field id. 

In particular, totally new fields (like the country code) were not just null, but in fact undefined.
This change causes it to detect the undefined rules and skip them in the same way.

### Screenshots / Demo Video
Repro of the bug reported by Dan:
![Screen Shot 2022-12-15 at 9 26 41 AM](https://user-images.githubusercontent.com/3675290/207929175-c3ad4417-ccea-4b2a-a7da-fe8caedc96c6.png)


State after this fix:
![Screen Shot 2022-12-15 at 9 27 03 AM](https://user-images.githubusercontent.com/3675290/207929511-109c4faf-78f4-43e8-b2cc-9208ffe617ba.png)

### Testing

### Checklist
- [X] Provided ticket and description
- [X] Provided screenshots/demo
- [X] Added PR reviewers
- [ ] Ensure at least 1 review before merging
