### PR TITLE
#378: Improve conditionally-required fields

### DIFF
--- a/packages/server/__tests__/arpa_reporter/server/services/validation-rules.spec.js
+++ b/packages/server/__tests__/arpa_reporter/server/services/validation-rules.spec.js
@@ -69,8 +69,8 @@ describe('validation rules', () => {
         const configs = validationRulesModule.__get__('CONDITIONAL_REQS_CONFIGS');
         const funcLookup = validationRulesModule.__get__('CONDITIONAL_REQUIREMENTS_BY_FIELD_ID');
         it('has valid configurations', () => {
-            const seenFieldIds = new Set()
-            assert(configs.length > 0)
+            const seenFieldIds = new Set();
+            assert(configs.length > 0);
             for (const config of configs) {
                 assert(config.fieldIDs && config.fieldIDs.length > 0,
                     'Conditional requirement config is missing fieldIDs');
@@ -86,24 +86,24 @@ describe('validation rules', () => {
         });
 
         it('relaxes some requirements for projects that have not started', () => {
-            const optionalIfNotStartedFn = funcLookup['Primary_Project_Demographics__c'];
+            const optionalIfNotStartedFn = funcLookup.Primary_Project_Demographics__c;
             assert(optionalIfNotStartedFn, 'Missing optionalIfNotStarted function');
             const testProject = {
-                Completion_Status__c: 'Completed'
+                Completion_Status__c: 'Completed',
             };
             assert.equal(optionalIfNotStartedFn(testProject), true,
                 'A completed project must include this field');
 
             testProject.Completion_Status__c = 'Not started';
             assert.equal(optionalIfNotStartedFn(testProject), false,
-                'A not-started project can omit it')
-            });
+                'A not-started project can omit it');
+        });
 
         it('requires a reason for canceled projects', () => {
-            const cancellationReasonFunc = funcLookup['Cancellation_Reason__c'];
+            const cancellationReasonFunc = funcLookup.Cancellation_Reason__c;
             assert(cancellationReasonFunc, 'Missing requirement function for Cancellation_Reason__c');
             const testProject = {
-                Completion_Status__c: 'Not started'
+                Completion_Status__c: 'Not started',
             };
             assert.equal(cancellationReasonFunc(testProject), false,
                 'A non-cancelled project does not need a cancellation reason');
@@ -113,5 +113,4 @@ describe('validation rules', () => {
                 'A cancelled project must include a cancellation reason');
         });
     });
-
 });

--- a/packages/server/src/arpa_reporter/services/validation-rules.js
+++ b/packages/server/src/arpa_reporter/services/validation-rules.js
@@ -69,12 +69,9 @@ const CONDITIONAL_REQS_CONFIGS = [
    into a more efficient lookup map */
 function convertConfigsToLookupMap() {
     const reqFnByFieldId = {}
-    for (const { fieldIDs, func } of CONDITIONAL_REQS_CONFIGS) {
-        for (const fieldID of fieldIDs) {
-            if (fieldID in reqFnByFieldId) {
-                throw new Error(`Field id ${fieldID} has overriding conditional requirements.`);
-            }
-            reqFnByFieldId[fieldID] = func;
+    for (const config of CONDITIONAL_REQS_CONFIGS) {
+        for (const fieldID of config.fieldIDs) {
+            reqFnByFieldId[fieldID] = config.func;
         }
     }
     return reqFnByFieldId;

--- a/packages/server/src/arpa_reporter/services/validation-rules.js
+++ b/packages/server/src/arpa_reporter/services/validation-rules.js
@@ -58,6 +58,10 @@ const CONDITIONAL_REQS_CONFIGS = [
         fieldIDs: optionalIfNotStartedFieldIds,
         func: optionalIfNotStarted
     },
+    {
+        fieldIDs: ['Cancellation_Reason__c'],
+        func: (record) => record.Completion_Status__c === 'Cancelled',
+    },
 ];
 
 /* The CONFIGS format above is convenient for when we want to write the conditional rules, but bad


### PR DESCRIPTION
### Ticket #378 

## Description
This PR aims to improve how we can enforce conditionally-required fields in ARPA reporter data (that is, fields that are sometimes required and sometimes not, depending on your answers to other questions).

This feature already existed in a hard-coded way, where we had a list of field ids that we knew should be treated as optional if the project status was "Not started".

This PR starts by refactoring that hard-coded feature in a way that is easier to add new conditions for new fields in the future. It creates a new `CONDITIONAL_REQS_CONFIGS` list for these configurations, and uses that to enforce the optional-if-not-started rules.

Then, in the second commit, I show how it is easy to add a new configuration. Here I added a rule that enforces that if the project status is "Cancelled", then the Cancellation_Reasons__c field must be required.

## Screenshots / Demo Video
I uploaded a test project that has status 'Cancelled' but no reason included. After commit 1 (refactoring the existing rule) but before commit 2 (adding the new cancellation_reason rule) we see that the file validates without errors:
<img width="636" alt="Screenshot 2023-03-07 at 10 55 21 AM" src="https://user-images.githubusercontent.com/3675290/223525158-78ca07b4-07ca-40e3-8dd2-ac7f7eedba47.png">

But after adding the 2-lines in commit 2, there is a new validation error:
<img width="632" alt="Screenshot 2023-03-07 at 10 56 30 AM" src="https://user-images.githubusercontent.com/3675290/223525220-04b54898-f8ea-4a9e-bf7a-cc6e913bed0d.png">


## Testing

### Automated and Unit Tests
- [x] Added Unit tests

### Manual tests for Reviewer
- [x] Added steps to test feature/functionality manually

## Checklist
- [x] Provided ticket and description
- [x] Provided screenshots/demo
- [x] Provided testing information
- [x] Provided adequate test coverage for all new code
- [x] Added PR reviewers