### PR TITLE
fix: validation error when agency is 0

### DIFF
--- a/packages/server/src/arpa_reporter/routes/users.js
+++ b/packages/server/src/arpa_reporter/routes/users.js
@@ -20,7 +20,7 @@ async function validateUser (user, creator) {
     throw new Error('Role required')
   }
 
-  if (!agency_id) {
+  if (agency_id == null) {
     throw new Error('Cannot create user without agency_id')
   }
 

--- a/packages/server/src/arpa_reporter/services/validate-upload.js
+++ b/packages/server/src/arpa_reporter/services/validate-upload.js
@@ -650,7 +650,6 @@ async function validateUpload (upload, user, trns = null) {
 
 module.exports = {
   validateUpload,
-  ValidationError
 }
 
 // NOTE: This file was copied from src/server/services/validate-upload.js (git @ ada8bfdc98) in the arpa-reporter repo on 2022-09-23T20:05:47.735Z


### PR DESCRIPTION
### Ticket #616 

Fixes #616 

### Description
Fixes error when agency_id is 0. Since 0 is falsy in JavaScript, we need to explicitly
check for null or undefined.