### PR TITLE
build: fix node-gyp build in docker-compose (781)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /app
 COPY . .
 RUN ["mkdir", "-p", "/root/.config/yarn"]
 RUN ["chmod", "-R", "777", "/root"]
-RUN ["apk", "--update", "add", "bash"]
+RUN ["apk", "--update", "add", "bash", "python3", "make", "g++"]
 RUN ["yarn", "run", "setup"]
 
 FROM app_base as client


### PR DESCRIPTION
### Ticket #
https://github.com/usdigitalresponse/usdr-gost/issues/781

### Description
There is an error to build node-gyp when you run `docker-compose up`

### Screenshots / Demo Video

### Testing
Run `docker-compose up`  and you should see your app running like the screenshot below

<img width="777" alt="Screenshot 2023-01-10 at 10 05 29 AM" src="https://user-images.githubusercontent.com/12984659/211628528-cc3a02bd-c09c-4fcc-87cc-36f67212a660.png">


### Checklist
- [x] Provided ticket and description
- [x] Your PR title contains the ISSUE ticket number e.g "86: ..."
- [x] Provided screenshots/demo
- [x] Provided testing information
- [x] Provided adequate test coverage for all new code
- [ ] Run automated tests (docker-compose exec app yarn test)
- [ ] Added PR reviewers
- [ ] Ensure at least 1 review before merging
