### PR TITLE
Fix: ARPA downloads failing on aws

### DIFF
--- a/packages/client/src/arpa_reporter/components/DownloadFileButton.vue
+++ b/packages/client/src/arpa_reporter/components/DownloadFileButton.vue
@@ -1,10 +1,12 @@
 <template>
-  <a :href="`/api/uploads/${upload.id}/download`" class="btn-sm btn-primary ml-2">
+  <a :href="apiURL(`/api/uploads/${upload.id}/download`)" class="btn-sm btn-primary ml-2">
       Download file
   </a>
 </template>
 
 <script>
+import { apiURL } from '@/helpers/fetchApi';
+
 export default {
   name: 'DownloadFileButton',
   props: {

--- a/packages/client/src/arpa_reporter/components/DownloadTemplateBtn.vue
+++ b/packages/client/src/arpa_reporter/components/DownloadTemplateBtn.vue
@@ -6,6 +6,7 @@
 
 <script>
 import DownloadButton from './DownloadButton.vue'
+import { apiURL } from '@/helpers/fetchApi';
 
 export default {
   name: 'DownloadTemplateBtn',
@@ -20,7 +21,7 @@ export default {
       return this.$store.state.viewPeriodID
     },
     href: function () {
-      return `/api/reporting_periods/${this.periodId}/template`
+      return apiURL(`/api/reporting_periods/${this.periodId}/template`)
     },
     isDisabled: function () {
       return !this.$store.getters.viewPeriodIsCurrent

--- a/packages/client/src/arpa_reporter/views/Home.vue
+++ b/packages/client/src/arpa_reporter/views/Home.vue
@@ -2,11 +2,11 @@
   <div>
     <div class="row mt-5 mb-5" v-if="viewingOpenPeriod">
       <div class="col" v-if="isAdmin">
-        <DownloadButton :href="downloadUrl()" class="btn btn-primary btn-block">Download Treasury Report</DownloadButton>
+        <DownloadButton :href="downloadTreasuryReportURL()" class="btn btn-primary btn-block">Download Treasury Report</DownloadButton>
       </div>
 
       <div class="col" v-if="isAdmin">
-        <DownloadButton href="/api/audit_report" class="btn btn-info btn-block">Download Audit Report</DownloadButton>
+        <DownloadButton :href="downloadAuditReportURL()" class="btn btn-info btn-block">Download Audit Report</DownloadButton>
       </div>
 
       <div class="col">
@@ -45,6 +45,7 @@
 <script>
 import DownloadButton from '../components/DownloadButton.vue'
 import DownloadTemplateBtn from '../components/DownloadTemplateBtn.vue'
+import { apiURL } from '@/helpers/fetchApi';
 
 export default {
   name: 'Home',
@@ -63,9 +64,12 @@ export default {
     }
   },
   methods: {
-    downloadUrl () {
+    downloadAuditReportURL: function () {
+      return apiURL('/api/audit_report')
+    },
+    downloadTreasuryReportURL () {
       const periodId = this.$store.getters.viewPeriod.id || 0
-      return `/api/exports?period_id=${periodId}`
+      return apiURL(`/api/exports?period_id=${periodId}`)
     },
     startUpload: function () {
       if (this.viewingOpenPeriod) {


### PR DESCRIPTION
### (Related to #602)

### Description

This PR updates the Vue templates for several buttons in the ARPA Reporter client that set their `href` to an API-destined (file) URL. Since these don't initiate a request to the API backend via a `fetch` operation, they were passed over when the `apiURL()` helper function was being incorporated. As a result, the download links on AWS deployments don't point to a valid target file on the backend, and the downloads fail (the exact nature of the failure is browser-specific).

### Screenshots / Demo Video

### Testing

### Checklist
- [X] Provided ticket and description
- [ ] Your PR title contains the ISSUE ticket number e.g "86: ..."
- [ ] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [x] Run automated tests (docker compose exec app yarn test)
- [x] Added PR reviewers
- [ ] Ensure at least 1 review before merging
