### PR TITLE
Fix a typo in audit report console logging

### DIFF
--- a/packages/server/src/arpa_reporter/routes/audit-report.js
+++ b/packages/server/src/arpa_reporter/routes/audit-report.js
@@ -15,7 +15,7 @@ router.get('/', requireUser, async function (req, res) {
     console.log('Successfully generated report');
   } catch (error) {
     // In addition to sending the error message in the 500 response, log the full error stacktrace
-    console.log(`Audit report generation failed. Logging the thrown error.`, e)
+    console.log(`Audit report generation failed. Logging the thrown error.`, error)
     return res.status(500).send(error.message)
   }
 


### PR DESCRIPTION
### Ticket #N/A

### Description

A quick typo fix!  I'm not sure how long this typo has been lying around in code, but I managed to run into this code path today.

### Screenshots / Demo Video

<img width="721" alt="image" src="https://user-images.githubusercontent.com/11449340/213611982-1e1329ca-e55d-498f-a1cf-71943802cf3f.png">

### Testing

### Checklist
- [ ] Provided ticket and description
- [ ] Your PR title contains the ISSUE ticket number e.g "86: ..."
- [x] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Run automated tests (docker compose exec app yarn test)
- [ ] Added PR reviewers
- [ ] Ensure at least 1 review before merging
