### PR TITLE
Fixes for API URLs pointing the wrong domain

### DIFF
--- a/packages/client/src/arpa_reporter/components/DownloadFileButton.vue
+++ b/packages/client/src/arpa_reporter/components/DownloadFileButton.vue
@@ -1,5 +1,5 @@
 <template>
-  <a :href="apiURL(`/api/uploads/${upload.id}/download`)" class="btn-sm btn-primary ml-2">
+  <a :href="href" class="btn-sm btn-primary ml-2">
       Download file
   </a>
 </template>
@@ -11,6 +11,11 @@ export default {
   name: 'DownloadFileButton',
   props: {
     upload: Object
+  },
+  computed: {
+    href: function () {
+      return apiURL(`/api/uploads/${upload.id}/download`)
+    }
   }
 }
 </script>

--- a/packages/client/src/components/Uploader.vue
+++ b/packages/client/src/components/Uploader.vue
@@ -36,6 +36,8 @@
 </template>
 
 <script>
+import { apiURL } from '@/helpers/fetchApi';
+
 export default {
   name: 'Uploader',
   props: {
@@ -71,7 +73,7 @@ export default {
       const formData = new FormData();
       formData.append('spreadsheet', file);
       try {
-        const url = `/api/organizations/:organizationId/${this.uploadRecordType}/import`;
+        const url = apiURL(`/api/organizations/:organizationId/${this.uploadRecordType}/import`);
         const options = {
           method: 'POST',
           credentials: 'include',

--- a/packages/client/src/store/modules/grants.js
+++ b/packages/client/src/store/modules/grants.js
@@ -121,11 +121,11 @@ export default {
         .filter(([key, value]) => value || typeof value === 'number')
         .map(([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(value)}`)
         .join('&');
-      const navUrl = fetchApi.addOrganizationId(`/api/organizations/:organizationId/grants/exportCSV?${query}`);
+      const navUrl = fetchApi.apiURL(fetchApi.addOrganizationId(`/api/organizations/:organizationId/grants/exportCSV?${query}`));
       window.location = navUrl;
     },
     exportCSVRecentActivities() {
-      window.location = fetchApi.addOrganizationId('/api/organizations/:organizationId/grants/exportCSVRecentActivities');
+      window.location = fetchApi.apiURL(fetchApi.addOrganizationId('/api/organizations/:organizationId/grants/exportCSVRecentActivities'));
     },
   },
   mutations: {


### PR DESCRIPTION
### (Related to #602)

### Description

This PR addresses a few places in the ARPA Reporter client where the `fetchApi.apiURL()` helper was not being used to format URLs intended to point to the API backend. In Render, where the client and backend share the same domain name, it's easy for this to go unnoticed because browsers default to the current domain. However, this causes issues in environments where the API is hosted on a different domain, such as AWS.

Additionally, this fixes a bug (likely introduced in #864 ) that caused the "Download file" button to stop appearing on the Uploads tab of the ARPA Reporter client.

### Screenshots / Demo Video

### Testing

### Checklist
- [X] Provided ticket and description
- [X] Your PR title contains the ISSUE ticket number e.g "86: ..."
- [ ] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Run automated tests (docker compose exec app yarn test)
- [X] Added PR reviewers
- [X] Ensure at least 1 review before merging
