### PR TITLE
fix: ECONNREFUSED for app in docker compose (944)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,8 @@ services:
       - "yarn"
       - "debug:server"
     depends_on:
-      - postgres
+      postgres:
+        condition: service_healthy
     env_file:
       - ./packages/server/.env
 
@@ -58,6 +59,10 @@ services:
       - ./docker/postgres/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d
       - ./docker/postgres/docker-entrypoint-preinitdb.d:/docker-entrypoint-preinitdb.d
       # - ./docker/postgres/persistence:/bitnami/postgresql
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "postgres"]
+      interval: 10s
+      start_period: 30s
 
 networks:
   app:


### PR DESCRIPTION
### Ticket #
#944 

### Description
Fixes a race condition in our docker compose setup, whereby the app can attempt to connect to the db before it has been fully initialized. This change sets us up to wait for the database to actually be ready before attempting to connect.

More about this approach [here](https://docs.docker.com/compose/compose-file/#long-syntax-1) and [here](https://www.postgresql.org/docs/current/app-pg-isready.html)

### Screenshots / Demo Video
N/A

### Testing
Ran regular tests

### Checklist
- [x] Provided ticket and description
- [x] Your PR title contains the ISSUE ticket number e.g "86: ..."
- [x] Provided screenshots/demo
- [x] Provided testing information
- [x] Provided adequate test coverage for all new code
- [x] Run automated tests (docker compose exec app yarn test)
- [x] Added PR reviewers
- [ ] Ensure at least 1 review before merging
