### PR TITLE
fix: [Partner submission] [Data Validation] Ensure email address form…

### DIFF
--- a/packages/server/__tests__/arpa_reporter/server/services/validate-upload.spec.js
+++ b/packages/server/__tests__/arpa_reporter/server/services/validate-upload.spec.js
@@ -1,0 +1,22 @@
+const _ = require('lodash');
+const assert = require('assert')
+const rewire = require('rewire');
+
+describe('validate upload', () => {
+    describe('validate field pattern', () => {
+        const validateFieldPattern = rewire('../../../../src/arpa_reporter/services/validate-upload').__get__(
+            'validateFieldPattern'
+        );
+        const EMAIL_KEY = "POC_Email_Address__c";
+        const malformedEmail = "john smith john.smith@email.com";
+        const properEmail = "john.smith@email.com";
+
+        it('Does not raise an error for valid emails', () => {
+            assert(validateFieldPattern(EMAIL_KEY, properEmail) === null);
+        });
+
+        it('Raises an error for invalid emails', () => {
+            assert(validateFieldPattern(EMAIL_KEY, malformedEmail) !== null);
+        });
+    })
+});

--- a/packages/server/src/arpa_reporter/services/validate-upload.js
+++ b/packages/server/src/arpa_reporter/services/validate-upload.js
@@ -17,7 +17,16 @@ const ValidationError = require('../lib/validation-error')
 // They can optionally have a decimal point followed by 1 or 2 more digits (?: \.\d{ 1, 2 })
 const CURRENCY_REGEX_PATTERN = /^\d+(?: \.\d{ 1, 2 })?$/g
 
+// Copied from www.emailregex.com
+const EMAIL_REGEX_PATTERN = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
+
 const BETA_VALIDATION_MESSAGE = "[BETA] This is a new validation that is running in beta mode (as a warning instead of a blocking error). If you see anything incorrect about this validation, please report it at grants-helpdesk@usdigitalresponse.org"
+
+// This maps from field name to regular expression that must match on the field.
+// Note that this only covers cases where the name of the field is what we want to match on.
+const FIELD_NAME_TO_PATTERN = {
+  "POC_Email_Address__c" : {pattern: EMAIL_REGEX_PATTERN, explanation: "Email must be of the form \"user@email.com\""}
+};
 
 // This is a convenience wrapper that lets us use consistent behavior for new validation errors.
 // Specifically, all new validations should have a message explaining they are in beta and errors
@@ -327,6 +336,16 @@ async function validateRecord ({ upload, record, typeRules: rules }) {
         }
       }
 
+      if (rule.dataType === 'String') {
+        const patternError = validateFieldPattern(key, value);
+        if (patternError) {
+          errors.push(
+            new ValidationError(patternError.message,
+              { severity: 'err', col: rule.columnName })
+          );
+        }
+      }
+
       // make sure max length is not too long
       if (rule.maxLength) {
         if (rule.dataType === 'String' && String(record[key]).length > rule.maxLength) {
@@ -343,6 +362,21 @@ async function validateRecord ({ upload, record, typeRules: rules }) {
 
   // return all the found errors
   return errors
+}
+
+function validateFieldPattern(fieldName, value) {
+  let error = null;
+  const matchedFieldPatternInfo = FIELD_NAME_TO_PATTERN[fieldName];
+  if (matchedFieldPatternInfo) {
+    const pattern = matchedFieldPatternInfo["pattern"];
+    const explanation = matchedFieldPatternInfo["explanation"];
+    if (value && typeof value === 'string' && !value.match(pattern)) {
+      error = new Error(
+         `Value entered in cell is "${value}". ${explanation}`,
+       )
+    }
+  }
+  return error;
 }
 
 async function validateRules ({ upload, records, rules, trns }) {


### PR DESCRIPTION
…at is valid (email address prefix + @ symbol + email domain) (381)

Initial server-side only fix for validating email format using regular expressions. Provides a simple pattern we could adopt for validating the regex patterns of other fields.

### Ticket #
381

### Description
There were a few potential approaches to take here. To start with, I opted for a server-only approach that, for now, only validates on upload.

Alternatives:
1. Excel-side `=ISNUMBER(MATCH("*@*.?*",A2,0))` -- not a true regex, doesn't work for the case provided ("John Smith john.smith@email.com") 
2. Excel-side custom `REGEXMATCH` function. -- Excel lacks Google Sheets' `REGEXMATCH` out of the box, and thus it's necessary to do something along the lines of [this custom VBA function](https://www.ablebits.com/office-addins-blog/excel-data-validation-regex/) to get it working. From there though, you can't get the macro back out for the `generateRules` script (they have `vbaraw` ([ref](https://docs.sheetjs.com/docs/csf/features/#vba-and-macros), but this is raw binary, not text - getting the code back out requires sheetjs PRO). You could do a generic "REGEXMATCH" function and grab the text - this could work in theory but its awkward going between js and VBA.
3. Making API calls direct from Excel -- This is the most preferable option, but requires some setup to get right, as well as its own custom VBA code. We should iterate toward this over time.
4. (This solution) Server-side only validation. Introduces discrepancy with client-side, but faster and easier, and if we set it up the right way, we could vend a function directly that excel could call.

### Screenshots / Demo Video
<img width="1661" alt="Screenshot 2023-02-02 at 2 52 00 AM" src="https://user-images.githubusercontent.com/120750336/216263864-ee5c207f-76b1-48d5-a7ae-cbd961dcf110.png">


### Testing
* Added unit test for newly-extracted function
* To test functionality, add a cell with value "john smith john.smith@gmail.com" to the subrecipients sheet and attempt to validate - you should see an error.

### Checklist
- [ x ] Provided ticket and description
- [ x ] Your PR title contains the ISSUE ticket number e.g "86: ..."
- [ x ] Provided screenshots/demo
- [ x ] Provided testing information
- [ x ] Provided adequate test coverage for all new code
- [ x ] Run automated tests (docker compose exec app yarn test)
- [ x ] Added PR reviewers
- [ ] Ensure at least 1 review before merging
