### PR TITLE
feat: adds script to unsubscribe users

### DIFF
--- a/packages/server/src/scripts/one-off/unsubscribe_users.js
+++ b/packages/server/src/scripts/one-off/unsubscribe_users.js
@@ -1,0 +1,45 @@
+/* eslint-disable */
+
+const knex = require('./src/db/connection');
+const db = require('./src/db');
+const emailConstants = require('./src/lib/email/constants');
+
+async function unsubscribeUsers(users) {
+    const emailUnsubscribePreference = Object.assign(
+        ...Object.values(emailConstants.notificationType).map(
+            (k) => ({ [k]: emailConstants.emailSubscriptionStatus.unsubscribed }),
+        ),
+    );
+
+    for (const user of users) {
+        console.log(`Unsubscribing user for emails ${user.id} ${user.email} ${user.agency_id}`);
+        await db.setUserEmailSubscriptionPreference(user.id, user.agency_id, emailUnsubscribePreference);
+    }
+}
+
+async function beginUnsubscription(tenantName, emailsToIgnore=[]) {
+    const tenant = await knex('tenants')
+        .select('id')
+        .where('display_name', '=', tenantName);
+
+    const agencies = await knex('agencies')
+        .select('id', 'name')
+        .where('tenant_id', '=', tenant[0].id);
+
+    const usersToUnsubscribe = [];
+
+    for (const agency of agencies) {
+        const users = await db.getUsersByAgency(agency.id);
+
+        for (const user of users) {
+            if (emailsToIgnore.includes(user.email)) {
+                continue;
+            } else {
+                usersToUnsubscribe.push(user);
+            }
+        }
+    };
+    await unsubscribeUsers(usersToUnsubscribe);
+}
+
+module.exports = { beginUnsubscription, unsubscribeUsers };


### PR DESCRIPTION
### Ticket #1014 
## Description
- This script was already run in production. I'm committing it so we have a record for the future.

## Screenshots / Demo Video
N/A

## Testing
### Automated and Unit Tests
- [ ] Added Unit tests
Not ideal, but I already ran this script in production by testing it manually in my local environment due to necessity of running this script.

### Manual tests for Reviewer
- [x] Added steps to test feature/functionality manually

```
> node
> const { beginUnsubscription } = require('./src/scripts/one-off/unsubscribe_users');
> await beginUnsubscription('USDR', ['youremail@yourhost.com']);

/* Confirm that all users are unsubscribed by querying the database except for your user */
select u.email, es.status, es.notification_type
from email_subscriptions es
join users u on u.id = es.user_id
join tenants t on t.id = u.tenant_id and t.name = 'USDR'
order by u.email, es.notification_type;
```

## Checklist
- [x] Provided ticket and description
- [ ] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [x] Added PR reviewers