### PR TITLE
Fix remaining ESLint errors in server/__tests__ directory

### DIFF
--- a/packages/server/.eslintrc.js
+++ b/packages/server/.eslintrc.js
@@ -36,19 +36,6 @@ module.exports = {
         'src/arpa_reporter/services/validate-data/validate.js',
         'src/arpa_reporter/services/validate-upload.js',
         'src/arpa_reporter/services/validation-rules.js',
-        '__tests__/arpa_reporter/server/services/validation-rules.spec.js',
-        '__tests__/arpa_reporter/server/db/reporting-periods.spec.js',
-        '__tests__/arpa_reporter/server/db/settings.spec.js',
-        '__tests__/arpa_reporter/server/db/uploads.spec.js',
-        '__tests__/arpa_reporter/server/environment.spec.js',
-        '__tests__/arpa_reporter/server/fixtures/add-dummy-data.js',
-        '__tests__/arpa_reporter/server/mocha_init.js',
-        '__tests__/arpa_reporter/server/seeds/01_roles.js',
-        '__tests__/arpa_reporter/server/seeds/07_reporting_periods.js',
-        '__tests__/arpa_reporter/server/services/validate-data/index.spec.js',
-        '__tests__/arpa_reporter/server/services/validate-data/validate.spec.js',
-        '__tests__/arpa_reporter/server/services/validate-upload.spec.js',
-        '__tests__/arpa_reporter/server/services/validation-rules.spec.js',
     ],
     rules: {
         'no-console': process.env.NODE_ENV === 'production' ? 'error' : 'off',
@@ -65,10 +52,6 @@ module.exports = {
         semi: ['error', 'always'],
         'no-restricted-syntax': [
             'error',
-            {
-                selector: 'ForOfStatement',
-                message: 'iterators/generators require regenerator-runtime, which is too heavyweight for this guide to allow them. Separately, loops should be avoided in favor of array iterations.',
-            },
             {
                 selector: 'LabeledStatement',
                 message: 'Labels are a form of GOTO; using them makes code confusing and hard to maintain and understand.',
@@ -90,6 +73,9 @@ module.exports = {
             files: ['*.test.js', '*.spec.js'],
             rules: {
                 'no-underscore-dangle': 'off',
+            },
+            globals: {
+                requireSrc: 'readonly',
             },
         },
     ],

--- a/packages/server/__tests__/arpa_reporter/server/db/uploads.spec.js
+++ b/packages/server/__tests__/arpa_reporter/server/db/uploads.spec.js
@@ -25,20 +25,20 @@ describe('db/uploads.js', () => {
 
         it('Requires a filename', async () => {
             upload.filename = null;
-            assert.rejects(async () => await withTenantId(TENANT_ID, () => uploads.createUpload(upload)));
+            assert.rejects(async () => withTenantId(TENANT_ID, () => uploads.createUpload(upload)));
         });
 
         describe('when there is invalid user id', () => {
             it('throws an error', async () => {
                 upload.user_id = 12345;
-                assert.rejects(async () => await withTenantId(TENANT_ID, uploads.createUpload(upload)));
+                assert.rejects(async () => withTenantId(TENANT_ID, uploads.createUpload(upload)));
             });
         });
 
         describe('when there is invalid reporting period', () => {
             it('throws an error', async () => {
                 upload.reporting_period_id = 12345;
-                assert.rejects(async () => await withTenantId(TENANT_ID, uploads.createUpload(upload)));
+                assert.rejects(async () => withTenantId(TENANT_ID, uploads.createUpload(upload)));
             });
         });
     });

--- a/packages/server/__tests__/arpa_reporter/server/environment.spec.js
+++ b/packages/server/__tests__/arpa_reporter/server/environment.spec.js
@@ -4,6 +4,13 @@ const fs = require('fs/promises');
 
 const env = require('../../../src/arpa_reporter/environment');
 
+function exists(fpath) {
+    return fs.access(fpath).then(
+        () => true,
+        () => false,
+    );
+}
+
 describe('environment settings', () => {
     it('SERVER_CODE_DIR point to the right place', async () => {
         const testPaths = [
@@ -13,6 +20,7 @@ describe('environment settings', () => {
 
         for (const relative of testPaths) {
             const absolute = path.join(env.SERVER_CODE_DIR, relative);
+            // eslint-disable-next-line no-await-in-loop
             const pathExists = await exists(absolute);
             assert.ok(pathExists, `expected ${absolute} to exist, is SERVER_CODE_DIR wrong?`);
         }
@@ -26,17 +34,11 @@ describe('environment settings', () => {
 
         for (const relative of testPaths) {
             const absolute = path.join(env.SERVER_DATA_DIR, relative);
+            // eslint-disable-next-line no-await-in-loop
             const pathExists = await exists(absolute);
             assert.ok(pathExists, `expected ${absolute} to exist, is SERVER_DATA_DIR wrong?`);
         }
     });
 });
-
-function exists(fpath) {
-    return fs.access(fpath).then(
-        () => true,
-        () => false,
-    );
-}
 
 // NOTE: This file was copied from tests/server/environment.spec.js (git @ ada8bfdc98) in the arpa-reporter repo on 2022-09-23T20:05:47.735Z

--- a/packages/server/__tests__/arpa_reporter/server/fixtures/add-dummy-data.js
+++ b/packages/server/__tests__/arpa_reporter/server/fixtures/add-dummy-data.js
@@ -1,3 +1,4 @@
+/* eslint-disable global-require */
 const { isRunningInGOST } = require('../helpers/is_gost');
 
 const setupAgencies = async (knex) => {

--- a/packages/server/__tests__/arpa_reporter/server/mocha_init.js
+++ b/packages/server/__tests__/arpa_reporter/server/mocha_init.js
@@ -1,3 +1,4 @@
+/* eslint-disable global-require */
 require('dotenv').config();
 
 const knex = require('../../../src/db/connection');

--- a/packages/server/__tests__/arpa_reporter/server/seeds/01_roles.js
+++ b/packages/server/__tests__/arpa_reporter/server/seeds/01_roles.js
@@ -6,12 +6,11 @@ exports.seed = async function (knex) {
     // Deletes ALL existing entries
     return knex('roles')
         .del()
-        .then(() =>
-            // Inserts seed entries
-            knex('roles').insert([
-                { name: 'admin', rules: {} },
-                { name: isGost ? 'staff' : 'reporter', rules: {} },
-            ]));
+        // Inserts seed entries
+        .then(() => knex('roles').insert([
+            { name: 'admin', rules: {} },
+            { name: isGost ? 'staff' : 'reporter', rules: {} },
+        ]));
 };
 
 // NOTE: This file was copied from tests/server/seeds/01_roles.js (git @ ada8bfdc98) in the arpa-reporter repo on 2022-09-23T20:05:47.735Z

--- a/packages/server/__tests__/arpa_reporter/server/seeds/07_reporting_periods.js
+++ b/packages/server/__tests__/arpa_reporter/server/seeds/07_reporting_periods.js
@@ -1,3 +1,5 @@
+const moment = require('moment');
+
 require('dotenv').config();
 
 // when making changes to this file, consider also updating the non-test seed:
@@ -14,7 +16,6 @@ exports.seed = async function (knex) {
         },
     ];
 
-    const moment = require('moment');
     const mstr = (mdate) => mdate.format('YYYY-MM-DD');
 
     // generate array of reporting periods, starting from right after the first period

--- a/packages/server/__tests__/arpa_reporter/server/services/validate-upload.spec.js
+++ b/packages/server/__tests__/arpa_reporter/server/services/validate-upload.spec.js
@@ -1,15 +1,16 @@
 const _ = require('lodash');
 const assert = require('assert');
 const rewire = require('rewire');
-const { getRules } = require('../../../../src/arpa_reporter/services/validation-rules');
-const { EXPENDITURE_CATEGORIES } = require('../../../../src/arpa_reporter/lib/format');
-
-const ALL_RULES = getRules();
-const ValidationError = require('../../../../src/arpa_reporter/lib/validation-error');
 const sinon = require('sinon');
 const { expect } = require('chai');
 
+const { getRules } = require('../../../../src/arpa_reporter/services/validation-rules');
+const { EXPENDITURE_CATEGORIES } = require('../../../../src/arpa_reporter/lib/format');
+const ValidationError = require('../../../../src/arpa_reporter/lib/validation-error');
+
 const validateUploadModule = rewire('../../../../src/arpa_reporter/services/validate-upload');
+
+const ALL_RULES = getRules();
 
 describe('validate upload', () => {
     describe('validate field pattern', () => {
@@ -40,8 +41,7 @@ describe('validation rules', () => {
 
 describe('setOrValidateAgencyBasedOnCoverSheet', () => {
     const setOrValidateAgencyBasedOnCoverSheet = validateUploadModule.__get__('setOrValidateAgencyBasedOnCoverSheet');
-    let recordFromUploadsTable; let
-        coverSheetAgency;
+    let setAgencyIdStub;
 
     beforeEach(() => {
         // Create a stub for the setAgencyId function
@@ -126,7 +126,7 @@ describe('validate record', () => {
         typeRules: ALL_RULES.ec2,
     }).then(
         (generatedErrors) => {
-            assert(generatedErrors.length == 0,
+            assert(generatedErrors.length === 0,
                 `Unexpected error when validating record: ${generatedErrors}`);
         },
         (thrownException) => { fail('Unexpected error while validating record', thrownException); },
@@ -141,8 +141,8 @@ describe('validate record', () => {
             typeRules: ALL_RULES.ec2,
         }).then(
             (generatedErrors) => {
-                assert(generatedErrors.length == 1);
-                assert(generatedErrors[0].severity == 'err');
+                assert(generatedErrors.length === 1);
+                assert(generatedErrors[0].severity === 'err');
                 assert.equal(generatedErrors[0].message, 'Value is required for Project_Identification_Number__c');
             },
             (thrownException) => { fail('Unexpected error while validating record', thrownException); },
@@ -158,8 +158,8 @@ describe('validate record', () => {
             typeRules: ALL_RULES.ec2,
         }).then(
             (generatedErrors) => {
-                assert(generatedErrors.length == 1);
-                assert(generatedErrors[0].severity == 'err');
+                assert(generatedErrors.length === 1);
+                assert(generatedErrors[0].severity === 'err');
                 assert.equal(generatedErrors[0].message, `Expected a number, but the value was 'N/A'`);
             },
             (thrownException) => { fail('Unexpected error while validating record', thrownException); },

--- a/packages/server/__tests__/arpa_reporter/server/services/validate-upload.spec.js
+++ b/packages/server/__tests__/arpa_reporter/server/services/validate-upload.spec.js
@@ -129,7 +129,7 @@ describe('validate record', () => {
             assert(generatedErrors.length === 0,
                 `Unexpected error when validating record: ${generatedErrors}`);
         },
-        (thrownException) => { fail('Unexpected error while validating record', thrownException); },
+        (thrownException) => { assert.fail(`Unexpected error while validating record: ${thrownException}`); },
     ));
 
     it('throws an error when a required field is missing', () => {
@@ -145,7 +145,7 @@ describe('validate record', () => {
                 assert(generatedErrors[0].severity === 'err');
                 assert.equal(generatedErrors[0].message, 'Value is required for Project_Identification_Number__c');
             },
-            (thrownException) => { fail('Unexpected error while validating record', thrownException); },
+            (thrownException) => { assert.fail(`Unexpected error while validating record: ${thrownException}`); },
         );
     });
 
@@ -162,7 +162,7 @@ describe('validate record', () => {
                 assert(generatedErrors[0].severity === 'err');
                 assert.equal(generatedErrors[0].message, `Expected a number, but the value was 'N/A'`);
             },
-            (thrownException) => { fail('Unexpected error while validating record', thrownException); },
+            (thrownException) => { assert.fail(`Unexpected error while validating record: ${thrownException}`); },
         );
     });
 });

--- a/packages/server/__tests__/arpa_reporter/server/services/validate-upload.spec.js
+++ b/packages/server/__tests__/arpa_reporter/server/services/validate-upload.spec.js
@@ -3,7 +3,8 @@ const assert = require('assert');
 const rewire = require('rewire');
 const { getRules } = require('../../../../src/arpa_reporter/services/validation-rules');
 const { EXPENDITURE_CATEGORIES } = require('../../../../src/arpa_reporter/lib/format');
-const ALL_RULES = getRules()
+
+const ALL_RULES = getRules();
 const ValidationError = require('../../../../src/arpa_reporter/lib/validation-error');
 const sinon = require('sinon');
 const { expect } = require('chai');
@@ -37,10 +38,10 @@ describe('validation rules', () => {
     });
 });
 
-
 describe('setOrValidateAgencyBasedOnCoverSheet', () => {
     const setOrValidateAgencyBasedOnCoverSheet = validateUploadModule.__get__('setOrValidateAgencyBasedOnCoverSheet');
-    let recordFromUploadsTable, coverSheetAgency;
+    let recordFromUploadsTable; let
+        coverSheetAgency;
 
     beforeEach(() => {
         // Create a stub for the setAgencyId function
@@ -56,32 +57,32 @@ describe('setOrValidateAgencyBasedOnCoverSheet', () => {
     it('should set the agency ID from cover sheet when upload record has no agency ID', async () => {
         const recordFromUploadsTable = { id: 1, agency_id: null, agency_code: null };
         const coverSheetAgency = { id: 123, code: 'DEF' };
-    
+
         await setOrValidateAgencyBasedOnCoverSheet(recordFromUploadsTable, coverSheetAgency);
-    
+
         // Expect setAgencyIdStub to be called with the correct arguments
         expect(setAgencyIdStub.calledOnceWithExactly(recordFromUploadsTable.id, coverSheetAgency.id)).to.be.true;
-      });
-    
-      it('should return a validation error when the upload record agency ID does not match cover sheet agency ID', async () => {
+    });
+
+    it('should return a validation error when the upload record agency ID does not match cover sheet agency ID', async () => {
         const recordFromUploadsTable = { id: 1, agency_id: 456, agency_code: 'AGENCY1' };
         const coverSheetAgency = { id: 123, code: 'AGENCY2' };
-    
+
         const result = await setOrValidateAgencyBasedOnCoverSheet(recordFromUploadsTable, coverSheetAgency);
-    
+
         // Expect setAgencyId to not be called
         expect(setAgencyIdStub.called).to.be.false;
-    
+
         // Expect the function to return a ValidationError with the correct message and metadata
         expect(result).to.be.an.instanceOf(ValidationError);
         expect(result.message).to.equal(`The agency on the spreadsheet, "${coverSheetAgency.code}", does not match the agency provided in the form, "${recordFromUploadsTable.agency_code}"`);
-      });
+    });
 
     it('should not modify agencyId if uploadRecordAgencyId matches coverSheetAgency.id', async () => {
         const recordFromUploadsTable = { id: 1, agency_id: 456, agency_code: 'AGENCY1' };
-        const coverSheetAgency = { 
-            id: recordFromUploadsTable.agency_id, 
-            code: recordFromUploadsTable.agency_code 
+        const coverSheetAgency = {
+            id: recordFromUploadsTable.agency_id,
+            code: recordFromUploadsTable.agency_code,
         };
 
         recordFromUploadsTable.agency_id = coverSheetAgency.id;
@@ -119,51 +120,49 @@ describe('validate record', () => {
         Number_Affordable_Housing_Units__c: 0,
     };
 
-    it('validates a valid project succesfully', () => {
-        return validateRecord({
-            upload: { ec_code: '2.16' },
-            record: VALID_EC2_PROJECT,
-            typeRules: ALL_RULES['ec2'],
-        }).then(
-            (generatedErrors) => {
-                assert(generatedErrors.length == 0,
-                    `Unexpected error when validating record: ${generatedErrors}`)
-            },
-            (thrownException) => { fail('Unexpected error while validating record', thrownException) }
-        );
-    });
+    it('validates a valid project succesfully', () => validateRecord({
+        upload: { ec_code: '2.16' },
+        record: VALID_EC2_PROJECT,
+        typeRules: ALL_RULES.ec2,
+    }).then(
+        (generatedErrors) => {
+            assert(generatedErrors.length == 0,
+                `Unexpected error when validating record: ${generatedErrors}`);
+        },
+        (thrownException) => { fail('Unexpected error while validating record', thrownException); },
+    ));
 
     it('throws an error when a required field is missing', () => {
-        let project = _.clone(VALID_EC2_PROJECT);
+        const project = _.clone(VALID_EC2_PROJECT);
         delete project.Project_Identification_Number__c;
         return validateRecord({
             upload: { ec_code: '2.16' },
             record: project,
-            typeRules: ALL_RULES['ec2'],
+            typeRules: ALL_RULES.ec2,
         }).then(
             (generatedErrors) => {
                 assert(generatedErrors.length == 1);
                 assert(generatedErrors[0].severity == 'err');
                 assert.equal(generatedErrors[0].message, 'Value is required for Project_Identification_Number__c');
             },
-            (thrownException) => { fail('Unexpected error while validating record', thrownException) }
+            (thrownException) => { fail('Unexpected error while validating record', thrownException); },
         );
-    })
+    });
 
     it('throws error for non-numeric values in numeric fields', () => {
-        let project = _.clone(VALID_EC2_PROJECT);
+        const project = _.clone(VALID_EC2_PROJECT);
         project.Number_Households_Eviction_Prevention__c = 'N/A';
         return validateRecord({
             upload: { ec_code: '2.16' },
             record: project,
-            typeRules: ALL_RULES['ec2'],
+            typeRules: ALL_RULES.ec2,
         }).then(
             (generatedErrors) => {
                 assert(generatedErrors.length == 1);
                 assert(generatedErrors[0].severity == 'err');
                 assert.equal(generatedErrors[0].message, `Expected a number, but the value was 'N/A'`);
             },
-            (thrownException) => { fail('Unexpected error while validating record', thrownException) }
+            (thrownException) => { fail('Unexpected error while validating record', thrownException); },
         );
     });
 });


### PR DESCRIPTION
### Ticket #839

## Description

This pull request removes ignore rules for the last remaining JavaScript and Vue files in the packages/server/__tests__ directory of this repository.

Note that all changes in this pull request were manually applied. Everything that could be resolved via eslint --fix was committed in https://github.com/usdigitalresponse/usdr-gost/pull/1036.

## Screenshots / Demo Video

BEFORE

<img width="847" alt="image" src="https://user-images.githubusercontent.com/11449340/223338421-ff3bf544-b053-49c3-b665-71a99e9718a8.png">

AFTER

<img width="842" alt="image" src="https://user-images.githubusercontent.com/11449340/223338520-df08d3a1-64d7-41ce-8129-302348c83bfd.png">

## Testing

Test these changes by running yarn lint in the packages/server directory.

### Automated and Unit Tests
- ~Added Unit tests~

### Manual tests for Reviewer
- [x] Added steps to test feature/functionality manually

## Checklist
- [x] Provided ticket and description
- [x] Provided screenshots/demo
- [x] Provided testing information
- ~Provided adequate test coverage for all new code~
- [x] Added PR reviewers