### PR TITLE
Tsh/enable grants digest in tf

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -99,6 +99,7 @@ module "api" {
   api_container_environment  = var.api_container_environment
   default_desired_task_count = var.api_default_desired_task_count
   enable_grants_scraper      = var.api_enable_grants_scraper
+  enable_grants_digest       = var.api_enable_grants_digest
 
   # DNS
   domain_name         = local.api_domain_name

--- a/terraform/modules/gost_api/task.tf
+++ b/terraform/modules/gost_api/task.tf
@@ -29,6 +29,7 @@ module "api_container_definition" {
     {
       ENABLE_GRANTS_SCRAPER     = "false"
       GRANTS_SCRAPER_DATE_RANGE = 7
+      ENABLE_GRANTS_DIGEST      = var.enable_grants_digest ? "true" : "false"
       GRANTS_SCRAPER_DELAY      = 1000
       NODE_OPTIONS              = "--max_old_space_size=1024"
       API_DOMAIN                = "https://${var.domain_name}"

--- a/terraform/modules/gost_api/variables.tf
+++ b/terraform/modules/gost_api/variables.tf
@@ -162,3 +162,9 @@ variable "enable_grants_scraper" {
   type        = bool
   default     = false
 }
+
+variable "enable_grants_digest" {
+  description = "When true, sets the ENABLE_GRANTS_DIGEST environment variable to true in the API container."
+  type        = bool
+  default     = false
+}

--- a/terraform/prod.tfvars
+++ b/terraform/prod.tfvars
@@ -16,6 +16,7 @@ api_enabled                    = true
 api_container_image_tag        = "stable"
 api_default_desired_task_count = 3
 api_enable_grants_scraper      = true
+api_enable_grants_digest       = true
 api_log_retention_in_days      = 30
 
 // Postgres

--- a/terraform/sandbox.tfvars
+++ b/terraform/sandbox.tfvars
@@ -16,6 +16,7 @@ api_enabled                    = true
 api_container_image_tag        = "latest"
 api_default_desired_task_count = 1
 api_enable_grants_scraper      = false
+api_enable_grants_digest       = false
 api_log_retention_in_days      = 7
 
 // Postgres

--- a/terraform/staging.tfvars
+++ b/terraform/staging.tfvars
@@ -16,6 +16,7 @@ api_enabled                    = true
 api_container_image_tag        = "latest"
 api_default_desired_task_count = 1
 api_enable_grants_scraper      = true
+api_enable_grants_digest       = false
 api_log_retention_in_days      = 14
 
 // Postgres

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -79,6 +79,10 @@ variable "api_enable_grants_scraper" {
   type = bool
 }
 
+variable "api_enable_grants_digest" {
+  type = bool
+}
+
 variable "api_log_retention_in_days" {
   type = number
 }


### PR DESCRIPTION
### Ticket #609 
## Description

This PR allows the `ENABLE_GRANTS_DIGEST` environment variable to be set to either `"true"` or `"false"` based on the value of a corresponding `enable_grants_digest` input variable for the `gost_api` terraform module.

The value passed to the `gost_api` module is set per-environment in the various `.tfvars` files. Per this PR, the values are:
- Sandbox: `false`
- Staging: `false`
- Prod: `true`

This ensures that the digest is only enabled in Prod.

## Screenshots / Demo Video

## Testing

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [ ] Provided ticket and description
- [ ] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers