### PR TITLE
#1044: Throw error for invalid non-numeric vals

### DIFF
--- a/packages/server/__tests__/arpa_reporter/server/services/validate-upload.spec.js
+++ b/packages/server/__tests__/arpa_reporter/server/services/validate-upload.spec.js
@@ -1,6 +1,9 @@
 const _ = require('lodash');
 const assert = require('assert');
 const rewire = require('rewire');
+const { getRules } = require('../../../../src/arpa_reporter/services/validation-rules');
+const { EXPENDITURE_CATEGORIES } = require('../../../../src/arpa_reporter/lib/format');
+const ALL_RULES = getRules()
 
 describe('validate upload', () => {
     describe('validate field pattern', () => {
@@ -18,5 +21,88 @@ describe('validate upload', () => {
         it('Raises an error for invalid emails', () => {
             assert(validateFieldPattern(EMAIL_KEY, malformedEmail) !== null);
         });
+    });
+});
+
+describe('validation rules', () => {
+    it('has rules for all expenditure categories (i.e. ec1, ec2...)', () => {
+        for (const ecCode of Object.keys(EXPENDITURE_CATEGORIES)) {
+            assert(ecCode in ALL_RULES);
+        }
+    });
+});
+
+describe('validate record', () => {
+    const validateRecord = rewire('../../../../src/arpa_reporter/services/validate-upload').__get__(
+        'validateRecord',
+    );
+    const VALID_EC2_PROJECT = {
+        Name: 'Sample project',
+        Project_Identification_Number__c: 101,
+        Completion_Status__c: 'Completed less than 50%',
+        Adopted_Budget__c: 500,
+        Total_Obligations__c: 500,
+        Total_Expenditures__c: 100,
+        Current_Period_Obligations__c: 0,
+        Current_Period_Expenditures__c: 0,
+        Project_Description__c: 'lorem ipsum',
+        Recipient_Approach_Description__c: 'lorem ipsum',
+        Spending_Allocated_Toward_Evidence_Based_Interventions: 0,
+        Program_Income_Earned__c: 0,
+        Program_Income_Expended__c: 0,
+        Primary_Project_Demographics__c: '4 Imp HHs that experienced increased food or housing insecurity',
+        Structure_Objectives_of_Asst_Programs__c: 'lorem ipsum',
+        Whether_program_evaluation_is_being_conducted: 'No',
+        Does_Project_Include_Capital_Expenditure__c: 'No',
+        Number_Households_Eviction_Prevention__c: 0,
+        Number_Affordable_Housing_Units__c: 0,
+    };
+
+    it('validates a valid project succesfully', () => {
+        return validateRecord({
+            upload: { ec_code: '2.16' },
+            record: VALID_EC2_PROJECT,
+            typeRules: ALL_RULES['ec2'],
+        }).then(
+            (generatedErrors) => {
+                assert(generatedErrors.length == 0,
+                    `Unexpected error when validating record: ${generatedErrors}`)
+            },
+            (thrownException) => { fail('Unexpected error while validating record', thrownException) }
+        );
+    });
+
+    it('throws an error when a required field is missing', () => {
+        let project = _.clone(VALID_EC2_PROJECT);
+        delete project.Project_Identification_Number__c;
+        return validateRecord({
+            upload: { ec_code: '2.16' },
+            record: project,
+            typeRules: ALL_RULES['ec2'],
+        }).then(
+            (generatedErrors) => {
+                assert(generatedErrors.length == 1);
+                assert(generatedErrors[0].severity == 'err');
+                assert.equal(generatedErrors[0].message, 'Value is required for Project_Identification_Number__c');
+            },
+            (thrownException) => { fail('Unexpected error while validating record', thrownException) }
+        );
+    })
+
+    it('throws error for non-numeric values in numeric fields', () => {
+        let project = _.clone(VALID_EC2_PROJECT);
+        project.Number_Households_Eviction_Prevention__c = 'N/A';
+        return validateRecord({
+            upload: { ec_code: '2.16' },
+            record: project,
+            typeRules: ALL_RULES['ec2'],
+        }).then(
+            (generatedErrors) => {
+                assert(generatedErrors.length == 1);
+                assert(generatedErrors[0].severity == 'err');
+                assert.equal(generatedErrors[0].message, `Expected a number, but the value was 'N/A'`);
+            },
+            (thrownException) => { fail('Unexpected error while validating record', thrownException) }
+        );
     });
 });

--- a/packages/server/src/arpa_reporter/lib/format.js
+++ b/packages/server/src/arpa_reporter/lib/format.js
@@ -91,6 +91,7 @@ module.exports = {
     tin,
     zip,
     zip4,
+    EXPENDITURE_CATEGORIES,
 };
 
 // NOTE: This file was copied from src/server/lib/format.js (git @ ada8bfdc98) in the arpa-reporter repo on 2022-09-23T20:05:47.735Z

--- a/packages/server/src/arpa_reporter/services/validate-upload.js
+++ b/packages/server/src/arpa_reporter/services/validate-upload.js
@@ -350,7 +350,6 @@ async function validateRecord({ upload, record, typeRules: rules }) {
             }
 
             if (rule.dataType === 'Numeric') {
-                console.log
               if (typeof(value) === 'string' && isNaN(parseFloat(value))) {
                 // If this value is a string that can't be interpretted as a number, then error.
                 // Note: This value might not be exactly what was entered in the workbook. The val

--- a/packages/server/src/arpa_reporter/services/validate-upload.js
+++ b/packages/server/src/arpa_reporter/services/validate-upload.js
@@ -349,6 +349,19 @@ async function validateRecord({ upload, record, typeRules: rules }) {
                 }
             }
 
+            if (rule.dataType === 'Numeric') {
+                console.log
+              if (typeof(value) === 'string' && isNaN(parseFloat(value))) {
+                // If this value is a string that can't be interpretted as a number, then error.
+                // Note: This value might not be exactly what was entered in the workbook. The val
+                // has already been fed through formatters that may have changed the value.
+                  errors.push(
+                    new ValidationError(`Expected a number, but the value was '${value}'`,
+                        { severity: 'err', col: rule.columnName })
+                  )
+              }
+            }
+
             // make sure max length is not too long
             if (rule.maxLength) {
                 if (rule.dataType === 'String' && String(record[key]).length > rule.maxLength) {


### PR DESCRIPTION
### Ticket #1044 

## Description
The backend is incorrectly accepting arbitrary strings as the value for fields that are supposed to be numeric only. This PR adds a validation that will throw an error in that case, while displaying the value that caused the error to help the uploader find the error.

The majority of the code in this PR is actually an expansion of the testing code so that we can more easily write testcases to check validations in the validateRecord method. I added a test for this non-numeric case, but also added a test that verifies that missing required fields will throw an error

## Screenshots / Demo Video
Test workbook includes these values:
![Screenshot 2023-03-03 at 9 35 26 AM](https://user-images.githubusercontent.com/3675290/222795355-9dea3292-eb17-4cc4-96cb-097da965db60.png)

Before the change, the validations show no errors:
<img width="565" alt="Screenshot 2023-03-03 at 9 57 58 AM" src="https://user-images.githubusercontent.com/3675290/222795379-a8f20481-f40c-4997-b947-549552ab32da.png">

After the change, we have new errors:
<img width="567" alt="Screenshot 2023-03-03 at 10 01 16 AM" src="https://user-images.githubusercontent.com/3675290/222795398-31ae7581-0c23-4884-91bc-7ad3cf7b9569.png">


## Testing

### Automated and Unit Tests
- [X] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [X] Provided ticket and description
- [X] Provided screenshots/demo
- [ ] Provided testing information
- [X] Provided adequate test coverage for all new code
- [X] Added PR reviewers