### PR TITLE
fix(client): reorder grants tabs (#617)

### DIFF
--- a/packages/client/src/components/Layout.vue
+++ b/packages/client/src/components/Layout.vue
@@ -30,11 +30,11 @@
       </b-collapse>
     </b-navbar>
     <b-nav tabs justified style="margin-top: 20px">
-        <b-nav-item to="/dashboard" exact exact-active-class="active">Dashboard</b-nav-item>
         <b-nav-item to="/my-grants" exact exact-active-class="active">My Grants</b-nav-item>
         <b-nav-item to="/grants" exact exact-active-class="active">Browse Grants</b-nav-item>
         <b-nav-item to="/eligibility-codes" exact exact-active-class="active">Eligibility Codes</b-nav-item>
         <b-nav-item to="/keywords" exact exact-active-class="active">Keywords</b-nav-item>
+        <b-nav-item to="/dashboard" exact exact-active-class="active">Dashboard</b-nav-item>
         <b-nav-item to="/users" exact exact-active-class="active" v-if="userRole === 'admin'">Users</b-nav-item>
         <b-nav-item to="/Agencies" exact exact-active-class="active">Agencies</b-nav-item>
         <b-nav-item v-if="canSeeTenantsTab" to="/tenants" exact exact-active-class="active">Tenants</b-nav-item>

--- a/packages/client/src/router/index.js
+++ b/packages/client/src/router/index.js
@@ -26,7 +26,7 @@ const routes = [
   {
     path: '/',
     name: 'layout',
-    redirect: '/dashboard',
+    redirect: '/my-grants',
     component: Layout,
     meta: {
       requiresAuth: true,
@@ -116,7 +116,7 @@ const routes = [
   },
   {
     path: '*',
-    redirect: '/dashboard',
+    redirect: '/my-grants',
   },
 ];
 


### PR DESCRIPTION
### Ticket #
https://github.com/usdigitalresponse/usdr-gost/issues/617

### Description
Reordering the navigation tabs based on feedback from the NV partners. More details on the ticket above

### Screenshots / Demo Video
<img width="1439" alt="Screenshot 2023-01-10 at 11 21 14 AM" src="https://user-images.githubusercontent.com/12984659/211642316-798b9ba5-fb54-430d-a772-f108289bd323.png">

### Testing
Run the repo and go to `http://localhost:8080`. You should be redirected to `http://localhost:8080/#/my-grants`

### Checklist
- [x] Provided ticket and description
- [x] Your PR title contains the ISSUE ticket number e.g "86: ..."
- [x] Provided screenshots/demo
- [x] Provided testing information
- [x] Provided adequate test coverage for all new code
- [x] Run automated tests (docker compose exec app yarn test)
- [x] Added PR reviewers
- [x] Ensure at least 1 review before merging
