### PR TITLE
[DRAFT] fix: docker-compose up fails: error: Could not find any python instal…

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /app
 COPY . .
 RUN ["mkdir", "-p", "/root/.config/yarn"]
 RUN ["chmod", "-R", "777", "/root"]
-RUN ["apk", "--update", "add", "bash"]
+RUN ["apk", "--update", "add", "bash", "python3", "g++", "make", "py3-pip"]
 RUN ["yarn", "run", "setup"]
 
 FROM app_base as client


### PR DESCRIPTION
…lation to use (781)

Docker compose up is currently failing because of missing dependencies. This adds in the necessary dependencies.
I do think larger Docker and Docker-compose changes are probably warranted here, but keeping this fix small for now.

### Ticket #
#781 

### Description
Docker compose up is currently failing because of missing dependencies. This adds those in. It is a bit odd that a js dependency requires python, but apparently it does! 

### Screenshots / Demo Video
See error message from original issue

### Testing
Successfully ran `docker compose up` and did not see a failure. I did not test deployment scenarios as I'm not sure how to do this just yet, but this is definitely worth a check!

### Checklist
- [x] Provided ticket and description
- [x] Your PR title contains the ISSUE ticket number e.g "86: ..."
- [x] Provided screenshots/demo
- [x] Provided testing information
- [x] Provided adequate test coverage for all new code
- [x] Run automated tests (docker compose exec app yarn test)
- [x] Added PR reviewers
- [ ] Ensure at least 1 review before merging
