### PR TITLE
Support freeform text notes on uploads (896)

### DIFF
--- a/packages/client/.vscode/launch.json
+++ b/packages/client/.vscode/launch.json
@@ -9,6 +9,23 @@
             "webRoot": "${workspaceFolder}",
             "preLaunchTask": "serve",
             "postDebugTask": "kill debugger"
-        }
+        },
+        {
+            "name": "Client Attach",
+            "port": 9229,
+            "request": "attach",
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
+            "type": "node"
+        },
+        {
+            "type": "chrome",
+            "request": "launch",
+            "name": "Docker Debug in Chrome",
+            "url": "http://localhost:8080",
+            "webRoot": "${workspaceFolder}",
+            "postDebugTask": "kill debugger"
+        },
     ]
 }

--- a/packages/client/.vscode/tasks.json
+++ b/packages/client/.vscode/tasks.json
@@ -4,7 +4,7 @@
 		{
 			"label": "serve",
 			"type": "npm",
-			"script": "serve",
+			"script": "yarn serve",
 			"isBackground": true,
 			"problemMatcher": [{
 				"base": "$tsc-watch",

--- a/packages/client/arpa_reporter/scss/index.scss
+++ b/packages/client/arpa_reporter/scss/index.scss
@@ -5,6 +5,18 @@ $theme-colors: (
   "secondary": #607d8b,
 );
 
-@import "bootstrap/scss/bootstrap";
+#app {
+  font-family: Avenir, Helvetica, Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  color: #2c3e50;
+}
+
+
+@import 'bootstrap/scss/bootstrap.scss';
+@import 'bootstrap-vue/src/index.scss';
+@import 'vue-select/src/scss/vue-select.scss';
+// @import '@braid/vue-formulate/themes/snow/snow.scss';
+
 
 /* NOTE: This file was copied from scss/index.scss (git @ ada8bfdc98) in the arpa-reporter repo on 2022-09-23T20:05:47.735Z */

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -12,11 +12,12 @@
     "coverage": "nyc yarn test",
     "env": "export $(cat .env)",
     "lint": "vue-cli-service lint",
-    "serve": "vue-cli-service serve",
+    "serve": "vue-cli-service --inspect ../../node_modules/@vue/cli-service/bin/vue-cli-service.js serve",
     "start": "yarn run serve",
     "test": "vue-cli-service test:unit"
   },
   "dependencies": {
+    "@braid/vue-formulate": "^2.5.3",
     "bootstrap": "^4.6.1",
     "bootstrap-vue": "^2.19.0",
     "core-js": "^3.21.1",

--- a/packages/client/src/arpa_reporter/App.vue
+++ b/packages/client/src/arpa_reporter/App.vue
@@ -6,7 +6,6 @@
 
 <script>
 import '../../arpa_reporter/scss/index.scss';
-import 'bootstrap/dist/js/bootstrap.min';
 
 import Navigation from './components/Navigation.vue';
 
@@ -17,14 +16,5 @@ export default {
   },
 };
 </script>
-
-<style>
-#app {
-  font-family: Avenir, Helvetica, Arial, sans-serif;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  color: #2c3e50;
-}
-</style>
 
 <!-- NOTE: This file was copied from src/App.vue (git @ ada8bfdc98) in the arpa-reporter repo on 2022-09-23T20:05:47.735Z -->

--- a/packages/client/src/arpa_reporter/views/NewUpload.vue
+++ b/packages/client/src/arpa_reporter/views/NewUpload.vue
@@ -122,19 +122,9 @@ export default {
       return file;
     },
     async onSubmit(formData) {
-      // This is technically a FileList, allowing for multiple uploads if configured
-      // this way, but for now we have only a single file.
-      const file = formData.spreadsheet[0];
-      const uploadData = {
-        reportingPeriodId: formData.reportingPeriodId,
-        agencyId: formData.agencyId,
-        expenditure_code: formData.expenditure_code,
-        notes: formData.notes,
-      };
       const uploadFormData = new FormData();
-      uploadFormData.append('spreadsheet', file);
-      Object.keys(uploadData).forEach((key) => {
-        const value = uploadData[key];
+      uploadFormData.append('spreadsheet', data.spreadsheet[0]);
+      Object.entries(_.omit(data, ['spreadsheet'])).forEach(([key, value]) => {
         if (value) {
           uploadFormData.append(key, value);
         }

--- a/packages/client/src/arpa_reporter/views/NewUpload.vue
+++ b/packages/client/src/arpa_reporter/views/NewUpload.vue
@@ -82,7 +82,7 @@ export default {
         },
         {
           component: 'div',
-          class: 'row',
+          class: 'd-flex',
           children: [
             {
               name: 'submit',

--- a/packages/client/src/arpa_reporter/views/NewUpload.vue
+++ b/packages/client/src/arpa_reporter/views/NewUpload.vue
@@ -48,6 +48,7 @@ export default {
           placeholder: 'Select one',
           options: this.reportingPeriodSelectItems(),
           validation: 'required',
+          disabled: true,
         },
         {
           type: 'select',

--- a/packages/client/src/arpa_reporter/views/NewUpload.vue
+++ b/packages/client/src/arpa_reporter/views/NewUpload.vue
@@ -1,95 +1,150 @@
 <template>
-  <div class="upload">
-    <h1>Submit Workbook</h1>
+  <div>
 
-    <div>
-      <div v-if="error" class="mt-3 alert alert-danger" role="alert">
-        {{ error }}
-      </div>
-
-      <form
-        method="post"
-        encType="multipart/form-data"
-        ref="form"
-        @submit.prevent="onSubmit"
-      >
-        <div class="form-group">
-          <input
-            class="form-control-file"
-            type="file"
-            id="spreadsheet"
-            name="spreadsheet"
-            @change="changeFiles"
-            ref="files"
-          />
-        </div>
-        <div class="form-group">
-          <button
-            class="btn btn-primary"
-            type="submit"
-            :disabled="uploadDisabled"
-            @click.prevent="onSubmit"
-          >
-            {{ uploadButtonLabel }}
-          </button>
-          <a class="ml-3" href="#" @click="cancelUpload">Cancel</a>
-        </div>
-      </form>
-    </div>
+    <FormulateForm
+      name="new-upload"
+      :form-errors="formErrors"
+      v-model="values"
+      :schema="schema"
+      @submit="onSubmit"
+    >
+    <FormulateErrors
+      class="alert alert-danger"
+    />
+    </FormulateForm>
   </div>
 </template>
 
 <script>
+import Vue from 'vue';
+import VueFormulate from '@braid/vue-formulate';
 import { postForm } from '../store';
 
+Vue.use(VueFormulate, {
+  classes: {
+    prefix: 'formulate-',
+    outer: 'form-group',
+    input: (context, classes) => {
+      // set this to 'form-control' unless it's a file input
+      const inputClass = context.type === 'file' ? '' : 'form-control';
+      return [classes, inputClass].join(' ');
+    },
+    inputHasErrors: 'is-invalid',
+    help: 'form-text text-muted',
+    errors: 'list-unstyled text-danger',
+  },
+});
 export default {
-  name: 'NewUpload',
   data() {
     return {
-      error: null,
-      files: null,
-      uploading: false,
+      formErrors: [],
+      initialValues: () => ({
+        reportingPeriodId: this.$store.getters.viewPeriodID ?? '',
+        agencyId: this.$store.getters.user.agency.id,
+      }),
+
+      values: {},
+      schema: [
+        {
+          type: 'select',
+          name: 'reportingPeriodId',
+          label: 'Reporting Period',
+          placeholder: 'Select one',
+          options: this.reportingPeriodSelectItems(),
+          validation: 'required',
+        },
+        {
+          type: 'select',
+          name: 'agencyId',
+          label: 'Agency Code',
+          options: this.agencySelectItems(),
+          validation: 'required',
+        },
+        {
+          type: 'text',
+          label: 'Expenditure Code',
+          name: 'expenditure_code',
+          validation: 'required',
+        },
+        {
+          type: 'file',
+          label: 'Workbook File',
+          name: 'spreadsheet',
+          validation: 'required',
+          uploader: this.uploadFile,
+          // Don't upload the file until the form is submitted
+          uploadBehavior: 'delayed',
+        },
+        {
+          type: 'textarea',
+          label: 'Notes',
+          name: 'notes',
+        },
+        {
+          component: 'div',
+          class: 'row',
+          children: [
+            {
+              name: 'submit',
+              type: 'submit',
+              label: 'Submit',
+              inputClass: ['btn', 'btn-primary'],
+            },
+            {
+              type: 'button',
+              label: 'Reset',
+              inputClass: ['btn', 'btn-danger', 'ml-2'],
+              '@click': this.onReset,
+            },
+          ],
+        },
+      ],
     };
   },
-  computed: {
-    uploadButtonLabel() {
-      return this.uploading ? 'Uploading...' : 'Upload';
-    },
-    uploadDisabled() {
-      return this.files === null || this.uploading;
-    },
+  created() {
+    this.values = this.initialValues();
   },
   methods: {
-    changeFiles(evt) {
-      this.files = evt.target.files;
+    reportingPeriodSelectItems() {
+      // create an object from this.$store.getters.viewableReportingPeriods where every key is period.id and every value is period.name
+      return Object.fromEntries(this.$store.getters.viewableReportingPeriods.map((period) => [period.id, period.name]));
     },
-    async onSubmit() {
-      const file = this.files[0];
-
-      if (!file) {
-        this.$refs.files.focus();
-        return;
-      }
-
-      this.error = null;
-      this.uploading = true;
-
-      const formData = new FormData();
-      formData.append('spreadsheet', file);
-
-      // TODO: (#896) Actually include data when submitting
-      // formData.append('notes', '<b>TEST & STRING!</b>');
-      // formData.append('reportingPeriodId', '64');
-      // formData.append('agencyId', '0');
-
+    agencySelectItems() {
+      return Object.fromEntries(this.$store.state.agencies.map((agency) => [agency.id, agency.name]));
+    },
+    // eslint-disable-next-line no-unused-vars
+    async uploadFile(file, progress, error, options) {
+      /* VueFormulate traditionally calls this method to upload the file
+         to some remote location, but for now, we don't want to do that.
+         It may eventually make sense to do that when we don't have access
+         to the file system, e.g in a lambda context. For now though,
+         we just return the file object. */
+      return file;
+    },
+    async onSubmit(formData) {
+      // This is technically a FileList, allowing for multiple uploads if configured
+      // this way, but for now we have only a single file.
+      const file = formData.spreadsheet[0];
+      const uploadData = {
+        reportingPeriodId: formData.reportingPeriodId,
+        agencyId: formData.agencyId,
+        expenditure_code: formData.expenditure_code,
+        notes: formData.notes,
+      };
+      const uploadFormData = new FormData();
+      uploadFormData.append('spreadsheet', file);
+      Object.keys(uploadData).forEach((key) => {
+        const value = uploadData[key];
+        if (value) {
+          uploadFormData.append(key, value);
+        }
+      });
       try {
-        const resp = await postForm('/api/uploads', formData);
-        const result = (await resp.json()) || { error: (await resp.body) };
-
+        const resp = await postForm('/api/uploads', uploadFormData);
+        const result = (await resp.json()) || { error: await resp.body };
         if (resp.ok) {
           const { upload } = result;
           if (!upload) throw new Error('Upload failed to return an upload ID');
-
           this.$store.commit('setRecentUploadId', upload.id);
           this.$router.push({ path: `/uploads/${upload.id}` });
         } else {
@@ -97,17 +152,13 @@ export default {
           throw new Error(`Upload failed: ${err}`);
         }
       } catch (e) {
-        this.error = e.message;
-        this.uploading = false;
+        this.formErrors = [e.message];
       }
     },
-
-    cancelUpload(e) {
-      e.preventDefault();
-      this.$router.push({ path: '/' });
+    onReset() {
+      this.$formulate.reset('new-upload', this.initialValues());
+      this.formErrors = [];
     },
   },
 };
 </script>
-
-<!-- NOTE: This file was copied from src/views/NewUpload.vue (git @ ada8bfdc98) in the arpa-reporter repo on 2022-09-23T20:05:47.735Z -->

--- a/packages/client/src/arpa_reporter/views/NewUpload.vue
+++ b/packages/client/src/arpa_reporter/views/NewUpload.vue
@@ -27,7 +27,7 @@ Vue.use(VueFormulate, {
     input: (context, classes) => {
       // set this to 'form-control' unless it's a file input
       const inputClass = context.type === 'file' ? 'form-control-file' : 'form-control';
-      return [classes, inputClass].join(' ');
+      return [inputClass];
     },
     inputHasErrors: 'is-invalid',
     help: 'form-text text-muted',

--- a/packages/client/src/arpa_reporter/views/NewUpload.vue
+++ b/packages/client/src/arpa_reporter/views/NewUpload.vue
@@ -1,6 +1,6 @@
 <template>
-  <div>
-
+  <div class="upload">
+    <h1>Submit Workbook</h1>
     <FormulateForm
       name="new-upload"
       :form-errors="formErrors"
@@ -18,12 +18,13 @@
 <script>
 import Vue from 'vue';
 import VueFormulate from '@braid/vue-formulate';
+import _ from 'lodash';
 import { postForm } from '../store';
 
 Vue.use(VueFormulate, {
   classes: {
-    prefix: 'formulate-',
     outer: 'form-group',
+    // eslint-disable-next-line no-unused-vars
     input: (context, classes) => {
       // set this to 'form-control' unless it's a file input
       const inputClass = context.type === 'file' ? 'form-control-file' : 'form-control';
@@ -38,12 +39,7 @@ export default {
   data() {
     return {
       formErrors: [],
-      initialValues: () => ({
-        reportingPeriodId: this.$store.getters.viewPeriodID ?? '',
-        agencyId: this.$store.getters.user.agency.id,
-      }),
-
-      values: {},
+      values: this.initialValues(),
       schema: [
         {
           type: 'select',
@@ -101,10 +97,13 @@ export default {
       ],
     };
   },
-  created() {
-    this.values = this.initialValues();
-  },
   methods: {
+    initialValues() {
+      return {
+        reportingPeriodId: this.$store.getters.viewPeriodID ?? '',
+        agencyId: this.$store.getters.user.agency.id,
+      };
+    },
     reportingPeriodSelectItems() {
       // create an object from this.$store.getters.viewableReportingPeriods where every key is period.id and every value is period.name
       return Object.fromEntries(this.$store.getters.viewableReportingPeriods.map((period) => [period.id, period.name]));
@@ -121,7 +120,7 @@ export default {
          we just return the file object. */
       return file;
     },
-    async onSubmit(formData) {
+    async onSubmit(data) {
       const uploadFormData = new FormData();
       uploadFormData.append('spreadsheet', data.spreadsheet[0]);
       Object.entries(_.omit(data, ['spreadsheet'])).forEach(([key, value]) => {

--- a/packages/client/src/arpa_reporter/views/NewUpload.vue
+++ b/packages/client/src/arpa_reporter/views/NewUpload.vue
@@ -26,7 +26,7 @@ Vue.use(VueFormulate, {
     outer: 'form-group',
     input: (context, classes) => {
       // set this to 'form-control' unless it's a file input
-      const inputClass = context.type === 'file' ? '' : 'form-control';
+      const inputClass = context.type === 'file' ? 'form-control-file' : 'form-control';
       return [classes, inputClass].join(' ');
     },
     inputHasErrors: 'is-invalid',

--- a/packages/client/src/arpa_reporter/views/Upload.vue
+++ b/packages/client/src/arpa_reporter/views/Upload.vue
@@ -75,7 +75,6 @@
             {{ upload.notes || 'Not set' }}
           </li>
 
-
           <li class="list-group-item" :class="validatedLiClass">
             <span class="font-weight-bold">Validation: </span>
 

--- a/packages/client/src/arpa_reporter/views/Upload.vue
+++ b/packages/client/src/arpa_reporter/views/Upload.vue
@@ -70,6 +70,12 @@
             {{ displayTs(upload.created_at) }} ({{ fromNow(upload.created_at) }}) by {{ upload.created_by }}
           </li>
 
+          <li class="list-group-item" :class="{ 'list-group-item-warning': !upload.notes }">
+            <span class="font-weight-bold">Notes: </span>
+            {{ upload.notes || 'Not set' }}
+          </li>
+
+
           <li class="list-group-item" :class="validatedLiClass">
             <span class="font-weight-bold">Validation: </span>
 

--- a/packages/client/src/arpa_reporter/views/Uploads.vue
+++ b/packages/client/src/arpa_reporter/views/Uploads.vue
@@ -183,8 +183,8 @@ export default {
           field: 'notes',
           filterOptions: {
             enabled: true,
-            placeholder: 'Filter by notes...'
-          }
+            placeholder: 'Filter by notes...',
+          },
         },
         validatedCol,
       ];

--- a/packages/client/src/arpa_reporter/views/Uploads.vue
+++ b/packages/client/src/arpa_reporter/views/Uploads.vue
@@ -178,6 +178,14 @@ export default {
             placeholder: 'Filter by filename...',
           },
         },
+        {
+          label: 'Notes',
+          field: 'notes',
+          filterOptions: {
+            enabled: true,
+            placeholder: 'Filter by notes...'
+          }
+        },
         validatedCol,
       ];
     },

--- a/packages/client/src/main.js
+++ b/packages/client/src/main.js
@@ -2,7 +2,7 @@ import Vue from 'vue';
 import { BootstrapVue, IconsPlugin } from 'bootstrap-vue';
 import vSelect from 'vue-select';
 import Vuelidate from 'vuelidate';
-
+import VueFormulate from '@braid/vue-formulate';
 import App from './App.vue';
 import router from './router';
 import store from './store';
@@ -15,6 +15,7 @@ Vue.use(BootstrapVue);
 // Optionally install the BootstrapVue icon components plugin
 Vue.use(IconsPlugin);
 Vue.use(Vuelidate);
+Vue.use(VueFormulate);
 Vue.component('v-select', vSelect);
 
 Vue.config.productionTip = false;

--- a/packages/client/src/main.js
+++ b/packages/client/src/main.js
@@ -2,7 +2,6 @@ import Vue from 'vue';
 import { BootstrapVue, IconsPlugin } from 'bootstrap-vue';
 import vSelect from 'vue-select';
 import Vuelidate from 'vuelidate';
-import VueFormulate from '@braid/vue-formulate';
 import App from './App.vue';
 import router from './router';
 import store from './store';
@@ -15,7 +14,6 @@ Vue.use(BootstrapVue);
 // Optionally install the BootstrapVue icon components plugin
 Vue.use(IconsPlugin);
 Vue.use(Vuelidate);
-Vue.use(VueFormulate);
 Vue.component('v-select', vSelect);
 
 Vue.config.productionTip = false;

--- a/packages/server/.vscode/launch.json
+++ b/packages/server/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "attach",
+            "name": "Docker: Attach to Node",
+            "remoteRoot": "/app/packages/server"
+        }
+    ]
+}

--- a/packages/server/src/arpa_reporter/db/uploads.js
+++ b/packages/server/src/arpa_reporter/db/uploads.js
@@ -40,7 +40,7 @@ function getUpload(id, trns = knex) {
         .leftJoin('users', 'uploads.user_id', 'users.id')
         .leftJoin('users AS vusers', 'uploads.validated_by', 'vusers.id')
         .leftJoin('agencies', 'uploads.agency_id', 'agencies.id')
-        .select('uploads.*', 'users.email AS created_by', 'agencies.code AS agency_code', 'vusers.email AS validated_by_email')
+        .select('uploads.*', 'users.email AS created_by', 'agencies.code AS agency_code', 'vusers.email AS validated_by_email', 'notes')
         .where('uploads.id', id)
         .then((r) => r[0]);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1171,6 +1171,19 @@
     "@babel/helper-validator-identifier" "^7.19.1"
     to-fast-properties "^2.0.0"
 
+"@braid/vue-formulate-i18n@^1.16.0":
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/@braid/vue-formulate-i18n/-/vue-formulate-i18n-1.16.0.tgz#71c9121c909c7bbdfd4dfcf6a57d554f5bb1ec75"
+  integrity sha512-CuX1kN7bWg4ukynnTS3LGsmPKrUvS2Wh75zKatIe+nHQQy0gSvfmggQsCz4QZey7Ois+pGYmOIgrE1SvX+zQTw==
+
+"@braid/vue-formulate@^2.5.3":
+  version "2.5.3"
+  resolved "https://registry.yarnpkg.com/@braid/vue-formulate/-/vue-formulate-2.5.3.tgz#539990590f2933783e7339e9f0fc87318641eceb"
+  integrity sha512-HdyslHKkzJAtMiD2BP0PfQ8/BaRs1NPlWA8DhgL4ImR/1tuzQLrZButVIqWiucfRitfrgeWz5qrByZs8zp5vFw==
+  dependencies:
+    "@braid/vue-formulate-i18n" "^1.16.0"
+    is-plain-object "^3.0.1"
+
 "@commitlint/cli@^11.0.0":
   version "11.0.0"
   resolved "https://registry.yarnpkg.com/@commitlint/cli/-/cli-11.0.0.tgz#698199bc52afed50aa28169237758fa14a67b5d3"
@@ -7954,6 +7967,11 @@ is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   integrity sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==
   dependencies:
     isobject "^3.0.1"
+
+is-plain-object@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-3.0.1.tgz#662d92d24c0aa4302407b0d45d21f2251c85f85b"
+  integrity sha512-Xnpx182SBMrr/aBik8y+GuR4U1L9FqMSojwDQwPMmxyC6bvEqly9UBCxhauBF5vNh2gwWJNX6oDV7O+OM4z34g==
 
 is-potential-custom-element-name@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
### Ticket #896 
## Description
Adds a form to set reportingId, agencyId, and notes in addition to uploading a file, using Vue-Formulate

## Screenshots / Demo Video
![Screenshot 2023-03-04 at 4 33 20 PM](https://user-images.githubusercontent.com/120750336/222929635-692da637-5681-4846-bb16-ad94bcfa6865.jpg)
![Screenshot 2023-03-04 at 4 35 40 PM](https://user-images.githubusercontent.com/120750336/222929662-7996d4c2-3c07-4dd8-8253-c315fb53eaf6.jpg)


## Testing
NOTE! This patch needs to be applied alongside https://github.com/usdigitalresponse/usdr-gost/pull/1035 for the functionality to work! 
Once that has been merged / this is made on top, you should be able to go to Uploads -> Submit Workbook and specify an agency and reporting period

### Automated and Unit Tests
- [ ] Added Unit tests 
(N/A - we do not yet have FE unit tests)

### Manual tests for Reviewer
- [x] Added steps to test feature/functionality manually

## Checklist
- [x] Provided ticket and description
- [x] Provided screenshots/demo
- [x] Provided testing information
- [x] Provided adequate test coverage for all new code
- [x] Added PR reviewers

NOTE: Setting as DRAFT for now in case @ajhyndman has another patch in the works / is planning on a different fix! Currently coordinating in slack. 