### PR TITLE
INFRA: Prep (new) staging for dns cutover

### DIFF
--- a/terraform/staging.tfvars
+++ b/terraform/staging.tfvars
@@ -6,7 +6,7 @@ ssm_deployment_parameters_path_prefix = "/gost/staging/deploy-config"
 
 // Website
 website_enabled     = true
-website_domain_name = "staging2.grants.usdigitalresponse.org"
+website_domain_name = "staging.grants.usdigitalresponse.org"
 
 // ECS Cluster
 cluster_container_insights_enabled = true

--- a/terraform/staging.tfvars
+++ b/terraform/staging.tfvars
@@ -13,7 +13,7 @@ cluster_container_insights_enabled = true
 
 // API / Backend
 api_enabled                    = true
-api_domain_name                = "api.staging2.grants.usdigitalresponse.org"
+api_domain_name                = "api.staging.grants.usdigitalresponse.org"
 api_container_image_tag        = "latest"
 api_default_desired_task_count = 1
 api_enable_grants_scraper      = true


### PR DESCRIPTION
### Ticket #609 
## Description

This PR prepares the new staging environment for DNS cutover.

Background: The AWS staging environment created a few months ago is hosted at `staging.grants.usdigitalresponse.org`. In preparation for further (production) migrations, a new staging environment was created to test the migration path (in this case, from "old staging" to "new staging"). Until now, the new staging environment, which is already managed by terraform in this repository, has been hosted at `staging2.grants.usdigitalresponse.org`. The changes in this PR updates references to  API and website hostnames so that they reside under `staging.grants.usdigitalresponse.org`. 

The net result of merging this PR is that both old and new staging environments are configured to host resources under `staging.grants.usdigitalresponse.org`. Once that is the case, the "core" maintainer of `grants.usdigitalresponse.org` (managed outside of this repo) can be updated to "flip the switch" and direct DNS resolution to either environment. The last step (also out of band) will be to update the core maintainer so that the the new staging environment is active under `staging.grants.usdigitalresponse.org`. You can see the effective DNS resolution path illustrated in the diagram below.

## Screenshots / Demo Video

![DNS Cutover - Copy of Page 1](https://user-images.githubusercontent.com/1851017/220744069-2f681681-dcd6-4f9a-a761-3da4aed3729d.png)

## Testing

See the [migration guide](https://docs.google.com/document/d/1GegFE47CNUgtZ16ZZ6lywBRw9VJlG1j6sNs6mHD2rEo/edit#heading=h.qxrjukh76zxp).

### Automated and Unit Tests
- ~~[ ] Added Unit tests~~ N/A

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [X] Provided ticket and description
- [X] Provided screenshots/demo N/A
- [X] Provided testing information
- [X] Provided adequate test coverage for all new code
- [X] Added PR reviewers

