### PR TITLE
ARPA: Add column and script for caching workbook json data

### DIFF
--- a/packages/server/migrations/20230119175045_add_parsed_data_blob_for_uploads.js
+++ b/packages/server/migrations/20230119175045_add_parsed_data_blob_for_uploads.js
@@ -5,6 +5,7 @@
 exports.up = async function (knex) {
     await knex.schema
         .table('uploads', (table) => {
+            table.timestamp('parsed_data_cached_at');
             table.jsonb('parsed_data');
         });
 };
@@ -16,6 +17,7 @@ exports.up = async function (knex) {
 exports.down = async function (knex) {
     await knex.schema
         .table('uploads', (table) => {
+            table.dropColumn('parsed_data_cached_at');
             table.dropColumn('parsed_data');
         });
 };

--- a/packages/server/migrations/20230119175045_add_parsed_data_blod_for_uploads.js
+++ b/packages/server/migrations/20230119175045_add_parsed_data_blod_for_uploads.js
@@ -1,0 +1,21 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function (knex) {
+    await knex.schema
+        .table('uploads', (table) => {
+            table.jsonb('parsed_data');
+        });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async function (knex) {
+    await knex.schema
+        .table('uploads', (table) => {
+            table.dropColumn('parsed_data');
+        });
+};

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -41,6 +41,7 @@
     "cron": "^1.8.2",
     "csv-stringify": "^6.0.5",
     "date-fns": "^2.23.0",
+    "deep-diff": "^1.0.2",
     "docx": "^7.3.0",
     "dotenv": "^16.0.0",
     "email-validator": "^2.0.4",

--- a/packages/server/src/arpa_reporter/db/reporting-periods.js
+++ b/packages/server/src/arpa_reporter/db/reporting-periods.js
@@ -32,6 +32,7 @@ module.exports = {
   getReportingPeriodID,
   getPreviousReportingPeriods,
   getAllReportingPeriods,
+  getAllReportingPeriodsForTenantId,
   createReportingPeriod,
   updateReportingPeriod
 }
@@ -46,7 +47,10 @@ function baseQuery (trns) {
 }
 
 async function getAllReportingPeriods (trns = knex) {
-  const tenantId = useTenantId()
+  return getAllReportingPeriodsForTenantId(useTenantId())
+}
+
+async function getAllReportingPeriodsForTenantId(tenantId, trns = knex) {
   return baseQuery(trns).where('reporting_periods.tenant_id', tenantId).orderBy('end_date', 'desc')
 }
 

--- a/packages/server/src/arpa_reporter/db/uploads.js
+++ b/packages/server/src/arpa_reporter/db/uploads.js
@@ -97,6 +97,12 @@ async function createUpload (upload, trns = knex) {
   return inserted
 }
 
+async function cacheRecords(upload, records, trns = knex) {
+  return trns('uploads')
+    .where('id', upload.id)
+    .update({ parsed_data: JSON.stringify(records) })
+}
+
 async function setAgencyId (uploadId, agencyId, trns = knex) {
   return trns('uploads')
     .where('id', uploadId)
@@ -157,6 +163,7 @@ module.exports = {
   getUpload,
   uploadsInPeriod,
   uploadsInSeries,
+  cacheRecords,
   setAgencyId,
   setEcCode,
   markValidated,

--- a/packages/server/src/arpa_reporter/db/uploads.js
+++ b/packages/server/src/arpa_reporter/db/uploads.js
@@ -46,7 +46,10 @@ function getUpload (id, trns = knex) {
 }
 
 function usedForTreasuryExport (periodId, trns = knex) {
-  const tenantId = useTenantId()
+  return usedforTreasuryExportWithTenantId(useTenantId(), periodId, trns)
+}
+
+function usedforTreasuryExportWithTenantId(tenantId, periodId, trns = knex) {
   requiredArgument(periodId, 'periodId must be specified in validForReportingPeriod')
 
   return baseQuery(trns)
@@ -174,7 +177,8 @@ module.exports = {
   setEcCode,
   markValidated,
   markNotValidated,
-  usedForTreasuryExport
+  usedForTreasuryExport,
+  usedforTreasuryExportWithTenantId
 }
 
 // NOTE: This file was copied from src/server/db/uploads.js (git @ ada8bfdc98) in the arpa-reporter repo on 2022-09-23T20:05:47.735Z

--- a/packages/server/src/arpa_reporter/db/uploads.js
+++ b/packages/server/src/arpa_reporter/db/uploads.js
@@ -100,7 +100,13 @@ async function createUpload (upload, trns = knex) {
 async function cacheRecords(upload, records, trns = knex) {
   return trns('uploads')
     .where('id', upload.id)
-    .update({ parsed_data: JSON.stringify(records) })
+    .update({
+      parsed_data_cached_at: trns.fn.now(),
+      parsed_data: JSON.stringify(records,
+        // This resursively filters out any fields named 'parsed_data' in the records, which is
+        // important for ensuring we don't recursively/redundantly write this data to the db.
+        (k, v) => (k === 'parsed_data') ? undefined : v)
+    })
 }
 
 async function setAgencyId (uploadId, agencyId, trns = knex) {

--- a/packages/server/src/arpa_reporter/services/records.js
+++ b/packages/server/src/arpa_reporter/services/records.js
@@ -177,8 +177,10 @@ async function recordsForUpload (upload) {
   }
 
   if (upload.parsed_data) {
+    // TODO: When should we use this data vs skipping it?
+    // How to check if the cache should be invalidated?
     log(`recordsForUpload(${upload.id}): Upload has cached data available to read`)
-    // TODO: When should we use the cached data vs a realtime read?
+    return upload.parsed_data
   }
 
   log(`recordsForUpload(${upload.id}): reading from disk`)

--- a/packages/server/src/scripts/parse_and_cache_data.js
+++ b/packages/server/src/scripts/parse_and_cache_data.js
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+/* eslint-disable */
+
+require("dotenv").config();
+
+const { loadRecordsForUpload } = require('../arpa_reporter/services/records')
+const _ = require("lodash");
+
+const inquirer = require("inquirer");
+
+// This is so named to keep from accidentally typing "knex" out of habit and thus having some
+// queries inadvertently outside the transaction.
+const knexWithoutTransaction = require("../db/connection");
+const { getUpload, cacheRecords } = require("../arpa_reporter/db/uploads");
+
+async function main() {
+    if (!process.env.POSTGRES_URL) {
+        console.error("must specify POSTGRES_URL env variable");
+        return;
+    }
+    console.log(
+        "Parsing and caching upload data with postgres db: ",
+        process.env.POSTGRES_URL
+    );
+
+    const { uploadId } = await inquirer.prompt([
+        {
+            type: "input",
+            name: "uploadId",
+            message: "What is the uuid of the upload you want to parse and cache:",
+        },
+    ])
+
+    console.log("Parsing and caching upload with id:", uploadId);
+
+
+    const upload = await getUpload(uploadId)
+    const records = await loadRecordsForUpload(upload)
+
+    await cacheRecords(upload, records)
+
+    // Now that the data has been written, check that it matches what we parsed from excel
+    const updatedUpload = await getUpload(uploadId)
+
+    if (_.isEqual(records, updatedUpload.parsed_data)) {
+        console.log("Cached data is equivalent to parsed data")
+    } else {
+        diff = compare(records, updatedUpload.parsed_data)
+        console.log("ERROR: Cached and parsed data are not equivalent")
+        console.log(diff)
+    }
+
+}
+
+// This method is copied verbatim from https://stackoverflow.com/a/41431685/21046021
+// and allows us to see every json path that differs between two objects
+var compare = function (a, b) {
+    var result = {
+        different: [],
+        missing_from_first: [],
+        missing_from_second: []
+    };
+
+    _.reduce(a, function (result, value, key) {
+        if (b.hasOwnProperty(key)) {
+            if (_.isEqual(value, b[key])) {
+                return result;
+            } else {
+                if (typeof (a[key]) != typeof ({}) || typeof (b[key]) != typeof ({})) {
+                    //dead end.
+                    result.different.push(key);
+                    return result;
+                } else {
+                    var deeper = compare(a[key], b[key]);
+                    result.different = result.different.concat(_.map(deeper.different, (sub_path) => {
+                        return key + "." + sub_path;
+                    }));
+
+                    result.missing_from_second = result.missing_from_second.concat(_.map(deeper.missing_from_second, (sub_path) => {
+                        return key + "." + sub_path;
+                    }));
+
+                    result.missing_from_first = result.missing_from_first.concat(_.map(deeper.missing_from_first, (sub_path) => {
+                        return key + "." + sub_path;
+                    }));
+                    return result;
+                }
+            }
+        } else {
+            result.missing_from_second.push(key);
+            return result;
+        }
+    }, result);
+
+    _.reduce(b, function (result, value, key) {
+        if (a.hasOwnProperty(key)) {
+            return result;
+        } else {
+            result.missing_from_first.push(key);
+            return result;
+        }
+    }, result);
+
+    return result;
+}
+
+if (require.main === module) {
+    main().then(() => process.exit());
+}

--- a/packages/server/src/scripts/parse_and_cache_whole_tenant.js
+++ b/packages/server/src/scripts/parse_and_cache_whole_tenant.js
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+/* eslint-disable */
+
+require("dotenv").config();
+
+const { loadRecordsForUpload } = require('../arpa_reporter/services/records')
+const _ = require("lodash");
+const { diff } = require('deep-diff');
+
+const inquirer = require("inquirer");
+
+// This is so named to keep from accidentally typing "knex" out of habit and thus having some
+// queries inadvertently outside the transaction.
+const knexWithoutTransaction = require("../db/connection");
+const { getUpload, cacheRecords, usedforTreasuryExportWithTenantId } = require("../arpa_reporter/db/uploads");
+const {  getAllReportingPeriodsForTenantId } = require("../arpa_reporter/db/reporting-periods");
+
+async function main() {
+    if (!process.env.POSTGRES_URL) {
+        console.error("must specify POSTGRES_URL env variable");
+        return;
+    }
+    console.log(
+        "Parsing and caching upload data with postgres db: ",
+        process.env.POSTGRES_URL
+    );
+
+    const { tenantId } = await inquirer.prompt([
+        {
+            type: "input",
+            name: "tenantId",
+            message: "What is the tenantId you want to populate the cache for:",
+        },
+    ])
+
+    console.log("Parsing and caching all active uploads for tenant with id", tenantId);
+
+    const reportingPeriods = await getAllReportingPeriodsForTenantId(tenantId)
+    const uploads = (await Promise.all(
+        reportingPeriods.flatMap(period => usedforTreasuryExportWithTenantId(tenantId, period.id))
+    )).flat()
+
+    console.log(`Parsing and caching data for ${uploads.length} uploads, with ids ${uploads.map(u => u.id)}`)
+    for (const upload of uploads) {
+        const records = await loadRecordsForUpload(upload)
+        await cacheRecords(upload, records)
+
+        /* TODO: Eventually we'll want to verify the diffs, but there is a known mismatch with timestamps currently 
+        const updatedUpload = await getUpload(upload.id)
+        const differences = diff(records, updatedUpload.parsed_data)
+        if (differences.length === 0) {
+            console.log("Cached data is equivalent to parsed data")
+        } else {
+            console.log("ERROR: Cached and parsed data are not equivalent")
+            console.log(differences)
+        }
+        */
+    }
+}
+
+if (require.main === module) {
+    main().then(() => process.exit());
+}
+
+/* Some useful SQL queries:
+
+Check all rows with cached data:
+SELECT * FROM uploads WHERE parsed_data is NOT NULL
+
+
+Wipe the cache:
+UPDATE uploads
+SET
+  parsed_data_cached_at = NULL,
+  parsed_data = NULL
+WHERE
+  parsed_data IS NOT NULL OR 
+  parsed_data_cached_at IS NOT NULL
+
+  */

--- a/yarn.lock
+++ b/yarn.lock
@@ -417,7 +417,6 @@
     js-tokens "^4.0.0"
 
 "@babel/parser@^7.1.6", "@babel/parser@^7.16.4", "@babel/parser@^7.18.4", "@babel/parser@^7.20.7", "@babel/parser@^7.7.0":
-"@babel/parser@^7.1.6", "@babel/parser@^7.16.4", "@babel/parser@^7.18.4", "@babel/parser@^7.20.7", "@babel/parser@^7.7.0":
   version "7.20.7"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.20.7.tgz#66fe23b3c8569220817d5feb8b9dcdc95bb4f71b"
   integrity sha512-T3Z9oHybU+0vZlY9CiDSJQTD5ZapcW18ZctFMi0MOAl/4BjFF4ul7NVSARLdbGO5vDqy9eQiGTV0LtKfvCYvcg==
@@ -6229,6 +6228,11 @@ dedent@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/dedent/-/dedent-0.7.0.tgz#2495ddbaf6eb874abb0e1be9df22d2e5a544326c"
   integrity sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA==
+
+deep-diff@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/deep-diff/-/deep-diff-1.0.2.tgz#afd3d1f749115be965e89c63edc7abb1506b9c26"
+  integrity sha512-aWS3UIVH+NPGCD1kki+DCU9Dua032iSsO43LqQpcs4R3+dVv7tX0qBGjiVHJHjplsoUM2XRO/KB92glqc68awg==
 
 deep-eql@^4.1.2:
   version "4.1.2"


### PR DESCRIPTION
### Ticket #
First step on ticket #832 

### Description
This PR begins the process of using cached data so that we can avoid the expensive excel parsing step, especially for tasks that read a huge number of files (like generating the audit report).

This PR adds the db migration to add a new column to the db, specifically of the jsonb (or json-binary) type.
This type is a little slower to write to the database, but faster to read out because it is alreadd parsed into a valid json shape.

This PR punts on the questions of when we should use/avoid the cache and when we need to invalidate data by not reading/writing to it during real user requests. It adds a manual script that can be run to cache parsed data for a single upload id. It then also does a comparison to see if the cached data exactly matches the parsed data. So far the only difference is in how timestamps are used (the cached data has converted the timestamp to a string, where the parsed data is using a native js time type).


### Screenshots / Demo Video
<img width="877" alt="Screen Shot 2023-01-19 at 12 39 49 PM" src="https://user-images.githubusercontent.com/3675290/213554936-9c1de17b-f77c-4406-8a6b-67c78fc693e1.png">

After running the script, json data is showing in the database:
<img width="1002" alt="Screen Shot 2023-01-19 at 12 42 13 PM" src="https://user-images.githubusercontent.com/3675290/213555388-0b6e3a18-a4ff-4040-b5b3-78fda02df1a8.png">


### Testing

### Checklist
- [x] Provided ticket and description
- [x] Your PR title contains the ISSUE ticket number e.g "86: ..."
- [x] Provided screenshots/demo
- [x] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Run automated tests (docker compose exec app yarn test)
- [x] Added PR reviewers
- [ ] Ensure at least 1 review before merging
