### PR TITLE
fix: ensure users without preferences are subscribed

### DIFF
--- a/packages/server/__tests__/db/db.test.js
+++ b/packages/server/__tests__/db/db.test.js
@@ -221,10 +221,27 @@ describe('db', () => {
         afterEach(() => {
             this.clock.restore();
         });
-        it('returns agencies with keywords and eligibility codes setup', async () => {
+        it('returns agencies with keywords and eligibility codes setup with explicit subscriptions setup', async () => {
             /* ensure that admin user is subscribed to all notifications */
             await db.setUserEmailSubscriptionPreference(fixtures.users.adminUser.id, fixtures.users.adminUser.agency_id);
 
+            /* ensure that staff user is not subscribed to any notifications */
+            const emailUnsubscribePreference = Object.assign(
+                ...Object.values(emailConstants.notificationType).map(
+                    (k) => ({ [k]: emailConstants.emailSubscriptionStatus.unsubscribed }),
+                ),
+            );
+            await db.setUserEmailSubscriptionPreference(fixtures.users.staffUser.id, fixtures.users.staffUser.agency_id, emailUnsubscribePreference);
+
+            const result = await db.getAgenciesSubscribedToDigest();
+            expect(result.length).to.equal(1);
+            expect(result[0].name).to.equal('State Board of Accountancy');
+            expect(result[0].recipients.length).to.equal(1);
+            expect(result[0].recipients[0]).to.equal(fixtures.users.adminUser.email);
+
+            await knex('email_subscriptions').del();
+        });
+        it('returns agencies with keywords and eligibility codes setup with default subscribed', async () => {
             /* ensure that staff user is not subscribed to any notifications */
             const emailUnsubscribePreference = Object.assign(
                 ...Object.values(emailConstants.notificationType).map(

--- a/packages/server/src/db/index.js
+++ b/packages/server/src/db/index.js
@@ -714,9 +714,12 @@ async function getAgenciesSubscribedToDigest(asOf) {
                 AND aec.enabled = TRUE
             JOIN keywords k ON k.agency_id = a.id
             JOIN users u ON u.agency_id = a.id
-            JOIN email_subscriptions es ON es.user_id = u.id
+            LEFT JOIN email_subscriptions es ON es.user_id = u.id
                 AND es.notification_type = '${emailConstants.notificationType.grantDigest}'
-                AND es.status = '${emailConstants.emailSubscriptionStatus.subscribed}'
+            WHERE (
+                es.status = '${emailConstants.emailSubscriptionStatus.subscribed}'
+                OR es.status is NULL
+            )
         GROUP BY
             a.id
         )


### PR DESCRIPTION
### Ticket #1008 
## Description
This PR updates the query to use a `LEFT JOIN` instead of a `JOIN` since there is a chance that a `email_subscription` record does not exist for the vast majority of users.

## Screenshots / Demo Video
N/A

## Testing
### Automated and Unit Tests
- [x] Added Unit tests

### Manual tests for Reviewer
- [x] Added steps to test feature/functionality manually

To test this manually
- Pull branch down locally
- Run the following queries on your database (Note you can do most of this on the dashboard as well. I have denoted those tasks that have a UI by putting a [UI] prefix on them.)
  - [UI] Pick a user you want to send email to `select * from users;`
  - [UI] `delete from email_subscriptions where user_id = <your_user_id>;`
  - `select * from grants limit 5` and pick a grand you want to update.
  - Delete all agency's keywords `delete from keywords where agency_id = <your_users_agency_id>;`
  - Ensure there is one keyword setup`insert into keywords (search_term, agency_id, type) values ('my_keyword', <your_users_agency_id>, 'include');`
  -  Ensure there is at least one grant that was opened yesterday that matches your keyword - `update grants set open_date = '2023-02-22' and description = concat('my_keyword',' ',description) where id = <pick a grant>;`
  - Ensure all eligibility codes are acceptable: `delete from agency_eligibility_codes where agency_id = <your_users_agency_id>;`
- Ensure all users' email address in the agency you have picked belong to you so you do not send any emails to other team members `select * from users where agency_id = <your_users_agency_id>;`
- If you find that there are users that should not receive an email then either update their email address or login to the dashboard and unsubscribe them.
- Run the email digest locally from node shell (`cd packages/server/src` `node`)

```js
const emailService = require('./lib/email');
/*
Note - this may make every user in your local database to receive an email.
If you do not want these users to receive an email, then update these emails to a version of your personal email
*/
await emailService.buildAndSendGrantDigest();
```
 
## Checklist
- [x] Provided ticket and description
- [x] Provided screenshots/demo
- [x] Provided testing information
- [x] Provided adequate test coverage for all new code
- [x] Added PR reviewers