### PR TITLE
fix: reporting period dropdown does not expand (#1076)

### DIFF
--- a/packages/client/src/arpa_reporter/App.vue
+++ b/packages/client/src/arpa_reporter/App.vue
@@ -6,6 +6,7 @@
 
 <script>
 import '../../arpa_reporter/scss/index.scss';
+import 'bootstrap/dist/js/bootstrap.min';
 
 import Navigation from './components/Navigation.vue';
 


### PR DESCRIPTION
I had erroneously removed the bootstrap js import when resolving a merge commit. This puts it back.

### Ticket #1076
## Description
See above

## Screenshots / Demo Video
![Screenshot 2023-03-07 at 6 31 19 PM](https://user-images.githubusercontent.com/120750336/223579270-39955b7c-7e0e-42e8-9117-09f2dcb1c46a.jpg)


## Testing
Open the Reporting Period menu at the top of the screen - it should now open

### Automated and Unit Tests
- [ ] Added Unit tests
(N/A until we've got Cypress set up)

### Manual tests for Reviewer
- [x] Added steps to test feature/functionality manually

## Checklist
- [x] Provided ticket and description
- [x] Provided screenshots/demo
- [x] Provided testing information
- [x] Provided adequate test coverage for all new code
- [x] Added PR reviewers