### PR TITLE
832: Use a disk cache (TEMP_DIR) to optimize audit report generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,10 +114,5 @@ dist
 
 .DS_Store
 
-packages/server/src/static/forms/generated
-
-# ARPA Reporter uploads
-packages/server/data
-
 # Locally-persisted postgres development data
 docker/postgres/persistence

--- a/packages/server/.gitignore
+++ b/packages/server/.gitignore
@@ -1,0 +1,7 @@
+src/static/forms/generated
+
+# ARPA Reporter uploads
+data
+
+# ARPA Reporter uploads dir used by mocha tests
+__tests__/arpa_reporter/server/mocha_uploads

--- a/packages/server/__tests__/arpa_reporter/server/services/persist-upload.spec.js
+++ b/packages/server/__tests__/arpa_reporter/server/services/persist-upload.spec.js
@@ -1,0 +1,74 @@
+const { expect } = require('chai')
+const { mock } = require('sinon')
+const fs = require('fs/promises')
+
+const XLSX = require('xlsx')
+const {
+  _uploadFSName,
+  _jsonFSName,
+  _persistJson,
+  _jsonForUpload,
+  persistUpload,
+  workbookForUpload,
+} = require('../../../../src/arpa_reporter/services/persist-upload')
+
+const MOCK_WORKBOOK = XLSX.utils.book_new();
+XLSX.utils.book_append_sheet(MOCK_WORKBOOK, XLSX.utils.aoa_to_sheet([[0, 1, 2]]), 'sheet_1');
+
+describe('persist-upload', () => {
+  describe('uploadFSName', () => {
+    it('generates a filesystem name based on upload ID', () => {
+      expect(
+        _uploadFSName({
+          id: 'abcd',
+          filename: 'upload01.xlsm',
+        }),
+      ).include('abcd.xlsm')
+    })
+  })
+
+  describe('jsonFSName', () => {
+    it('generates a filesystem name based on upload ID', () => {
+      expect(_jsonFSName({ id: 'abcd', filename: 'upload01.xlsm' })).include(
+        'abcd.json',
+      )
+    })
+  })
+
+  describe('persistJson', () => {
+    let fsMock
+    beforeEach(() => {
+      fsMock = mock(fs)
+    })
+
+    afterEach(() => {
+      fsMock.restore()
+    })
+
+    it('serializes a workbook object and saves it to disk', async () => {
+      const upload = { id: 'abcd', filename: 'upload01.xlsm' }
+      fsMock.expects('mkdir').once()
+      fsMock.expects('writeFile').once().withArgs(_jsonFSName(upload))
+      await _persistJson(upload, MOCK_WORKBOOK)
+      fsMock.verify()
+    })
+  })
+
+  describe('jsonForUpload', () => {
+    it('serializing and deserializing an upload are reversible', async () => {
+      const upload = { id: 'abcd', filename: 'upload01.xlsm' }
+      await _persistJson(upload, MOCK_WORKBOOK)
+      const workbook = await _jsonForUpload(upload)
+      expect(workbook).deep.equal(MOCK_WORKBOOK)
+    })
+
+    it('preserves Date objects', async () => {
+      const upload = { id: 'efgh', filename: 'upload02.xlsm' }
+      const mockWorkbook = { ...MOCK_WORKBOOK, date: new Date(0) }
+      await _persistJson(upload, mockWorkbook)
+      const workbook = await _jsonForUpload(upload)
+      expect(workbook).deep.equal(mockWorkbook)
+      expect(workbook.date instanceof Date).is.true
+    })
+  })
+})

--- a/packages/server/__tests__/arpa_reporter/server/services/persist-upload.spec.js
+++ b/packages/server/__tests__/arpa_reporter/server/services/persist-upload.spec.js
@@ -30,7 +30,16 @@ describe('persist-upload', () => {
   describe('jsonFSName', () => {
     it('generates a filesystem name based on upload ID', () => {
       expect(_jsonFSName({ id: 'abcd', filename: 'upload01.xlsm' })).include(
-        'abcd.json',
+        '/abcd.json',
+      )
+    })
+
+    it('groups cache contents in subfolders by first character of upload ID', () => {
+      expect(_jsonFSName({ id: 'abcd', filename: 'upload01.xlsm' })).include(
+        '/a/abcd.json',
+      )
+      expect(_jsonFSName({ id: '01234', filename: 'upload02.xlsm' })).include(
+        '/0/01234.json',
       )
     })
   })

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -41,6 +41,7 @@
     "connect-history-api-fallback": "^1.6.0",
     "cookie-parser": "^1.4.5",
     "cron": "^1.8.2",
+    "cryo": "0.0.6",
     "csv-stringify": "^6.0.5",
     "date-fns": "^2.23.0",
     "docx": "^7.3.0",

--- a/packages/server/src/arpa_reporter/environment.js
+++ b/packages/server/src/arpa_reporter/environment.js
@@ -11,7 +11,11 @@ const VERBOSE = Boolean(process.env.VERBOSE)
 const POSTGRES_URL = process.env.POSTGRES_URL
 
 const DATA_DIR = resolve(process.env.DATA_DIR)
-const TEMP_DIR = join(DATA_DIR, 'tmp')
+// FIXME: TEMP_DIR should probbaly be a sub-path of uploads.
+// see also: https://usdigitalresponse.slack.com/archives/C031R1Y49KL/p1675828761404989
+// After we move to AWS, consider uncommenting the following line:
+// const TEMP_DIR = join(DATA_DIR, 'tmp')
+const TEMP_DIR = join(UPLOAD_DIR, 'tmp')
 const UPLOAD_DIR = join(DATA_DIR, 'uploads')
 const PERIOD_TEMPLATES_DIR = join(UPLOAD_DIR, 'period_templates')
 

--- a/packages/server/src/arpa_reporter/environment.js
+++ b/packages/server/src/arpa_reporter/environment.js
@@ -11,12 +11,12 @@ const VERBOSE = Boolean(process.env.VERBOSE)
 const POSTGRES_URL = process.env.POSTGRES_URL
 
 const DATA_DIR = resolve(process.env.DATA_DIR)
+const UPLOAD_DIR = join(DATA_DIR, 'uploads')
 // FIXME: TEMP_DIR should probbaly be a sub-path of uploads.
 // see also: https://usdigitalresponse.slack.com/archives/C031R1Y49KL/p1675828761404989
 // After we move to AWS, consider uncommenting the following line:
 // const TEMP_DIR = join(DATA_DIR, 'tmp')
 const TEMP_DIR = join(UPLOAD_DIR, 'tmp')
-const UPLOAD_DIR = join(DATA_DIR, 'uploads')
 const PERIOD_TEMPLATES_DIR = join(UPLOAD_DIR, 'period_templates')
 
 // Note: in legacy standalone ARPA Report repo, this points to src/server; in GOST

--- a/packages/server/src/arpa_reporter/environment.js
+++ b/packages/server/src/arpa_reporter/environment.js
@@ -11,6 +11,7 @@ const VERBOSE = Boolean(process.env.VERBOSE)
 const POSTGRES_URL = process.env.POSTGRES_URL
 
 const DATA_DIR = resolve(process.env.DATA_DIR)
+const TEMP_DIR = join(DATA_DIR, 'tmp')
 const UPLOAD_DIR = join(DATA_DIR, 'uploads')
 const PERIOD_TEMPLATES_DIR = join(UPLOAD_DIR, 'period_templates')
 
@@ -46,6 +47,7 @@ const LOGIN_WARNING_MESSAGE = process.env.LOGIN_WARNING_MESSAGE
 
 module.exports = {
   DATA_DIR,
+  TEMP_DIR,
   UPLOAD_DIR,
   PERIOD_TEMPLATES_DIR,
   SERVER_CODE_DIR,

--- a/packages/server/src/arpa_reporter/services/persist-upload.js
+++ b/packages/server/src/arpa_reporter/services/persist-upload.js
@@ -23,7 +23,7 @@ const uploadFSName = (upload) => {
 
 const jsonFSName = (upload) => {
   const filename = `${upload.id}.json`
-  return path.join(TEMP_DIR, filename)
+  return path.join(TEMP_DIR, upload.id[0], filename)
 }
 
 async function persistUpload ({ filename, user, buffer }) {
@@ -47,12 +47,9 @@ async function persistUpload ({ filename, user, buffer }) {
 
   // persist the original upload to the filesystem
   try {
-    await fs.mkdir(UPLOAD_DIR, { recursive: true })
-    await fs.writeFile(
-      uploadFSName(upload),
-      buffer,
-      { flag: 'wx' }
-    )
+    const filename = uploadFSName(upload)
+    await fs.mkdir(path.dirname(filename), { recursive: true })
+    await fs.writeFile(filename, buffer, { flag: 'wx' })
   } catch (e) {
     throw new ValidationError(`Cannot persist ${upload.filename} to filesystem: ${e}`)
   }
@@ -64,12 +61,9 @@ async function persistUpload ({ filename, user, buffer }) {
 async function persistJson (upload, workbook) {
   // persist the parsed JSON from an upload to the filesystem
   try {
-    await fs.mkdir(TEMP_DIR, { recursive: true })
-    await fs.writeFile(
-      jsonFSName(upload),
-      Cryo.stringify(workbook),
-      { flag: 'wx' }
-    )
+    const filename = jsonFSName(upload)
+    await fs.mkdir(path.dirname(filename), { recursive: true })
+    await fs.writeFile(filename, Cryo.stringify(workbook), { flag: 'wx' })
   } catch (e) {
     throw new ValidationError(`Cannot persist ${upload.filename} to filesystem: ${e}`)
   }

--- a/packages/server/src/arpa_reporter/services/persist-upload.js
+++ b/packages/server/src/arpa_reporter/services/persist-upload.js
@@ -1,7 +1,7 @@
 /* eslint camelcase: 0 */
 
 const path = require('path')
-const { mkdir, writeFile, readFile } = require('fs/promises')
+const fs = require('fs/promises')
 
 const Cryo = require('cryo')
 const XLSX = require('xlsx')
@@ -47,8 +47,8 @@ async function persistUpload ({ filename, user, buffer }) {
 
   // persist the original upload to the filesystem
   try {
-    await mkdir(UPLOAD_DIR, { recursive: true })
-    await writeFile(
+    await fs.mkdir(UPLOAD_DIR, { recursive: true })
+    await fs.writeFile(
       uploadFSName(upload),
       buffer,
       { flag: 'wx' }
@@ -64,8 +64,8 @@ async function persistUpload ({ filename, user, buffer }) {
 async function persistJson (upload, workbook) {
   // persist the parsed JSON from an upload to the filesystem
   try {
-    await mkdir(TEMP_DIR, { recursive: true })
-    await writeFile(
+    await fs.mkdir(TEMP_DIR, { recursive: true })
+    await fs.writeFile(
       jsonFSName(upload),
       Cryo.stringify(workbook),
       { flag: 'wx' }
@@ -76,11 +76,11 @@ async function persistJson (upload, workbook) {
 }
 
 async function bufferForUpload (upload) {
-  return readFile(uploadFSName(upload))
+  return fs.readFile(uploadFSName(upload))
 }
 
 async function jsonForUpload (upload) {
-  return Cryo.parse(await readFile(jsonFSName(upload), {encoding: 'utf-8'}))
+  return Cryo.parse(await fs.readFile(jsonFSName(upload), {encoding: 'utf-8'}))
 }
 
 /**
@@ -118,7 +118,13 @@ async function workbookForUpload (upload, options) {
 module.exports = {
   persistUpload,
   workbookForUpload,
-  uploadFSName
+  uploadFSName,
+
+  // exported for test purposes only!
+  _uploadFSName: uploadFSName,
+  _jsonFSName: jsonFSName,
+  _persistJson: persistJson,
+  _jsonForUpload: jsonForUpload,
 }
 
 // NOTE: This file was copied from src/server/services/persist-upload.js (git @ ada8bfdc98) in the arpa-reporter repo on 2022-09-23T20:05:47.735Z

--- a/packages/server/src/arpa_reporter/services/records.js
+++ b/packages/server/src/arpa_reporter/services/records.js
@@ -1,7 +1,7 @@
 const XLSX = require('xlsx')
 const { merge } = require('lodash')
 
-const { bufferForUpload } = require('./persist-upload')
+const { workbookForUpload } = require('./persist-upload')
 const { getPreviousReportingPeriods } = require('../db/reporting-periods')
 const { usedForTreasuryExport } = require('../db/uploads')
 const { log } = require('../lib/log')
@@ -62,8 +62,11 @@ async function loadRecordsForUpload (upload) {
 
   const rules = getRules()
 
-  const buffer = await bufferForUpload(upload)
-  const workbook = XLSX.read(buffer, {
+
+  // NOTE: workbookForUpload relies on a disk cache for optimization.
+  // If you change any of the below parsing parameters, you will need to
+  // clear the server's TEMP_DIR folder to ensure they take effect.
+  const workbook = await workbookForUpload(upload, {
     cellDates: true,
     type: 'buffer',
     sheets: [CERTIFICATION_SHEET, COVER_SHEET, LOGIC_SHEET, ...Object.keys(DATA_SHEET_TYPES)]

--- a/yarn.lock
+++ b/yarn.lock
@@ -5892,6 +5892,11 @@ cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
+cryo@0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/cryo/-/cryo-0.0.6.tgz#16833295d2ee16ff39711db840617b7ae4af0ba4"
+  integrity sha512-vSbO1hJvP9oOGXcKHiAj3U37rtErI8jIZ8gOp8EfiQgPncAv6nc4JArGWzqrxlwA5xe6Sph5OUAg//7yqTOyIg==
+
 crypto-random-string@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-2.0.0.tgz#ef2a7a966ec11083388369baa02ebead229b30d5"


### PR DESCRIPTION
### Ticket #832

NOTE: This re-introduces #842.

### Description

Audit report generation has been getting progressively slower, as we need to process more and more upload workbooks to produce the desired report.

The motivating idea behind this approach is that the single slowest part of audit report generation is not the logic, formatting or even disk access.  It is the `XLSX.read` operation.

Short of digging into this third party code, a minimally invasive way to optimise this expensive step is to introduce a cache layer.

Each upload, parsed as JSON is about a megabyte in size.  Our production ARPA tool manages about 1000 uploads today.  That's a little more data than I think we should be comfortable holding in RAM.  We could persist this cached content in our database, but parsing and printing JSON into a database involves overhead and adds load to the DB service.

In this diff, I try a relatively naive disk cache instead.  This mirrors the way we handle the original .xlsm upload content today.

Operationally, the impact of this diff is:
- No DB migrations required (now or in the future)
- No manual scripts required to populate cache
- Changes to the audit report or record parsing logic do not require manual intervention
- Cache will need to be flushed if and only if we change the parsing options passed to `XLSX.read`.
- To flush the cache: wipe the TEMP_DIR folder from the deployment's disk instance

This pull request is an alternative approach to #833.  We should land one or the other (not both)!

### Screenshots / Demo Video

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/11449340/213626377-88e62b19-5b1d-4054-a59e-841e2260ecc3.png">

### Testing

To test:
- check out branch
- `yarn install`
- `yarn start`
- Set `VERBOSE=true` in your .env file
- Upload at least one valid workbook, if none present in your instance
- Click the "Download audit report" button on the home screen
- Verify that subsequent downloads are faster, and verbose console logs indicate expected cache usage

### Checklist
- [x] Provided ticket and description
- [x] Your PR title contains the ISSUE ticket number e.g "86: ..."
- [x] Provided screenshots/demo
- [x] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Run automated tests (docker compose exec app yarn test)
- [x] Added PR reviewers
- [ ] Ensure at least 1 review before merging
