### PR TITLE
fix: Remove max_line_length restriction from editorconfig (839)

### DIFF
--- a/packages/client/.editorconfig
+++ b/packages/client/.editorconfig
@@ -4,4 +4,3 @@ indent_size = 2
 end_of_line = lf
 trim_trailing_whitespace = true
 insert_final_newline = true
-max_line_length = 100


### PR DESCRIPTION
Removes the max line restriction from editorconfig, which conflicts with the restriction set by `eslint` and applies more broadly / less intelligently than the `eslint` restriction.

### Ticket #
#839 

### Description
(see above)

### Screenshots / Demo Video
N/A

### Testing
This PR itself should not trigger the line-length restriction

### Checklist
- [x] Provided ticket and description
- [x] Your PR title contains the ISSUE ticket number e.g "86: ..."
- [x] Provided screenshots/demo
- [x] Provided testing information
- [x] Provided adequate test coverage for all new code
- [x] Run automated tests (docker compose exec app yarn test)
- [x] Added PR reviewers
- [ ] Ensure at least 1 review before merging
