### PR TITLE
951 fix bug with empty emails when there are fewer than 2 new grants

### DIFF
--- a/packages/server/__tests__/email/email.test.js
+++ b/packages/server/__tests__/email/email.test.js
@@ -351,5 +351,25 @@ describe('Email sender', () => {
 
             expect(sendFake.calledTwice).to.equal(true);
         });
+        it('builds all the grants if fewer than 3 available', async () => {
+            const agencies = await db.getAgency(fixtures.agencies.accountancy.id);
+            const agency = agencies[0];
+            agency.matched_grants = [fixtures.grants.healthAide];
+            const body = await email.buildDigestBody({ agency });
+            expect(body).to.include(fixtures.grants.healthAide.description);
+        });
+        it('builds only first 3 grants if >3 available', async () => {
+            const agencies = await db.getAgency(fixtures.agencies.accountancy.id);
+            const agency = agencies[0];
+            const ignoredGrant = { ...fixtures.grants.healthAide };
+            ignoredGrant.description = 'Added a brand new description';
+
+            agency.matched_grants = [fixtures.grants.healthAide, fixtures.grants.earFellowship, fixtures.grants.redefiningPossible, ignoredGrant];
+            const body = await email.buildDigestBody({ agency });
+            expect(body).to.include(fixtures.grants.healthAide.description);
+            expect(body).to.include(fixtures.grants.earFellowship.description);
+            expect(body).to.include(fixtures.grants.redefiningPossible.description);
+            expect(body).to.not.include(ignoredGrant.description);
+        });
     });
 });

--- a/packages/server/src/lib/email.js
+++ b/packages/server/src/lib/email.js
@@ -186,19 +186,8 @@ async function sendGrantAssignedEmail({ grantId, agencyIds, userId }) {
     agencies.forEach((agency) => module.exports.sendGrantAssignedNotficationForAgency(agency, grantDetail, userId));
 }
 
-async function sendGrantDigestForAgency(data) {
-    const { agency, openDate } = data;
-    console.log(`${agency.name} is subscribed for notifications on ${openDate}`);
-
-    if (!agency.matched_grants || agency.matched_grants?.length === 0) {
-        console.error(`There were no grants available for ${agency.name}`);
-        return;
-    }
-
-    if (!agency.recipients || agency.recipients?.length === 0) {
-        console.error(`There were no email recipients available for ${agency.name}`);
-        return;
-    }
+async function buildDigestBody(data) {
+    const { agency } = data;
 
     const grantDetails = [];
     agency.matched_grants.slice(0, 3).forEach((grant) => grantDetails.push(module.exports.getGrantDetail(grant, notificationType.grantDigest)));
@@ -219,6 +208,25 @@ async function sendGrantDigestForAgency(data) {
         body_detail: `There are ${agency.matched_grants.length} new grants matching your agency's keywords and settings.`,
         additional_body: additionalBody,
     });
+
+    return formattedBody;
+}
+
+async function sendGrantDigestForAgency(data) {
+    const { agency, openDate } = data;
+    console.log(`${agency.name} is subscribed for notifications on ${openDate}`);
+
+    if (!agency.matched_grants || agency.matched_grants?.length === 0) {
+        console.error(`There were no grants available for ${agency.name}`);
+        return;
+    }
+
+    if (!agency.recipients || agency.recipients?.length === 0) {
+        console.error(`There were no email recipients available for ${agency.name}`);
+        return;
+    }
+
+    const formattedBody = await buildDigestBody({ agency });
 
     const emailHTML = module.exports.addBaseBranding(formattedBody, {
         tool_name: 'Grants Identification Tool',
@@ -268,4 +276,5 @@ module.exports = {
     sendGrantDigestForAgency,
     getGrantDetail,
     addBaseBranding,
+    buildDigestBody,
 };

--- a/packages/server/src/lib/email.js
+++ b/packages/server/src/lib/email.js
@@ -201,7 +201,7 @@ async function sendGrantDigestForAgency(data) {
     }
 
     const grantDetails = [];
-    agency.matched_grants.slice(2).forEach((grant) => grantDetails.push(module.exports.getGrantDetail(grant, notificationType.grantDigest)));
+    agency.matched_grants.slice(0, 2).forEach((grant) => grantDetails.push(module.exports.getGrantDetail(grant, notificationType.grantDigest)));
 
     const formattedBodyTemplate = fileSystem.readFileSync(path.join(__dirname, '../static/email_templates/_formatted_body.html'));
     const contentSpacerTemplate = fileSystem.readFileSync(path.join(__dirname, '../static/email_templates/_content_spacer.html'));

--- a/packages/server/src/lib/email.js
+++ b/packages/server/src/lib/email.js
@@ -201,7 +201,7 @@ async function sendGrantDigestForAgency(data) {
     }
 
     const grantDetails = [];
-    agency.matched_grants.slice(0, 2).forEach((grant) => grantDetails.push(module.exports.getGrantDetail(grant, notificationType.grantDigest)));
+    agency.matched_grants.slice(0, 3).forEach((grant) => grantDetails.push(module.exports.getGrantDetail(grant, notificationType.grantDigest)));
 
     const formattedBodyTemplate = fileSystem.readFileSync(path.join(__dirname, '../static/email_templates/_formatted_body.html'));
     const contentSpacerTemplate = fileSystem.readFileSync(path.join(__dirname, '../static/email_templates/_content_spacer.html'));


### PR DESCRIPTION
### Ticket #951 

### Description
The code was initially ignoring the first two grants and building the email for the remaining. However, the logic should have been to ignore any grant beyond the first 3.

This bug was caused by a mistake in array slicing.

### Screenshots / Demo Video
N/A

### Testing
- Added unit tests

### Checklist
- [x] Provided ticket and description
- [x] Your PR title contains the ISSUE ticket number e.g "86: ..."
- [x] Provided screenshots/demo
- [x] Provided testing information
- [x] Provided adequate test coverage for all new code
- [x] Run automated tests (docker compose exec app yarn test)
- [x] Added PR reviewers
- [ ] Ensure at least 1 review before merging
