### PR TITLE
Reconfigure domains for sandbox and staging

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -24,6 +24,7 @@ data "aws_ssm_parameter" "private_subnet_ids" {
 locals {
   private_subnet_ids       = split(",", data.aws_ssm_parameter.private_subnet_ids.value)
   permissions_boundary_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/${var.permissions_boundary_policy_name}"
+  api_domain_name          = coalesce(var.api_domain_name, "api.${var.website_domain_name}")
 }
 
 
@@ -39,7 +40,7 @@ module "website" {
 
   dns_zone_id     = data.aws_ssm_parameter.public_dns_zone_id.value
   domain_name     = var.website_domain_name
-  gost_api_domain = var.api_domain_name
+  gost_api_domain = local.api_domain_name
 }
 
 module "api_to_postgres_security_group" {
@@ -100,7 +101,7 @@ module "api" {
   enable_grants_scraper      = var.api_enable_grants_scraper
 
   # DNS
-  domain_name         = var.api_domain_name
+  domain_name         = local.api_domain_name
   dns_zone_id         = data.aws_ssm_parameter.public_dns_zone_id.value
   website_domain_name = var.website_domain_name
 

--- a/terraform/sandbox.tfvars
+++ b/terraform/sandbox.tfvars
@@ -6,7 +6,7 @@ ssm_deployment_parameters_path_prefix = "/gost/sandbox/deploy-config"
 
 // Website
 website_enabled     = true
-website_domain_name = "sandbox-grants.usdigitalresponse.org"
+website_domain_name = "sandbox.grants.usdr.dev"
 
 // ECS Cluster
 cluster_container_insights_enabled = false

--- a/terraform/sandbox.tfvars
+++ b/terraform/sandbox.tfvars
@@ -6,14 +6,13 @@ ssm_deployment_parameters_path_prefix = "/gost/sandbox/deploy-config"
 
 // Website
 website_enabled     = true
-website_domain_name = "sandbox.grants.usdigitalresponse.org"
+website_domain_name = "sandbox-grants.usdigitalresponse.org"
 
 // ECS Cluster
 cluster_container_insights_enabled = false
 
 // API / Backend
 api_enabled                    = true
-api_domain_name                = "api.sandbox.grants.usdigitalresponse.org"
 api_container_image_tag        = "latest"
 api_default_desired_task_count = 1
 api_enable_grants_scraper      = false

--- a/terraform/staging.tfvars
+++ b/terraform/staging.tfvars
@@ -6,14 +6,13 @@ ssm_deployment_parameters_path_prefix = "/gost/staging/deploy-config"
 
 // Website
 website_enabled     = true
-website_domain_name = "staging.grants.usdigitalresponse.org"
+website_domain_name = "staging-grants.usdigitalresponse.org"
 
 // ECS Cluster
 cluster_container_insights_enabled = true
 
 // API / Backend
 api_enabled                    = true
-api_domain_name                = "api.staging.grants.usdigitalresponse.org"
 api_container_image_tag        = "latest"
 api_default_desired_task_count = 1
 api_enable_grants_scraper      = true

--- a/terraform/staging.tfvars
+++ b/terraform/staging.tfvars
@@ -6,7 +6,7 @@ ssm_deployment_parameters_path_prefix = "/gost/staging/deploy-config"
 
 // Website
 website_enabled     = true
-website_domain_name = "staging-grants.usdigitalresponse.org"
+website_domain_name = "staging.grants.usdr.dev"
 
 // ECS Cluster
 cluster_container_insights_enabled = true

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -59,6 +59,7 @@ variable "api_enabled" {
 
 variable "api_domain_name" {
   type = string
+  default = ""
 }
 
 variable "api_container_image_tag" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -58,7 +58,7 @@ variable "api_enabled" {
 }
 
 variable "api_domain_name" {
-  type = string
+  type    = string
   default = ""
 }
 


### PR DESCRIPTION
### Ticket #609 
## Description

This PR updates the configured subdomains for sandbox and staging environments. The new subdomains are:
- Sandbox: `sandbox.grants.usdr.dev`
- Staging: `staging.grants.usdr.dev`

## Screenshots / Demo Video

## Testing

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [X] Provided ticket and description
- [ ] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [X] Added PR reviewers