### PR TITLE
fix: agency dropdown shows name, not code (#1078)

### DIFF
--- a/packages/client/src/arpa_reporter/views/NewUpload.vue
+++ b/packages/client/src/arpa_reporter/views/NewUpload.vue
@@ -110,7 +110,7 @@ export default {
       return Object.fromEntries(this.$store.getters.viewableReportingPeriods.map((period) => [period.id, period.name]));
     },
     agencySelectItems() {
-      return Object.fromEntries(this.$store.state.agencies.map((agency) => [agency.id, agency.name]));
+      return Object.fromEntries(this.$store.state.agencies.map((agency) => [agency.id, agency.code]));
     },
     // eslint-disable-next-line no-unused-vars
     async uploadFile(file, progress, error, options) {


### PR DESCRIPTION
I had previously used "name" as the value for the dropdown, assuming "code" was a numeric code. It's in fact a string, and should be shown in this dropdown.

### Ticket #1078 
## Description
See above

## Screenshots / Demo Video
Old:
![Screenshot 2023-03-07 at 11 50 46 PM](https://user-images.githubusercontent.com/120750336/223622651-edec9911-60d6-430e-abfb-6148ce961707.jpg)

New:
![Screenshot 2023-03-07 at 11 49 45 PM](https://user-images.githubusercontent.com/120750336/223622485-1a8e8327-819c-46c8-b966-0f6b7cda5e30.jpg)


## Testing
Go to http://localhost:8080/arpa_reporter/new_upload , expand the "Agency Code" dropdown.

### Automated and Unit Tests
- [ ] Added Unit tests
(N/A for now until we have cypress tests)

### Manual tests for Reviewer
- [x] Added steps to test feature/functionality manually

## Checklist
- [x] Provided ticket and description
- [x] Provided screenshots/demo
- [x] Provided testing information
- [x] Provided adequate test coverage for all new code
- [x] Added PR reviewers