### PR TITLE
609: Fix conflicting concurrency groups for build workflows

### DIFF
--- a/.github/workflows/build-api.yaml
+++ b/.github/workflows/build-api.yaml
@@ -16,7 +16,7 @@ on:
       - published
 
 concurrency:
-  group: ${{ github.ref }}
+  group: ${{ github.workflow_ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/build-api.yaml
+++ b/.github/workflows/build-api.yaml
@@ -30,6 +30,7 @@ jobs:
       contents: read
       packages: write
     steps:
+      - run: echo ${{ github.workflow_ref }}
       - uses: actions/checkout@v3
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2

--- a/.github/workflows/build-api.yaml
+++ b/.github/workflows/build-api.yaml
@@ -30,7 +30,6 @@ jobs:
       contents: read
       packages: write
     steps:
-      - run: echo ${{ github.workflow_ref }}
       - uses: actions/checkout@v3
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2

--- a/.github/workflows/build-website.yml
+++ b/.github/workflows/build-website.yml
@@ -14,7 +14,7 @@ on:
       - "yarn.lock"
 
 concurrency:
-  group: ${{ github.ref }}
+  group: ${{ github.workflow_ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-website.yml
+++ b/.github/workflows/build-website.yml
@@ -26,6 +26,7 @@ jobs:
     env:
       BUILD_DIR: packages/client
     steps:
+      - run: echo ${{ github.workflow_ref }}
       - uses: actions/checkout@v3
       - name: Install Node.js
         uses: actions/setup-node@v2

--- a/.github/workflows/build-website.yml
+++ b/.github/workflows/build-website.yml
@@ -26,7 +26,6 @@ jobs:
     env:
       BUILD_DIR: packages/client
     steps:
-      - run: echo ${{ github.workflow_ref }}
       - uses: actions/checkout@v3
       - name: Install Node.js
         uses: actions/setup-node@v2


### PR DESCRIPTION
### Ticket #609 

### Description

This PR modifies the `concurrency.group` (concurrency group identifier) settings for disparate GitHub Actions workflows so that website builds do not cancel API builds, and vice-versa. It accomplishes by changing the identifier from `github.ref` (which is ref-/branch-specific) to `github.workflow_ref` (which identifies the specific workflow file in addition to the ref).

#### Background & additional info
Currently, both the ["Build Docker image for GOST API"](https://github.com/usdigitalresponse/usdr-gost/blob/2d17fa9f204c4cd0ef7ea9eb994195a09355e267/.github/workflows/build-api.yaml) and ["Build GOST Website"](https://github.com/usdigitalresponse/usdr-gost/blob/_staging/.github/workflows/build-website.yml) workflows have workflow-level concurrency group configurations that are meant to ensure only the most-recent revision triggering the same workflow is allowed to run. 

As an example:
- Assume that the "Build GOST Website" workflow takes about 5 minutes to complete
- The workflow is triggered by a squash commit to `_staging`, e.g. commit `aaaaaaa`
- Two minutes later (while the workflow is already running), a second squash commit to `_staging`, commit `bbbbbbb` triggers the same workflow

The desired behavior is for the workflow run triggered for commit `aaaaaaa` to be cancelled and superseded by a workflow run for commit `bbbbbbb`. This helps prevent race conditions where changes from an older commit are published over changes for a newer commit (for example, `aaaaaaa` starts first, but `bbbbbbb` finishes first, so that artifacts are published in the wrong order).

Prior to these changes, both workflows' concurrency group identifiers are set to `github.ref` (e.g. `refs/head/_staging`), which causes undesirable behavior in the following circumstances:
1. When a single commit contains both website and API modifications, whichever workflow starts second cancels the first, thereby causing only the website _or_ API build artifacts to be published, but not both.
2. When (e.g.) commit `aaaaaaa` only contains API changes, and commit `bbbbbbb` only contains website changes, if they are both merged at approximately the same time, only the website changes for `bbbbbbb` are published because the (unrelated) `aaaaaaa` workflow run gets cancelled.

The solution for this conflict is simple: use [the `github.workflow_ref` context variable](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context), which prepends the path to the workflow's file to the ref (e.g. `usdigitalresponse/usdr-gost/.github/workflows/build-api.yaml@refs/head/_staging`), so that only concurrent executions that share the the same ref _and_ workflow are deduplicated.

### Screenshots / Demo Video

N/A

### Testing

The following workflow executions are evidence of these changes working as-expected:

1. Triggering a "Build Docker image for GOST API" workflow cancels an in-progress execution of the same workflow/ref pair:
    - [Job 3943170503](https://github.com/usdigitalresponse/usdr-gost/actions/runs/3943170503) (triggered by opening this PR) was cancelled by [job 3943181492](https://github.com/usdigitalresponse/usdr-gost/actions/runs/3943181492) (triggered by a push to the PR branch).
2. Triggering a "Build GOST Website" workflow cancels an in-progress execution of the same workflow/ref pair:
    - [Job 3943170497](https://github.com/usdigitalresponse/usdr-gost/actions/runs/3943170497) (triggered by opening this PR) was cancelled by [job 3943181493](https://github.com/usdigitalresponse/usdr-gost/actions/runs/3943181493) (triggered by a push to the PR branch).
3. Both "Build Docker image for GOST API" and "Build GOST Website" workflows can run concurrently for the same ref:
    - [Job 3943181492](https://github.com/usdigitalresponse/usdr-gost/actions/runs/3943181492) and  [job 3943181493](https://github.com/usdigitalresponse/usdr-gost/actions/runs/3943181493) both were triggered by the same event (commit beb347a268c33fd04041aef719be1cbce2808dd3 pushed to an open (this) PR branch) and ran to completion.

### Checklist
- [x] Provided ticket and description
- [x] Your PR title contains the ISSUE ticket number e.g "86: ..."
- [ ] Provided screenshots/demo
- [x] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [x] Run automated tests (docker compose exec app yarn test)
- [x] Added PR reviewers
- [ ] Ensure at least 1 review before merging
