### PR TITLE
609: Fix #977

### DIFF
--- a/.github/workflows/build-api.yml
+++ b/.github/workflows/build-api.yml
@@ -49,7 +49,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: .
-          push: ${{ github.event_name != 'pull_request' && false }}
+          push: ${{ github.event_name != 'pull_request' }}
           file: docker/production-api.Dockerfile
           tags: ${{ steps.meta.outputs.tags }}
           platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
### Ticket #609

### Description

A bug in the "Build Docker image for GOST API" workflow was introduced in #977. To prevent test runs from publishing Docker images, the "Build and push Docker image" job's conditional `if` check had been modified to always evaluate to `false`, which was not changed back prior to deployment.

To fix, this PR removes the part of the  expression that was added for debugging, which reenables the intended behavior of pushing Docker images unless the workflow was triggered by a pull request.

### Screenshots / Demo Video

### Testing

### Checklist
- [X] Provided ticket and description
- [X] Your PR title contains the ISSUE ticket number e.g "86: ..."
- [ ] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Run automated tests (docker compose exec app yarn test)
- [ ] Added PR reviewers
- [ ] Ensure at least 1 review before merging
