### PR TITLE
609: Add git metadata to docker env

### DIFF
--- a/.github/workflows/build-api.yaml
+++ b/.github/workflows/build-api.yaml
@@ -53,6 +53,7 @@ jobs:
             type=raw,enable=${{ github.ref == 'refs/heads/main' }},priority=300,value=stable
           labels: |
             org.opencontainers.image.title=usdr-gost-api
+            org.opencontainers.image.version={{date 'YYYYMMDD.HHmm'}}
       - name: Build and push Docker image
         uses: docker/build-push-action@v3
         with:

--- a/.github/workflows/build-api.yaml
+++ b/.github/workflows/build-api.yaml
@@ -62,5 +62,9 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           platforms: linux/amd64,linux/arm64
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            GIT_COMMIT=${{ github.sha }}
+            GIT_REF=${{ github.ref }}
+            TIMESTAMP=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }}
       - if: ${{ github.event_name == 'pull_request' }}
         run: echo "Builds triggered by pull requests are not published."

--- a/docker/production-api.Dockerfile
+++ b/docker/production-api.Dockerfile
@@ -1,5 +1,10 @@
 FROM node:16.14.0-alpine as app_base
 
+# Define build argument defaults
+ARG GIT_COMMIT=""
+ARG GIT_REF=""
+ARG TIMESTAMP=""
+
 # Prepare the environment
 RUN ["apk", "--update", "add", "bash", "postgresql-client", "util-linux"]
 RUN ["mkdir", "-p", "/home/node"]
@@ -11,6 +16,11 @@ COPY ./packages/server /app
 COPY ./yarn.lock /app/yarn.lock
 RUN ["yarn", "install", "--frozen-lockfile", "--production", "--network-timeout", "300000"]
 RUN ["yarn", "cache", "clean"]
+
+# Inject build-time environment variables
+ENV BUILD_GIT_COMMIT=${GIT_COMMIT}
+ENV BUILD_GIT_REF=${GIT_REF}
+ENV BUILD_TIMESTAMP=${TIMESTAMP}
 
 # Start the server
 USER node


### PR DESCRIPTION
### Ticket #609

### Description

This PR tweaks the Docker builds used for staging and eventually prod environments to include additional build-time metadata in the runtime environment variables. Specifically, it makes these environment variables available within the containers:
- `BUILD_GIT_COMMIT`
  - The (long) commit sha for which the container was built.
  - Example: `b3610f88f49bde9647b3151f59b8091541a7a3a5`
- `BUILD_GIT_REF`
  - The ref/branch name where the commit was pushed when the build was triggered.
  - Example: `refs/heads/_staging`
- `BUILD_TIMESTAMP`
  - The timestamp (in UTC) when the build was triggered.
  - Example: `2023-01-13T19:47:38.438Z`

### Screenshots / Demo Video

### Testing

You can test the workflow locally using [act](https://github.com/nektos/act) (warning: it's complicated) or build the docker image directly and check the resulting environment:
```shell
$ docker build . -f docker/production-api.Dockerfile \
  --build-arg GIT_COMMIT=$(git rev-parse HEAD) \
  --build-arg GIT_REF=HEAD \
  --build-arg TIMESTAMP=$(TZ=UTC date --iso-8601=ns) \
  --quiet
sha256:<hash>  # i.e.
$ docker run --rm -it <hash> bash -c "env | grep BUILD | sort"
BUILD_GIT_COMMIT=b3610f88f49bde9647b3151f59b8091541a7a3a5
BUILD_GIT_REF=HEAD
BUILD_TIMESTAMP=2023-01-13T20:10:17.661868Z
```

### Checklist
- [X] Provided ticket and description
- [X] Your PR title contains the ISSUE ticket number e.g "86: ..."
- [X] Provided screenshots/demo (see test example)
- [X] Provided testing information
- [X] Provided adequate test coverage for all new code
- [X] Run automated tests (docker compose exec app yarn test)
- [X] Added PR reviewers
- [ ] Ensure at least 1 review before merging
