### PR TITLE
Configure terraform for production environment (#1038)

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -24,6 +24,7 @@ data "aws_ssm_parameter" "private_subnet_ids" {
 locals {
   private_subnet_ids       = split(",", data.aws_ssm_parameter.private_subnet_ids.value)
   permissions_boundary_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/${var.permissions_boundary_policy_name}"
+  api_domain_name          = coalesce(var.api_domain_name, "api.${var.website_domain_name}")
 }
 
 
@@ -39,7 +40,7 @@ module "website" {
 
   dns_zone_id     = data.aws_ssm_parameter.public_dns_zone_id.value
   domain_name     = var.website_domain_name
-  gost_api_domain = var.api_domain_name
+  gost_api_domain = local.api_domain_name
 }
 
 module "api_to_postgres_security_group" {
@@ -100,7 +101,7 @@ module "api" {
   enable_grants_scraper      = var.api_enable_grants_scraper
 
   # DNS
-  domain_name         = var.api_domain_name
+  domain_name         = local.api_domain_name
   dns_zone_id         = data.aws_ssm_parameter.public_dns_zone_id.value
   website_domain_name = var.website_domain_name
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.55.0"
+      version = "~> 4.56.0"
     }
   }
 

--- a/terraform/modules/gost_api/task.tf
+++ b/terraform/modules/gost_api/task.tf
@@ -5,7 +5,7 @@ locals {
 
 module "api_container_definition" {
   source  = "cloudposse/ecs-container-definition/aws"
-  version = "0.58.1"
+  version = "0.58.2"
 
   container_name           = "api"
   container_image          = local.api_container_image
@@ -71,7 +71,7 @@ module "api_container_definition" {
 
 module "datadog_container_definition" {
   source  = "cloudposse/ecs-container-definition/aws"
-  version = "0.58.1"
+  version = "0.58.2"
 
   container_name           = "datadog"
   container_image          = "public.ecr.aws/datadog/agent:latest"

--- a/terraform/production.s3.tfbackend
+++ b/terraform/production.s3.tfbackend
@@ -1,0 +1,5 @@
+region         = "us-west-2"
+bucket         = "729134339726-us-west-2-terraform"
+key            = "usdr/gost/production/us-west-2/terraform.tfstate"
+dynamodb_table = "terraform-lock"
+encrypt        = "true"

--- a/terraform/production.tfvars
+++ b/terraform/production.tfvars
@@ -1,0 +1,25 @@
+namespace = "gost-prod"
+
+// Common
+ssm_service_parameters_path_prefix    = "/gost/prod"
+ssm_deployment_parameters_path_prefix = "/gost/prod/deploy-config"
+
+// Website
+website_enabled     = true
+website_domain_name = "grants.usdigitalresponse.org"
+
+// ECS Cluster
+cluster_container_insights_enabled = true
+
+// API / Backend
+api_enabled                    = true
+api_container_image_tag        = "stable"
+api_default_desired_task_count = 3
+api_enable_grants_scraper      = true
+api_log_retention_in_days      = 30
+
+// Postgres
+postgres_enabled                   = true
+postgres_prevent_destroy           = true
+postgres_snapshot_before_destroy   = true
+postgres_apply_changes_immediately = false

--- a/terraform/sandbox.tfvars
+++ b/terraform/sandbox.tfvars
@@ -6,14 +6,13 @@ ssm_deployment_parameters_path_prefix = "/gost/sandbox/deploy-config"
 
 // Website
 website_enabled     = true
-website_domain_name = "sandbox.grants.usdigitalresponse.org"
+website_domain_name = "sandbox.grants.usdr.dev"
 
 // ECS Cluster
 cluster_container_insights_enabled = false
 
 // API / Backend
 api_enabled                    = true
-api_domain_name                = "api.sandbox.grants.usdigitalresponse.org"
 api_container_image_tag        = "latest"
 api_default_desired_task_count = 1
 api_enable_grants_scraper      = false

--- a/terraform/staging.tfvars
+++ b/terraform/staging.tfvars
@@ -6,14 +6,13 @@ ssm_deployment_parameters_path_prefix = "/gost/staging/deploy-config"
 
 // Website
 website_enabled     = true
-website_domain_name = "staging.grants.usdigitalresponse.org"
+website_domain_name = "staging.grants.usdr.dev"
 
 // ECS Cluster
 cluster_container_insights_enabled = true
 
 // API / Backend
 api_enabled                    = true
-api_domain_name                = "api.staging.grants.usdigitalresponse.org"
 api_container_image_tag        = "latest"
 api_default_desired_task_count = 1
 api_enable_grants_scraper      = true

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -58,7 +58,8 @@ variable "api_enabled" {
 }
 
 variable "api_domain_name" {
-  type = string
+  type    = string
+  default = ""
 }
 
 variable "api_container_image_tag" {


### PR DESCRIPTION
## Description

This PR is a follow-up to #1038. Once merged, it will enable CI/CD workflows to target our AWS environment.