### PR TITLE
#378: First pass at conditionally required fields in ARPA validator

### DIFF
--- a/packages/server/src/arpa_reporter/services/validate-upload.js
+++ b/packages/server/src/arpa_reporter/services/validate-upload.js
@@ -246,6 +246,14 @@ async function validateRecord ({ upload, record, typeRules: rules }) {
           `Value is required for ${key}`,
           { col: rule.columnName, severity: 'err' }
         ))
+      } else if (rule.required === 'Conditional') {
+        if (rule.isRequiredFn && rule.isRequiredFn(record)) {
+          errors.push(new ValidationError(
+            // This message should make it clear that this field is conditionally required
+            `Based on other values in this row, a value is required for ${key}`,
+            { col: rule.columnName, severity: 'err' }
+          ))
+        }
       }
 
     // if there's something in the field, make sure it meets requirements

--- a/packages/server/src/arpa_reporter/services/validation-rules.js
+++ b/packages/server/src/arpa_reporter/services/validation-rules.js
@@ -10,6 +10,50 @@ const recordValueFormatters = {
   toLowerCase: (val) => _.isString(val) ? val.toLowerCase() : val
 }
 
+// These conditional functions should return true if the field is required.
+// This fn is used mark certain fields as required, as long as the status of the project
+// isn't 'Not started'
+function optionalIfNotStarted(projectRow) {
+  if (projectRow.Completion_Status__c === 'Not started') {
+    return false;
+  }
+  return true;
+}
+
+// This is the list of field ids that should be optional if the status is 'Not started'
+// For any other status, the field should be considered required.
+const optionalIfNotStartedFieldIds = new Set([
+  'Primary_Project_Demographics__c',
+  'Number_Students_Tutoring_Programs__c',
+  'Does_Project_Include_Capital_Expenditure__c',
+  // Start off with just these 2 field ids for testing, before enabling for all of these ids
+  /*
+  'Structure_Objectives_of_Asst_Programs__c',
+  'Recipient_Approach_Description__c',
+  'Individuals_Served__c',
+  'Spending_Allocated_Toward_Evidence_Based_Interventions',
+  'Whether_program_evaluation_is_being_conducted', // XXX reduced ec?
+  'Small_Businesses_Served__c',
+  'Number_Non_Profits_Served__c',
+  'Number_Workers_Enrolled_Sectoral__c',
+  'Number_Workers_Competing_Sectoral__c',
+  'Number_People_Summer_Youth__c',
+  'School_ID_or_District_ID__c',
+  'Industry_Experienced_8_Percent_Loss__c',
+  'Number_Households_Eviction_Prevention__c',
+  'Number_Affordable_Housing_Units__c',
+  'Number_Children_Served_Childcare__c',
+  'Number_Families_Served_Home_Visiting__c',
+  'Payroll_Public_Health_Safety__c',
+  'Number_of_FTEs_Rehired__c',
+  'Sectors_Critical_to_Health_Well_Being__c',
+  'Workers_Served__c',
+  'Premium_Pay_Narrative__c',
+  'Number_of_Workers_K_12__c',
+  'Technology_Type_Planned__c',
+  */
+])
+
 /*
 Structured data recording all the immediate corrections we want to apply to dropdowns.
 There are 2 types of corrections we can apply:
@@ -88,6 +132,9 @@ function generateRules () {
             rule.persistentFormatters.push(val => valuesToCoerce.includes(val) ? correctValue : val)
           }
         }
+      }
+      if (optionalIfNotStartedFieldIds.has(rule.key)) {
+        rule.isRequiredFn = optionalIfNotStarted;
       }
     }
   }


### PR DESCRIPTION
### Ticket #
https://github.com/usdigitalresponse/usdr-gost/issues/378

### Description
Right now, the validator backend can only really handle fields that are either always required for the particular EC code, or always fully optional. This causes a problem because many fields are actually "conditional": They may be required depending on values added for other fields in the row.

The most common form of this condition is that many fields are not required if the project status is 'Not started', but otherwise must be entered.

This PR creates a system that lets us configure a list of field ids that should include this new check: If we see that the data for the field is empty, and then we see that this field is conditional, and then we see that the conditional check says the data is required, then it will add a validation error. I've started by only turning this on for ~2~ *3* particular fields ids (Primary_Project_Demographics__c and Number_Students_Tutoring_Programs__c. *I also added Does_Project_Include_Capital_Expenditure__c as an important test case*) to allow us to test this in a way that is less dangerous than starting it with all ~20 ids.  

### Screenshots / Demo Video
In a test file, I have two projects in EC code 2.25, where the only data set is the project status.
For the project on line 13, the status is 'Completed'
For the project on line 14, the status is 'Not started'.

The only difference in the validation errors when I run it with this new code, is that the line 13 project has two additional errors: 
<img width="728" alt="Screen Shot 2022-12-22 at 4 04 09 PM" src="https://user-images.githubusercontent.com/3675290/209245440-61216e50-9dc4-401c-a5ce-0ad150292698.png">

Note: This feature depends very strongly on an assumption that making a field id conditionally required in one place means that it will be conditionally required in all places that we ask that question. If this turns out to be untrue, then we need to update the system to configure these functions by ec AND field-id, not just by field-id.

More details on that assumption in https://usdigitalresponse.slack.com/archives/C031R1Y49KL/p1671751915108879?thread_ts=1671740558.980399&cid=C031R1Y49KL

### Testing

### Checklist
- [X] Provided ticket and description
- [X] Your PR title contains the ISSUE ticket number e.g "86: ..."
- [X] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Run automated tests (docker compose exec app yarn test)
- [ ] Added PR reviewers
- [ ] Ensure at least 1 review before merging
