### PR TITLE
889-hide certain columns on browse grants

### DIFF
--- a/packages/client/src/components/GrantsTable.vue
+++ b/packages/client/src/components/GrantsTable.vue
@@ -38,7 +38,7 @@
         </multiselect>
       </b-col>
     </b-row>
-    <b-table id="grants-table" sticky-header="600px" hover :items="formattedGrants" :fields="fields" selectable striped
+    <b-table id="grants-table" sticky-header="600px" hover :items="formattedGrants" :fields="fields.filter( field => !field.hideGrantItem)" selectable striped
       :sort-by.sync="orderBy" :sort-desc.sync="orderDesc" :no-local-sorting="true"
       select-mode="single" :busy="loading" @row-selected="onRowSelected">
       <template #cell(award_floor)="row">
@@ -80,6 +80,7 @@ export default {
     showResult: Boolean,
     showAging: Boolean,
     showAssignedToAgency: String,
+    hideGrantItems: Boolean,
   },
   data() {
     return {
@@ -92,6 +93,7 @@ export default {
           label: 'Opportunity Number',
           variant: 'dark',
           stickyColumn: true, // was in the grant id col but not sure if necessary
+          hideGrantItem: this.hideGrantItems,
         },
         {
           key: 'title',
@@ -107,9 +109,11 @@ export default {
         {
           // opportunity_status
           key: 'status',
+          hideGrantItem: this.hideGrantItems,
         },
         {
           key: 'opportunity_category',
+          hideGrantItem: this.hideGrantItems,
         },
         {
           key: 'cost_sharing',

--- a/packages/client/src/views/Grants.vue
+++ b/packages/client/src/views/Grants.vue
@@ -1,5 +1,5 @@
 <template>
-  <GrantsTable />
+  <GrantsTable :hideGrantItems="true"/>
 </template>
 
 <script>


### PR DESCRIPTION
### Ticket #889
## Description
Hide certain columns if it's on the browse grants page. 
Hide the following: 
 - Opportunity Number
 - Status
 - Opportunity Category
## Screenshots / Demo Video
Browse Grants
<img width="1511" alt="Screenshot 2023-03-06 at 6 05 41 PM" src="https://user-images.githubusercontent.com/3173822/223292794-f351d9ce-3ce0-464a-b680-c403a9dee1eb.png">
My Grants
<img width="1512" alt="Screenshot 2023-03-06 at 6 05 49 PM" src="https://user-images.githubusercontent.com/3173822/223292804-be5ad55a-4d14-40fa-a52b-31d54e23643b.png">

## Testing

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [x] Added steps to test feature/functionality manually

- Go to my grants page. All columns should remain. 
- Go to browse grants page. The following column/data should no longer be there:
  - Opportunity Number
  - Status
  - Opportunity Category
## Checklist
- [x] Provided ticket and description
- [x] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [x] Added PR reviewers