### PR TITLE
feat: adds table to store subscription data

### DIFF
--- a/packages/server/migrations/20230104150018_add_email_subscription.js
+++ b/packages/server/migrations/20230104150018_add_email_subscription.js
@@ -1,0 +1,25 @@
+const constants = require('../src/lib/email/constants');
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function (knex) {
+    return knex.schema.createTable('email_subscriptions', (table) => {
+        table.increments('id', { primaryKey: true }).notNullable();
+        table.timestamp('created_at', { useTz: true }).notNullable().defaultTo(knex.fn.now());
+        table.timestamp('updated_at', { useTz: true }).nullable();
+        table.integer('agency_id').notNullable();
+        table.foreign('agency_id').references('id').inTable('agencies');
+        table.string('notification_type', [50]).notNullable().checkIn(Object.values(constants.notificationType), 'email_subscriptions_notification_type_check');
+        table.string('status', [50]).notNullable().checkIn(Object.values(constants.emailSubscriptionStatus), 'email_subscriptions_status_check');
+    });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function (knex) {
+    return knex.schema.dropTable('email_subscriptions');
+};

--- a/packages/server/src/lib/email/constants.js
+++ b/packages/server/src/lib/email/constants.js
@@ -1,0 +1,12 @@
+const notificationType = {
+    grantAssignment: 'GRANT_ASSIGNMENT',
+    grantInterest: 'GRANT_INTEREST',
+    grantDigest: 'GRANT_DIGEST',
+};
+
+const emailSubscriptionStatus = {
+    subscribed: 'SUBSCRIBED',
+    unsubscribed: 'UNSUBSCRIBED',
+};
+
+module.exports = { notificationType, emailSubscriptionStatus };


### PR DESCRIPTION
### Ticket #19

### Description
- Adds a table to store subscription preferences for agencies and their email notifications.
- This is based on the following RFC: https://docs.google.com/document/d/1TImE6llR6E-9Z3IKeXJjIElQ5P94UJhQT1jMgwMtRac/edit#

Note: I have reduced the complexity in this PR by keeping all the data in a single table. Hence, the divergence from the RFC. As the feature develops, I'll add additional migrations.

### Screenshots / Demo Video
<img width="1453" alt="image" src="https://user-images.githubusercontent.com/6497366/210619575-4fcffae8-a76b-4df9-84b3-2d176b5799be.png">

### Testing
- Tested the migrations up and down locally

### Checklist
- [x] Provided ticket and description
- [x] Your PR title contains the ISSUE ticket number e.g "86: ..."
- [x] Provided screenshots/demo
- [x] Provided testing information
- [x] Provided adequate test coverage for all new code
- [x] Run automated tests (docker compose exec app yarn test)
- [x] Added PR reviewers
- [ ] Ensure at least 1 review before merging
