### PR TITLE
fix: getNewGrantsForAgency test fails when run locally (#785)

### DIFF
--- a/packages/server/__tests__/db/db.test.js
+++ b/packages/server/__tests__/db/db.test.js
@@ -238,10 +238,11 @@ describe('db', () => {
             const result = await db.getNewGrantsForAgency(fixtures.agencies.accountancy);
             expect(result.length).to.equal(0);
         });
-        it('returns zero grants if no grants match criteria and opened yesterday', async () => {
+        it('returns a grant whose modification date is one day ago', async () => {
             const newGrant = fixtures.grants.healthAide;
             newGrant.grant_id = '444816';
-            newGrant.open_date = '2022-06-21';
+            // Note the use of `Date` -- this ensures compatibility with our mocked time
+            newGrant.open_date = new Date('2022-06-21');
             await knex(TABLES.grants).insert(Object.values([newGrant]));
             const result = await db.getNewGrantsForAgency(fixtures.agencies.accountancy);
             expect(result.length).to.equal(1);


### PR DESCRIPTION
The getNewGrantsForAgency test was failing locally for machines with different timezones due to a hard-coded date string. This fixes date math by moving to use Date objects instead.

### Ticket #
#785

### Description
See above - due to timezone differences, a hard-coded date string meant to represent one day ago was in fact two days ago for anything less than GMT. Using `Date` for the desired end-date as well resolves this. 

### Screenshots / Demo Video
```
x  yarn test
 getNewGrantsForAgency
      ✔ returns zero grants if no grants match criteria and opened yesterday
      ✔ returns a grant whose modification date is one day ago
```

### Testing
Run `yarn test` with a locally-running setup, verify that `getNewGrantsForAgency` passes. Run `docker compose exec app yarn test` ensure that docker-run tests also still pass. 

### Checklist
- [x] Provided ticket and description
- [x] Your PR title contains the ISSUE ticket number e.g "86: ..."
- [x] Provided screenshots/demo
- [x] Provided testing information
- [x] Provided adequate test coverage for all new code
- [x] Run automated tests (docker compose exec app yarn test)
- [x] Added PR reviewers
- [x] Ensure at least 1 review before merging
