### PR TITLE
Ensure deployments don't get skipped under certain conditions

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -129,6 +129,7 @@ jobs:
       - select_target_environment
       - deploy_terraform
     if: |
+      always() &&
       needs.build_website.result == 'success' &&
       (needs.deploy_terraform.result == 'success' || needs.deploy_terraform.result == 'skipped')
     environment: ${{ needs.select_target_environment.outputs.selected }}
@@ -163,6 +164,7 @@ jobs:
       - select_target_environment
       - deploy_terraform
     if: |
+      always() &&
       needs.build_api.result == 'success' &&
       (needs.deploy_terraform.result == 'success' || needs.deploy_terraform.result == 'skipped')
     environment: ${{ needs.select_target_environment.outputs.selected }}


### PR DESCRIPTION
## Description

This is a follow-up to #1042. The deployment job didn't actually run (likely related to https://github.com/actions/runner/issues/491#issuecomment-850884422). The solution seems to be to include an `always()` expression in the conditional evaluation for the deployment jobs.