### PR TITLE
Fix: Use bound upload object when computing href

### DIFF
--- a/packages/client/src/arpa_reporter/components/DownloadFileButton.vue
+++ b/packages/client/src/arpa_reporter/components/DownloadFileButton.vue
@@ -14,7 +14,7 @@ export default {
   },
   computed: {
     href: function () {
-      return apiURL(`/api/uploads/${upload.id}/download`)
+      return apiURL(`/api/uploads/${this.upload.id}/download`)
     }
   }
 }


### PR DESCRIPTION
### Follow up to #871 

### Description

I jumped the gun in the last PR- the `href` computed property was referring to an unknown `upload` object and should have instead been referring to the bound (`this.upload`) object. This PR fixes that issue and (confirmed) makes the button show up again.

### Screenshots / Demo Video

### Testing

### Checklist
- [ ] Provided ticket and description
- [ ] Your PR title contains the ISSUE ticket number e.g "86: ..."
- [ ] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Run automated tests (docker compose exec app yarn test)
- [ ] Added PR reviewers
- [ ] Ensure at least 1 review before merging
