### PR TITLE
fix: filtering by both validated and exported now works

### DIFF
--- a/packages/client/src/arpa_reporter/views/Uploads.vue
+++ b/packages/client/src/arpa_reporter/views/Uploads.vue
@@ -128,7 +128,7 @@ export default {
         },
         tdClass: (row) => { if (!row.validated_at) return 'table-danger' },
         filterOptions: {
-          enabled: true,
+          enabled: !this.onlyExported,
           placeholder: 'Any validation status',
           filterDropdownItems: [
             { value: true, text: 'Show only validated' }
@@ -136,8 +136,6 @@ export default {
           filterFn: (validatedAt, isIncluded) => validatedAt
         }
       }
-
-      if (this.onlyExported) validatedCol.filterOptions = null
 
       return [
         {


### PR DESCRIPTION
### Ticket #861 

Fix the filtering logic so that we disable the validated filter when switching to exported only results
Fixes #861

