### PR TITLE
fix: bug with user preferences not being honored

### DIFF
--- a/packages/server/__tests__/db/db.test.js
+++ b/packages/server/__tests__/db/db.test.js
@@ -225,9 +225,18 @@ describe('db', () => {
             /* ensure that admin user is subscribed to all notifications */
             await db.setUserEmailSubscriptionPreference(fixtures.users.adminUser.id, fixtures.users.adminUser.agency_id);
 
+            /* ensure that staff user is not subscribed to any notifications */
+            const emailUnsubscribePreference = Object.assign(
+                ...Object.values(emailConstants.notificationType).map(
+                    (k) => ({ [k]: emailConstants.emailSubscriptionStatus.unsubscribed }),
+                ),
+            );
+            await db.setUserEmailSubscriptionPreference(fixtures.users.staffUser.id, fixtures.users.staffUser.agency_id, emailUnsubscribePreference);
+
             const result = await db.getAgenciesSubscribedToDigest();
             expect(result.length).to.equal(1);
             expect(result[0].name).to.equal('State Board of Accountancy');
+            expect(result[0].recipients.length).to.equal(1);
 
             await knex('email_subscriptions').del();
         });

--- a/packages/server/__tests__/db/db.test.js
+++ b/packages/server/__tests__/db/db.test.js
@@ -222,9 +222,14 @@ describe('db', () => {
             this.clock.restore();
         });
         it('returns agencies with keywords and eligibility codes setup', async () => {
+            /* ensure that admin user is subscribed to all notifications */
+            await db.setUserEmailSubscriptionPreference(fixtures.users.adminUser.id, fixtures.users.adminUser.agency_id);
+
             const result = await db.getAgenciesSubscribedToDigest();
             expect(result.length).to.equal(1);
             expect(result[0].name).to.equal('State Board of Accountancy');
+
+            await knex('email_subscriptions').del();
         });
     });
 

--- a/packages/server/__tests__/db/db.test.js
+++ b/packages/server/__tests__/db/db.test.js
@@ -237,6 +237,7 @@ describe('db', () => {
             expect(result.length).to.equal(1);
             expect(result[0].name).to.equal('State Board of Accountancy');
             expect(result[0].recipients.length).to.equal(1);
+            expect(result[0].recipients[0]).to.equal(fixtures.users.adminUser.email);
 
             await knex('email_subscriptions').del();
         });

--- a/packages/server/src/db/index.js
+++ b/packages/server/src/db/index.js
@@ -714,6 +714,9 @@ async function getAgenciesSubscribedToDigest(asOf) {
                 AND aec.enabled = TRUE
             JOIN keywords k ON k.agency_id = a.id
             JOIN users u ON u.agency_id = a.id
+            JOIN email_subscriptions es ON es.user_id = u.id
+                AND es.notification_type = '${emailConstants.notificationType.grantDigest}'
+                AND es.status = '${emailConstants.emailSubscriptionStatus.subscribed}'
         GROUP BY
             a.id
         )


### PR DESCRIPTION
### Ticket #986 

### Description
- When I opted to use a more efficient query, I did not take into account a user's email subscription preference. This has caused emails to go out erroneously to users that had previously unsubscribed.

### Screenshots / Demo Video
N/A

### Testing
- Added better unit test coverage

### Checklist
- [x] Provided ticket and description
- [x] Your PR title contains the ISSUE ticket number e.g "86: ..."
- [x] Provided screenshots/demo
- [x] Provided testing information
- [x] Provided adequate test coverage for all new code
- [x] Run automated tests (docker compose exec app yarn test)
- [x] Added PR reviewers
- [x] Ensure at least 1 review before merging
