### PR TITLE
Fix: Ensure Certify Reporting Period requests target the correct API domain

### DIFF
--- a/packages/client/src/arpa_reporter/views/ReportingPeriods.vue
+++ b/packages/client/src/arpa_reporter/views/ReportingPeriods.vue
@@ -72,6 +72,8 @@
 </template>
 
 <script>
+import { apiURL } from '@/helpers/fetchApi'
+
 const moment = require('moment')
 const _ = require('lodash')
 
@@ -111,7 +113,7 @@ export default {
       this.$refs.closeModal.click()
 
       try {
-        const resp = await fetch('/api/reporting_periods/close', { method: 'POST' })
+        const resp = await fetch(apiURL('/api/reporting_periods/close'), { method: 'POST' })
         const result = resp.headers.get('Content-Type').includes('json')
           ? await resp.json()
           : { error: await resp.text() }


### PR DESCRIPTION
### (Related to #602 )

### Description

This PR addresses an issue where the "Certify Reporting Period" flow results in a 403 response for the POST request sent to `/api/reporting_periods/close`. The underlying issue is the same as [some](https://github.com/usdigitalresponse/usdr-gost/pull/871) [other](https://github.com/usdigitalresponse/usdr-gost/pull/864) recent PRs: the URL for the request targets the domain name where the client is hosted, rather than the domain of the API. Like those other instances, the fix is to call the `fetchApi.apiURL()` helper function when the URL is being generated, which will ensure that the request targets the correct hostname for the API associated with the deployment environment.

### Screenshots / Demo Video

### Testing

### Checklist
- [X] Provided ticket and description
- [X] Your PR title contains the ISSUE ticket number e.g "86: ..."
- [ ] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [X] Run automated tests (docker compose exec app yarn test)
- [X] Added PR reviewers
- [X] Ensure at least 1 review before merging
