### PR TITLE
[DRAFT] fix: Make it possible to debug tests in VSCode via Mocha Test Explorer (820)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,3 +121,4 @@ packages/server/data
 
 # Locally-persisted postgres development data
 docker/postgres/persistence
+.env*

--- a/packages/server/.vscode/launch.json
+++ b/packages/server/.vscode/launch.json
@@ -1,0 +1,31 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "seed test",
+            "runtimeExecutable": "yarn",
+            "runtimeArgs": [
+              "db:seed:test"
+            ],
+            "cwd": "${workspaceRoot}",
+            "timeout": 10000
+          },
+        {
+            "type": "node",
+            "request": "attach",
+            "name": "Mocha Attach",
+            "port": 9229,
+            "continueOnAttach": true,
+            "autoAttachChildProcesses": true,
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
+            "preLaunchTask": "Mocha Setup"
+        }
+    ]
+}

--- a/packages/server/.vscode/settings.json
+++ b/packages/server/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "mochaExplorer.debuggerConfig": "Mocha Attach",
+    "mochaExplorer.env": {
+        "NODE_ENV": "test", 
+        "SUPPRESS_EMAIL": "true"
+    }
+}

--- a/packages/server/.vscode/tasks.json
+++ b/packages/server/.vscode/tasks.json
@@ -1,0 +1,10 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Mocha Setup",
+      "type": "shell",
+      "command": "${workspaceFolder}/__tests__/arpa_reporter/server/mocha_setup.sh"
+    }
+  ]
+}

--- a/packages/server/__tests__/arpa_reporter/server/fixtures/add-dummy-data.js
+++ b/packages/server/__tests__/arpa_reporter/server/fixtures/add-dummy-data.js
@@ -3,7 +3,6 @@ const { isRunningInGOST } = require('../helpers/is_gost')
 
 const setupAgencies = async knex => {
   const isGost = await isRunningInGOST(knex)
-
   return knex('agencies').insert([
     { id: 1, name: 'Generic Government', code: 'GOV', tenant_id: 0 },
     { id: 2, name: 'Office of Management and Budget', code: 'OMB', tenant_id: 0 },
@@ -14,7 +13,11 @@ const setupAgencies = async knex => {
     row => isGost ? ({ ...row, main_agency_id: row.id }) : row
   )).then(() => {
     return 'Agency data added OK'
-  })
+  }).catch((err) => {
+    console.error(err);
+  }).finally(() => {
+    console.debug('Dummy data added');
+  });
 }
 
 module.exports = {

--- a/packages/server/__tests__/arpa_reporter/server/mocha_setup.sh
+++ b/packages/server/__tests__/arpa_reporter/server/mocha_setup.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+set -o pipefail
+set -o errexit
+set -o nounset
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+# Import .env variables if not already defined.
+if [[ $DIR =~ "__tests__/arpa_reporter" ]]
+then
+  # in GOST, mocha_wrapper.sh will be located in packages/server/__tests__/arpa_reporter/server
+  # and .env inside packages/server
+  DOTENV="$DIR/../../../.env"
+else
+  # in legacy ARPA Reporter repo, mocha_wrapper.sh is located in tests/server and .env at repo root
+  DOTENV="$DIR/../../.env"
+fi
+
+echo "DOTENV - $DOTENV"
+
+source /dev/stdin <<DONE
+$(grep -v '^#' $DOTENV | sed -E 's|^([^=]+)=(.*)|: ${\1=\2}; export \1|g')
+DONE
+
+# note: this is the DB name of the non-test db, used in reset-db.sh to check if
+# dev and test DBs are the same
+export DEVDBNAME="${POSTGRES_URL##*/}"
+
+# Legacy for devs w/o POSTGRES_TEST_URL set explicitly in .env
+if [[ -z $POSTGRES_TEST_URL ]]
+then
+  export POSTGRES_TEST_URL="${POSTGRES_URL}_test"
+fi
+
+# reset-db.sh and knex within mocha only aware of a single DB URL
+export POSTGRES_URL=$POSTGRES_TEST_URL
+
+export DATA_DIR=`dirname $0`/mocha_uploads
+
+echo "IMPORTANT VARS: DEVDBNAME=$DEVDBNAME, POSTGRES_TEST_URL=$POSTGRES_TEST_URL, POSTGRES_URL=$POSTGRES_URL, DATA_DIR=$DATA_DIR"
+
+"$DIR"/reset-db.sh

--- a/packages/server/__tests__/arpa_reporter/server/mocha_wrapper.sh
+++ b/packages/server/__tests__/arpa_reporter/server/mocha_wrapper.sh
@@ -1,40 +1,6 @@
 #!/bin/bash
 
-set -o errexit
-
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-
-# Import .env variables if not already defined.
-if [[ $DIR =~ "__tests__/arpa_reporter" ]]
-then
-  # in GOST, mocha_wrapper.sh will be located in packages/server/__tests__/arpa_reporter/server
-  # and .env inside packages/server
-  DOTENV="$DIR/../../../.env"
-else
-  # in legacy ARPA Reporter repo, mocha_wrapper.sh is located in tests/server and .env at repo root
-  DOTENV="$DIR/../../.env"
-fi
-
-source /dev/stdin <<DONE
-$(grep -v '^#' $DOTENV | sed -E 's|^([^=]+)=(.*)|: ${\1=\2}; export \1|g')
-DONE
-
-# note: this is the DB name of the non-test db, used in reset-db.sh to check if
-# dev and test DBs are the same
-export DEVDBNAME="${POSTGRES_URL##*/}"
-
-# Legacy for devs w/o POSTGRES_TEST_URL set explicitly in .env
-if [[ -z $POSTGRES_TEST_URL ]]
-then
-  export POSTGRES_TEST_URL="${POSTGRES_URL}_test"
-fi
-
-# reset-db.sh and knex within mocha only aware of a single DB URL
-export POSTGRES_URL=$POSTGRES_TEST_URL
-
-export DATA_DIR=`dirname $0`/mocha_uploads
-
-$DIR/reset-db.sh
+source mocha_setup.sh
 
 if [ $# -gt 0 ]; then
   mocha --require=`dirname $0`/mocha_init.js $*

--- a/packages/server/__tests__/arpa_reporter/server/reset-db.sh
+++ b/packages/server/__tests__/arpa_reporter/server/reset-db.sh
@@ -5,6 +5,7 @@ set -o errexit
 set -o nounset
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+echo "DIR IS $DIR";
 
 dbconn=${POSTGRES_URL#*//}  # from postgres://user:pass@host/dbname -> user:pass@host/dbname
 userpass=${dbconn%@*}       # 'user:pass'
@@ -45,6 +46,6 @@ else
 fi
 
 yarn knex migrate:latest
-yarn knex --knexfile $DIR/knexfile.js seed:run
+yarn knex --knexfile "$DIR"/knexfile.js seed:run
 
 # NOTE: This file was copied from tests/server/reset-db.sh (git @ ada8bfdc98) in the arpa-reporter repo on 2022-09-23T20:05:47.735Z

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -99,5 +99,15 @@
     "standard": "^16.0.3",
     "supertest": "^6.2.3",
     "typescript": "^4.7.2"
+  },
+  "mocha": {
+    "spec": "__tests__/**/*.{spec,test}.js",
+    "require": [
+      "__tests__/arpa_reporter/server/mocha_init.js",
+      "__tests__/api/fixtures.js"
+    ],
+    "timeout": 10000,
+    "bail" : true,
+    "exit" : true
   }
 }


### PR DESCRIPTION
### Ticket #
#820 

### Description
(WIP)!
Initial proof of concept for using Mocha Test Explorer to run tests. 

To use this:
1. Open the vscode workspace
2. Install the Mocha Test Explorer extension in VSCode
3. Open the Testing panel, hit the "debug" icon to debug tests. Under the hood, this will run the debug target that is listed in `launch.json`, which runs the relevant task in `tasks.json`. In turn, this runs the scripts in `mocha_setup`

### Screenshots / Demo Video
N/A for now

### Testing
N/A 

### Checklist
- [x] Provided ticket and description
- [x] Your PR title contains the ISSUE ticket number e.g "86: ..."
- [x] Provided screenshots/demo
- [x] Provided testing information
- [x] Provided adequate test coverage for all new code
- [x] Run automated tests (docker compose exec app yarn test)
- [] Added PR reviewers
- [ ] Ensure at least 1 review before merging

### Next steps

Limitations of this patch:
* We have bigger issues here about how we're resetting the db - there are two files that are doing this, and they're competing -- `reset-db.sh` and `resetdb.js`. 
* We should make it possible to not have to run these `.sh` prep scripts at all - I think `resetdb.js` is the way forward here for reseting tests appropriately, we should make that fix.


