### PR TITLE
feat: take subscription status into account

### DIFF
--- a/packages/client/src/components/Modals/ProfileSettings.vue
+++ b/packages/client/src/components/Modals/ProfileSettings.vue
@@ -94,7 +94,10 @@ export default {
       this.$emit('update:showModal', false);
     },
     onUserSubscriptionChangeSubmit(data) {
-      const updatedPreferences = {};
+      const updatedPreferences = {
+        GRANT_ASSIGNMENT: 'UNSUBSCRIBED',
+        GRANT_DIGEST: 'UNSUBSCRIBED',
+      };
       data.forEach((notificationType) => { updatedPreferences[notificationType] = 'SUBSCRIBED'; });
       this.updateEmailSubscriptionPreferences({
         userId: this.loggedInUser.id,

--- a/packages/server/__tests__/db/db.test.js
+++ b/packages/server/__tests__/db/db.test.js
@@ -363,6 +363,27 @@ describe('db', () => {
 
             expect(expectedError instanceof Error).to.equal(true);
         });
+        it('default subscribes all users to a notification if no rows exist', async () => {
+            await knex('email_subscriptions').del();
+            const assignmentResult = await db.getSubscribersForNotification(fixtures.agencies.accountancy.id, emailConstants.notificationType.grantAssignment);
+            const assignmentSubscribers = assignmentResult.map((r) => r.email);
+            const digestResult = await db.getSubscribersForNotification(fixtures.agencies.accountancy.id, emailConstants.notificationType.grantDigest);
+            const digestSubscribers = digestResult.map((r) => r.email);
+            const interestResult = await db.getSubscribersForNotification(fixtures.agencies.accountancy.id, emailConstants.notificationType.grantInterest);
+            const interestSubscribers = interestResult.map((r) => r.email);
+
+            expect(assignmentResult.length).to.equal(2);
+            expect(assignmentSubscribers.includes(fixtures.users.staffUser.email)).to.equal(true);
+            expect(assignmentSubscribers.includes(fixtures.users.adminUser.email)).to.equal(true);
+
+            expect(digestResult.length).to.equal(2);
+            expect(digestSubscribers.includes(fixtures.users.staffUser.email)).to.equal(true);
+            expect(digestSubscribers.includes(fixtures.users.adminUser.email)).to.equal(true);
+
+            expect(interestResult.length).to.equal(2);
+            expect(interestSubscribers.includes(fixtures.users.staffUser.email)).to.equal(true);
+            expect(interestSubscribers.includes(fixtures.users.adminUser.email)).to.equal(true);
+        });
         it('gets subscribed users for an agency', async () => {
             await db.setUserEmailSubscriptionPreference(
                 fixtures.users.adminUser.id,

--- a/packages/server/__tests__/db/db.test.js
+++ b/packages/server/__tests__/db/db.test.js
@@ -363,5 +363,47 @@ describe('db', () => {
 
             expect(expectedError instanceof Error).to.equal(true);
         });
+        it('gets subscribed users for an agency', async () => {
+            await db.setUserEmailSubscriptionPreference(
+                fixtures.users.adminUser.id,
+                fixtures.agencies.accountancy.id,
+                {
+                    [emailConstants.notificationType.grantAssignment]: emailConstants.emailSubscriptionStatus.subscribed,
+                    [emailConstants.notificationType.grantDigest]: emailConstants.emailSubscriptionStatus.subscribed,
+                    [emailConstants.notificationType.grantInterest]: emailConstants.emailSubscriptionStatus.unsubscribed,
+                },
+            );
+            await db.setUserEmailSubscriptionPreference(
+                fixtures.users.staffUser.id,
+                fixtures.agencies.accountancy.id,
+                {
+                    [emailConstants.notificationType.grantAssignment]: emailConstants.emailSubscriptionStatus.subscribed,
+                    [emailConstants.notificationType.grantDigest]: emailConstants.emailSubscriptionStatus.unsubscribed,
+                    [emailConstants.notificationType.grantInterest]: emailConstants.emailSubscriptionStatus.unsubscribed,
+                },
+            );
+            const assignmentResult = await db.getSubscribersForNotification(
+                fixtures.agencies.accountancy.id,
+                emailConstants.notificationType.grantAssignment,
+            );
+            const assignmentSubscribers = assignmentResult.map((r) => r.email);
+            const digestResult = await db.getSubscribersForNotification(
+                fixtures.agencies.accountancy.id,
+                emailConstants.notificationType.grantDigest,
+            );
+            const digestSubscribers = digestResult.map((r) => r.email);
+            const interestResult = await db.getSubscribersForNotification(
+                fixtures.agencies.accountancy.id,
+                emailConstants.notificationType.grantInterest,
+            );
+            expect(assignmentResult.length).to.equal(2);
+            expect(assignmentSubscribers.includes(fixtures.users.staffUser.email)).to.equal(true);
+            expect(assignmentSubscribers.includes(fixtures.users.adminUser.email)).to.equal(true);
+
+            expect(digestResult.length).to.equal(1);
+            expect(digestSubscribers.includes(fixtures.users.adminUser.email)).to.equal(true);
+
+            expect(interestResult.length).to.equal(0);
+        });
     });
 });

--- a/packages/server/src/db/index.js
+++ b/packages/server/src/db/index.js
@@ -82,6 +82,24 @@ async function getUsersByAgency(agencyId) {
     return users;
 }
 
+async function getSubscribersForNotification(agencyId, notificationType) {
+    const subscribers = await knex('users')
+        .select(
+            'users.id',
+            'users.email',
+        )
+        .join('email_subscriptions', function () {
+            this
+                .on('users.id', '=', 'email_subscriptions.user_id')
+                .andOn('users.agency_id', '=', 'email_subscriptions.agency_id');
+        })
+        .where('users.agency_id', agencyId)
+        .andWhere('email_subscriptions.notification_type', notificationType)
+        .andWhere('email_subscriptions.status', emailConstants.emailSubscriptionStatus.subscribed);
+
+    return subscribers;
+}
+
 async function getUsersEmailAndName(ids) {
     return knex.select('id', 'name', 'email').from('users').whereIn('id', ids);
 }
@@ -949,6 +967,7 @@ module.exports = {
     createUser,
     deleteUser,
     getUsersByAgency,
+    getSubscribersForNotification,
     getUsersEmailAndName,
     getUser,
     getAgencyCriteriaForAgency,

--- a/packages/server/src/db/index.js
+++ b/packages/server/src/db/index.js
@@ -87,17 +87,17 @@ async function getSubscribersForNotification(agencyId, notificationType) {
         .select(
             'users.id',
             'users.email',
+            'email_subscriptions.status',
         )
-        .join('email_subscriptions', function () {
+        .leftJoin('email_subscriptions', function () {
             this
                 .on('users.id', '=', 'email_subscriptions.user_id')
-                .andOn('users.agency_id', '=', 'email_subscriptions.agency_id');
+                .andOn('users.agency_id', '=', 'email_subscriptions.agency_id')
+                .andOn('email_subscriptions.notification_type', '=', knex.raw('?', [notificationType]));
         })
-        .where('users.agency_id', agencyId)
-        .andWhere('email_subscriptions.notification_type', notificationType)
-        .andWhere('email_subscriptions.status', emailConstants.emailSubscriptionStatus.subscribed);
+        .where('users.agency_id', agencyId);
 
-    return subscribers;
+    return subscribers.filter((s) => s.status !== emailConstants.emailSubscriptionStatus.unsubscribed);
 }
 
 async function getUsersEmailAndName(ids) {

--- a/packages/server/src/lib/email.js
+++ b/packages/server/src/lib/email.js
@@ -5,6 +5,7 @@ const path = require('path');
 const mustache = require('mustache');
 const emailService = require('./email/service-email');
 const db = require('../db');
+const { notificationType } = require('./email/constants');
 
 const expiryMinutes = 30;
 
@@ -164,7 +165,7 @@ async function sendGrantAssignedNotficationForAgency(assignee_agency, grantDetai
     // TODO: add plain text version of the email
     const emailPlain = emailHTML.replace(/<[^>]+>/g, '');
     const emailSubject = `Grant Assigned to ${assignee_agency.name}`;
-    const assginees = await db.getUsersByAgency(assignee_agency.id);
+    const assginees = await db.getSubscribersForNotification(assignee_agency.id, notificationType.grantAssignment);
 
     assginees.forEach((assignee) => module.exports.deliverEmail(
         {
@@ -198,7 +199,7 @@ async function sendGrantDigestForAgency(agency) {
         return undefined;
     }
 
-    const recipients = await db.getUsersByAgency(agency.id);
+    const recipients = await db.getSubscribersForNotification(agency.id, notificationType.grantDigest);
     if (recipients.length === 0) {
         console.log(`${agency.name} has no users for grants digest on ${moment().format('YYYY-MM-DD')}`);
         return undefined;


### PR DESCRIPTION
### Ticket #19 

### Description
PR does 3 things that will help with launching the Email notifications feature:
1. Ensures that we take into account a user's subscription preferences before sending an email to them.
2. Manual trigger for sending out the grants digest email for a USDR super-user.
3. Fixes a bug that did not allow a user to unsubscribe from a subscription in the email notifications management UI

### Screenshots / Demo Video
N/A

### Testing
- Unit tests for all features added

### Checklist
- [x] Provided ticket and description
- [x] Your PR title contains the ISSUE ticket number e.g "86: ..."
- [x] Provided screenshots/demo
- [x] Provided testing information
- [x] Provided adequate test coverage for all new code
- [x] Run automated tests (docker compose exec app yarn test)
- [x] Added PR reviewers
- [ ] Ensure at least 1 review before merging
