### PR TITLE
fix: [Partner submission] Add 'Status of Completion' to Audit File (374)

### DIFF
--- a/packages/server/src/arpa_reporter/lib/audit-report.js
+++ b/packages/server/src/arpa_reporter/lib/audit-report.js
@@ -148,7 +148,8 @@ async function getProjectSummaryRow(data) {
     'Total Cumulative Obligations': record.content.Total_Obligations__c,
     'Total Cumulative Expenditures': record.content.Total_Expenditures__c,
     'Current Period Obligations': record.content.Current_Period_Obligations__c,
-    'Current Period Expenditures': record.content.Current_Period_Expenditures__c
+    'Current Period Expenditures': record.content.Current_Period_Expenditures__c,
+    'Completion Status': record.content.Completion_Status__c
   }
 }
 


### PR DESCRIPTION
### Ticket #
#374 

### Description
Adds status of completion to the audit file summary tab

### Screenshots / Demo Video
![completion_status](https://user-images.githubusercontent.com/120750336/217984080-bb753913-0a5f-4e94-88b2-3f6fd8c58dd9.jpeg)


### Testing
Ran "download audit report" and verified that field was present in summary tab

### Checklist
- [x] Provided ticket and description
- [x] Your PR title contains the ISSUE ticket number e.g "86: ..."
- [x] Provided screenshots/demo
- [x] Provided testing information
- [x] Provided adequate test coverage for all new code
- [x] Run automated tests (docker compose exec app yarn test)
- [x] Added PR reviewers
- [x] Ensure at least 1 review before merging
