### PR TITLE
feat: support explicitly setting agency and reporting period in the ARPA Reporter upload api (#895)

### DIFF
--- a/packages/client/src/arpa_reporter/views/NewUpload.vue
+++ b/packages/client/src/arpa_reporter/views/NewUpload.vue
@@ -79,7 +79,7 @@ export default {
 
       // TODO: (#896) Actually include data when submitting
       // formData.append('notes', '<b>TEST & STRING!</b>');
-      // formData.append('reportingPeriodId', '1');
+      // formData.append('reportingPeriodId', '64');
       // formData.append('agencyId', '0');
 
       try {

--- a/packages/client/src/arpa_reporter/views/NewUpload.vue
+++ b/packages/client/src/arpa_reporter/views/NewUpload.vue
@@ -79,6 +79,8 @@ export default {
 
       // TODO: (#896) Actually include data when submitting
       // formData.append('notes', '<b>TEST & STRING!</b>');
+      // formData.append('reportingPeriodId', '1');
+      // formData.append('agencyId', '0');
 
       try {
         const resp = await postForm('/api/uploads', formData);

--- a/packages/server/__tests__/arpa_reporter/server/services/persist-upload.spec.js
+++ b/packages/server/__tests__/arpa_reporter/server/services/persist-upload.spec.js
@@ -63,19 +63,21 @@ describe('persist-upload', () => {
 
     describe('createUploadRow', () => {
         const createUploadRow = persistUploadModule.__get__('createUploadRow');
-
-        it('should create an upload row with escaped notes', async () => {
-            const notes = '<script>alert("xss");</script>';
-            const userId = 1;
-            const reportingPeriodId = 2;
-            const agencyId = 2;
-            const uploadRow = await createUploadRow('filename.xlsx', reportingPeriodId, userId, agencyId, notes);
+        it('should create an upload row with expected properties', async () => {
+            const uploadData = {
+                filename: 'test.xlsx',
+                reportingPeriodId: 2,
+                userId: 1,
+                agencyId: 2,
+                notes: 'notes',
+            };
+            const uploadRow = await createUploadRow(uploadData);
             expect(uploadRow).to.deep.equal({
-                filename: 'filename.xlsx',
+                filename: 'test.xlsx',
                 reporting_period_id: 2,
                 user_id: 1,
                 agency_id: 2,
-                notes: '<script>alert("xss");</script>',
+                notes: 'notes',
             });
         });
     });

--- a/packages/server/__tests__/arpa_reporter/server/services/persist-upload.spec.js
+++ b/packages/server/__tests__/arpa_reporter/server/services/persist-upload.spec.js
@@ -7,86 +7,17 @@ const XLSX = require('xlsx');
 const ValidationError = require('../../../../src/arpa_reporter/lib/validation-error');
 const { UPLOAD_DIR } = require('../../../../src/arpa_reporter/environment');
 
-const persistUpload = rewire('../../../../src/arpa_reporter/services/persist-upload');
+const persistUploadModule = rewire('../../../../src/arpa_reporter/services/persist-upload');
 
 // These are used in multiple places
-const jsonFSName = persistUpload.__get__('jsonFSName');
-const persistJson = persistUpload.__get__('persistJson');
-const uploadFSName = persistUpload.__get__('uploadFSName');
+const jsonFSName = persistUploadModule.__get__('jsonFSName');
+const persistJson = persistUploadModule.__get__('persistJson');
+const uploadFSName = persistUploadModule.__get__('uploadFSName');
 
 const MOCK_WORKBOOK = XLSX.utils.book_new();
 XLSX.utils.book_append_sheet(MOCK_WORKBOOK, XLSX.utils.aoa_to_sheet([[0, 1, 2]]), 'sheet_1');
 
 describe('persist-upload', () => {
-    describe('validateBuffer', () => {
-        const validateBuffer = persistUpload.__get__('validateBuffer');
-
-        it('should return true for a valid excel file', async () => {
-            const buffer = await fs.readFile(path.join(__dirname, '../fixtures/arpa-examples/OBM01-768622-09302020-v20220320.xlsm'));
-            const result = await validateBuffer(buffer);
-            expect(result).not.to.throw;
-        });
-
-        it('should throw an error for an invalid buffer', async () => {
-            const buffer = Buffer.from([0x01]);
-            expect(validateBuffer(buffer)).to.throw;
-        });
-    });
-
-    describe('createUploadRow', () => {
-        const createUploadRow = persistUpload.__get__('createUploadRow');
-
-        it('should create an upload row with escaped notes', async () => {
-            const body = { notes: '<script>alert("xss");</script>' };
-            const user = { id: 1 };
-            const reportingPeriod = { id: 2 };
-            const uploadRow = await createUploadRow('filename.xlsx', reportingPeriod, user, body);
-            expect(uploadRow.filename).to.equal('filename.xlsx');
-            expect(uploadRow.reporting_period_id).to.equal(2);
-            expect(uploadRow.user_id).to.equal(1);
-            expect(uploadRow.notes).to.equal('&lt;script&gt;alert(&quot;xss&quot;);&lt;/script&gt;');
-        });
-    });
-
-    describe('persistUploadToFS', () => {
-        const persistUploadToFS = persistUpload.__get__('persistUploadToFS');
-        let fsMock;
-        const filename = 'test.xlsx';
-        const upload = { filename, id: 1 };
-        const filePath = uploadFSName(upload);
-        const buffer = Buffer.from('test data');
-
-        beforeEach(() => {
-            fsMock = sinon.mock(fs);
-        });
-
-        afterEach(() => {
-            fsMock.restore();
-        });
-
-        it('should write the file to disk', async () => {
-            fsMock.expects('mkdir').once().withArgs(UPLOAD_DIR, { recursive: true }).resolves();
-            fsMock.expects('writeFile').once().withArgs(filePath, buffer, { flag: 'wx' }).resolves();
-
-            await persistUploadToFS(upload, buffer);
-
-            fsMock.verify();
-        });
-
-        it('should throw a ValidationError if an error occurs', async () => {
-            const expectedError = new ValidationError(`Cannot persist ${upload.filename} to filesystem: Error: EEXIST: file already exists`);
-            fsMock.expects('mkdir').throws(new Error('EEXIST: file already exists'));
-
-            try {
-                await persistUploadToFS(upload, buffer);
-                throw new Error('Expected an error to be thrown');
-            } catch (err) {
-                expect(err).to.be.an.instanceof(ValidationError);
-                expect(err.message).to.equal(expectedError.message);
-            }
-        });
-    });
-
     describe('uploadFSName', () => {
         it('generates a filesystem name based on upload ID', () => {
             expect(
@@ -115,8 +46,210 @@ describe('persist-upload', () => {
         });
     });
 
-    describe('persistJson', () => {
+    describe('validateBuffer', () => {
+        const validateBuffer = persistUploadModule.__get__('validateBuffer');
+
+        it('should return true for a valid excel file', async () => {
+            const buffer = await fs.readFile(path.join(__dirname, '../fixtures/arpa-examples/OBM01-768622-09302020-v20220320.xlsm'));
+            const result = await validateBuffer(buffer);
+            expect(result).not.to.throw;
+        });
+
+        it('should throw an error for an invalid buffer', async () => {
+            const buffer = Buffer.from([0x01]);
+            expect(validateBuffer(buffer)).to.throw;
+        });
+    });
+
+    describe('createUploadRow', () => {
+        const createUploadRow = persistUploadModule.__get__('createUploadRow');
+
+        it('should create an upload row with escaped notes', async () => {
+            const notes = '<script>alert("xss");</script>';
+            const userId = 1;
+            const reportingPeriodId = 2;
+            const agencyId = 2;
+            const uploadRow = await createUploadRow('filename.xlsx', reportingPeriodId, userId, agencyId, notes);
+            expect(uploadRow).to.deep.equal({
+                filename: 'filename.xlsx',
+                reporting_period_id: 2,
+                user_id: 1,
+                agency_id: 2,
+                notes: '<script>alert("xss");</script>',
+            });
+        });
+    });
+
+    describe('persistUploadToFS', () => {
+        const persistUploadToFS = persistUploadModule.__get__('persistUploadToFS');
         let fsMock;
+        const filename = 'test.xlsx';
+        const upload = { filename, id: 1 };
+        const filePath = uploadFSName(upload);
+        const buffer = Buffer.from('test data');
+
+        beforeEach(() => {
+            fsMock = sinon.mock(fs);
+        });
+        beforeEach(() => {
+            fsMock = sinon.mock(fs);
+        });
+
+        afterEach(() => {
+            fsMock.restore();
+        });
+        afterEach(() => {
+            fsMock.restore();
+        });
+
+        it('should write the file to disk', async () => {
+            fsMock.expects('mkdir').once().withArgs(UPLOAD_DIR, { recursive: true }).resolves();
+            fsMock.expects('writeFile').once().withArgs(filePath, buffer, { flag: 'wx' }).resolves();
+
+            await persistUploadToFS(upload, buffer);
+
+            fsMock.verify();
+        });
+        it('should write the file to disk', async () => {
+            fsMock.expects('mkdir').once().withArgs(UPLOAD_DIR, { recursive: true }).resolves();
+            fsMock.expects('writeFile').once().withArgs(filePath, buffer, { flag: 'wx' }).resolves();
+
+            await persistUploadToFS(upload, buffer);
+
+            fsMock.verify();
+        });
+
+        it('should throw a ValidationError if an error occurs', async () => {
+            const expectedError = new ValidationError(`Cannot persist ${upload.filename} to filesystem: Error: EEXIST: file already exists`);
+            fsMock.expects('mkdir').throws(new Error('EEXIST: file already exists'));
+
+            try {
+                await persistUploadToFS(upload, buffer);
+                throw new Error('Expected an error to be thrown');
+            } catch (err) {
+                expect(err).to.be.an.instanceof(ValidationError);
+                expect(err.message).to.equal(expectedError.message);
+            }
+        });
+    });
+});
+
+describe('getValidNotes', () => {
+    const getValidNotes = persistUploadModule.__get__('getValidNotes');
+
+    it('should return null if notes is undefined', () => {
+        const notes = undefined;
+        const validNotes = getValidNotes(notes);
+        expect(validNotes).to.equal(null);
+    });
+
+    it('should escape html tags', () => {
+        const notes = '<script>alert("xss");</script>';
+        const validNotes = getValidNotes(notes);
+        expect(validNotes).to.equal('&lt;script&gt;alert(&quot;xss&quot;);&lt;/script&gt;');
+    });
+});
+
+describe('getValidAgencyId', () => {
+    const getValidAgencyId = persistUploadModule.__get__('getValidAgencyId');
+    let sandbox;
+
+    beforeEach(() => {
+        sandbox = sinon.createSandbox();
+    });
+
+    afterEach(() => {
+        sandbox.restore();
+    });
+
+    it('should return null if agencyId is undefined', async () => {
+        const agencyId = undefined;
+        const validAgencyId = await getValidAgencyId(agencyId);
+        expect(validAgencyId).to.equal(null);
+    });
+
+    it('should throw a ValidationError if agencyId is not equal to the user agency', async () => {
+        const agencyId = 1;
+        const userAgencyId = 2;
+        const getUserStub = sandbox.stub().returns({ agency_id: userAgencyId });
+        persistUploadModule.__set__('getUser', getUserStub);
+        try {
+            // eslint-disable-next-line no-unused-vars
+            const validAgencyId = await getValidAgencyId(agencyId, userAgencyId);
+            throw new Error('Expected an error to be thrown');
+        } catch (err) {
+            expect(err).to.be.an.instanceof(ValidationError);
+            expect(err.message).to.equal('Authenticated user (agencyID 2) is not associated with the identified agency 1');
+        }
+    });
+
+    it('should return the agencyId if it is equal to the user agency', async () => {
+        const agencyId = 1;
+        const userAgencyId = 1;
+        const getUserStub = sandbox.stub().returns({ agency_id: userAgencyId });
+        persistUploadModule.__set__('getUser', getUserStub);
+        const validAgencyId = await getValidAgencyId(agencyId, userAgencyId);
+        expect(validAgencyId).to.equal(agencyId);
+    });
+});
+
+describe('getValidReportingPeriodId', () => {
+    const getValidReportingPeriodId = persistUploadModule.__get__('getValidReportingPeriodId');
+    const getReportingPeriod = sinon.stub();
+    persistUploadModule.__set__('getReportingPeriod', getReportingPeriod);
+    let sandbox;
+
+    beforeEach(() => {
+        sandbox = sinon.createSandbox();
+        getReportingPeriod.resetHistory();
+    });
+
+    afterEach(() => {
+        sandbox.restore();
+    });
+
+    it('should fall back to the current reporting period if reportingPeriodId is undefined', async () => {
+        const reportingPeriodId = undefined;
+        const getReportingPeriodStub = sandbox.stub().returns({ id: 1 });
+        persistUploadModule.__set__('getReportingPeriod', getReportingPeriodStub);
+        const validReportingPeriodId = await getValidReportingPeriodId(reportingPeriodId);
+        expect(validReportingPeriodId).to.equal(1);
+    });
+
+    it('should return the ID of the reporting period when it exists', async () => {
+        const reportingPeriod = { id: 123 };
+        getReportingPeriod.resolves(reportingPeriod);
+        persistUploadModule.__set__('getReportingPeriod', getReportingPeriod);
+
+        const result = await getValidReportingPeriodId(reportingPeriod.id);
+
+        expect(getReportingPeriod.calledOnceWith(reportingPeriod.id)).to.be.true;
+        expect(result).to.equal(reportingPeriod.id);
+    });
+
+    it('should throw a ValidationError when the reporting period does not exist', async () => {
+        const reportingPeriodId = 456;
+        getReportingPeriod.resolves(null);
+        persistUploadModule.__set__('getReportingPeriod', getReportingPeriod);
+
+        try {
+            await getValidReportingPeriodId(reportingPeriodId);
+            // The test should fail if the function does not throw an error
+            expect.fail('Expected function to throw an error');
+        } catch (error) {
+            expect(error).to.be.an.instanceOf(ValidationError);
+            expect(error.message).to.equal(`Supplied reporting period ID ${reportingPeriodId} does not correspond to any existing reporting period`);
+            expect(getReportingPeriod.calledOnceWith(reportingPeriodId)).to.be.true;
+        }
+    });
+});
+
+describe('persistJson', () => {
+    let fsMock;
+    beforeEach(() => {
+        fsMock = sinon.mock(fs);
+    });
+    describe('persistJson', () => {
         beforeEach(() => {
             fsMock = sinon.mock(fs);
         });
@@ -135,7 +268,7 @@ describe('persist-upload', () => {
     });
 
     describe('jsonForUpload', () => {
-        const jsonForUpload = persistUpload.__get__('jsonForUpload');
+        const jsonForUpload = persistUploadModule.__get__('jsonForUpload');
 
         it('serializing and deserializing an upload are reversible', async () => {
             const upload = { id: 'abcd', filename: 'upload01.xlsm' };

--- a/packages/server/src/arpa_reporter/services/persist-upload.js
+++ b/packages/server/src/arpa_reporter/services/persist-upload.js
@@ -57,14 +57,14 @@ async function validateBuffer(buffer) {
 
 /**
  * Create Upload row object
- * @param {string} filename
- * @param {object} reportingPeriod
- * @param {string} userId
- * @param {string} agencyId
- * @param {string} notes
+ * @param {object} uploadData
  * @returns {object}
- */
-function createUploadRow(filename, reportingPeriodId, userId, agencyId, notes) {
+*/
+function createUploadRow(uploadData) {
+    const {
+        filename, reportingPeriodId, userId, agencyId, notes,
+    } = uploadData;
+
     return {
         filename: path.basename(filename),
         reporting_period_id: reportingPeriodId,
@@ -175,7 +175,14 @@ async function persistUpload({
     const validatedNotes = getValidNotes(suppliedNotes);
 
     // Create the upload row
-    const uploadRow = createUploadRow(filename, validatedReportingPeriodId, user.id, validatedAgencyId, validatedNotes);
+    const uploadData = {
+        filename,
+        reportingPeriodId: validatedReportingPeriodId,
+        userId: user.id,
+        agencyId: validatedAgencyId,
+        notes: validatedNotes,
+    };
+    const uploadRow = createUploadRow(uploadData);
 
     // Insert the upload row into the database
     const upload = await createUpload(uploadRow);

--- a/packages/server/src/arpa_reporter/services/validate-upload.js
+++ b/packages/server/src/arpa_reporter/services/validate-upload.js
@@ -56,11 +56,21 @@ async function validateAgencyId({ upload, records, trns }) {
         );
     }
 
-    // always set agency id if possible; we omit passing the transaction in this
-    // case, so that the agency id gets set even if the upload fails to validate
-    if (matchingAgency.id !== upload.agency_id) {
-        await setAgencyId(upload.id, matchingAgency.id);
+  // grab agency id from the upload, if it exists
+  const uploadAgencyId = upload.agency_id;
+
+  if (uploadAgencyId == null) {
+    // if the upload doesn't have an agency id, set it to the agency id from the cover sheet
+    await setAgencyId(upload.id, matchingAgency.id);
+  } else {
+    // if the upload already has an agency id, it must match the agency id from the cover sheet
+    if (uploadAgencyId !== matchingAgency.id) {
+      return new ValidationError(
+        `Agency code ${matchingAgency.id} does not match agency id from upload ${uploadAgencyId}`,
+        { tab: 'cover', row: 2, col: 'A' }
+      );
     }
+  }
 }
 
 async function validateEcCode({ upload, records }) {


### PR DESCRIPTION
Backend change to allow setting agency and reporting period in uploads. Not yet populated on the frontend.

DRAFT until I can verify a few scenarios / have a few examples to work against

### Ticket #895
## Description
Adding a simple change to apply the logic from the original ticket when uploading values for agencyId and reportingPeriodId

## Screenshots / Demo Video
N/A, backend only change

## Testing
* Not yet possible to test this, as values are not being populated in the UI, but you should be able to upload workbooks as usual without side effects

### Automated and Unit Tests
- [x] Added Unit tests

### Manual tests for Reviewer
- [x] Added steps to test feature/functionality manually

## Checklist
- [x] Provided ticket and description
- [x] Provided screenshots/demo
- [x] Provided testing information
- [x] Provided adequate test coverage for all new code
- [x] Added PR reviewers