### PR TITLE
fix: remove expenditure code field from NewUpload 

### DIFF
--- a/packages/client/src/arpa_reporter/views/NewUpload.vue
+++ b/packages/client/src/arpa_reporter/views/NewUpload.vue
@@ -58,12 +58,6 @@ export default {
           validation: 'required',
         },
         {
-          type: 'text',
-          label: 'Expenditure Code',
-          name: 'expenditure_code',
-          validation: 'required',
-        },
-        {
           type: 'file',
           label: 'Workbook File',
           name: 'spreadsheet',


### PR DESCRIPTION
Earlier screenshots had this field present, but partners gave the feedback that it should be removed. It is not actually used in the BE so we can safely remove.

### Ticket #1083 
## Description
See above 

## Screenshots / Demo Video
![Screenshot 2023-03-09 at 1 14 01 PM](https://user-images.githubusercontent.com/120750336/224118585-feea7d6e-38bd-466f-a706-e451ff4ecc1b.jpg)

(Note that until we merge https://github.com/usdigitalresponse/usdr-gost/pull/1079 , the Agency Code is still showing "name"). 

## Testing
Go to http://localhost:8080/arpa_reporter/new_upload , and inspect fields. "Expenditure Code" should not be present.

### Automated and Unit Tests
- [ ] Added Unit tests
(N/A for FE changes for now until cypress)

### Manual tests for Reviewer
- [x] Added steps to test feature/functionality manually

## Checklist
- [x] Provided ticket and description
- [x] Provided screenshots/demo
- [x] Provided testing information
- [x] Provided adequate test coverage for all new code
- [x] Added PR reviewers