### PR TITLE
fix: ignore rows with only display_only fields

### DIFF
--- a/packages/server/src/arpa_reporter/services/records.js
+++ b/packages/server/src/arpa_reporter/services/records.js
@@ -122,6 +122,12 @@ async function loadRecordsForUpload (upload) {
 
     // each row in the input sheet becomes a unique record
     for (const row of rows) {
+      // Don't include any Display_Only data in the records
+      delete row.Display_Only
+      // If the row is empty, don't include it in the records
+      if (Object.keys(row).length === 0) {
+        continue
+      }
       const formattedRow = {}
       Object.keys(row).forEach(fieldId => {
         let value = row[fieldId]


### PR DESCRIPTION
### Ticket #
None (reported via email by Alysha)

### Description
Partners have reported errors where empty rows in their workbooks are failing validation because required fields are empty. An inveidtigation showed that this is being caused by a new Display Only data type that we are using to include additional contextual info in certain tabs (e.g. including the subrecipients legal name, as found in other tabs, next to the subrecipient UEI/TIN columns.).

This new Display Only feature is causing the parser to think that empty rows are not empty. This updates the parser to remove any Display_Only data, and then skip a row if it is empty.


### Screenshots / Demo Video

Before the fix, we see over 3000 errors:
<img width="730" alt="Screen Shot 2022-12-20 at 4 23 47 PM" src="https://user-images.githubusercontent.com/3675290/208795571-47d0bfca-e4e5-4735-bf05-be5f241d756e.png">


After the fix we're down to only the real 13 problems in the file:
<img width="647" alt="Screen Shot 2022-12-20 at 4 24 00 PM" src="https://user-images.githubusercontent.com/3675290/208795559-1685ccbf-2d2b-4952-a261-eb81b3ee8b01.png">

### Testing

### Checklist
- [X] Provided ticket and description
- [X] Your PR title contains the ISSUE ticket number e.g "86: ..."
- [X] Provided screenshots/demo
- [X] Added PR reviewers
- [ ] Ensure at least 1 review before merging
