### PR TITLE
feat: unique entity id requirement emphasis (#1027)

### DIFF
--- a/packages/server/__tests__/arpa_reporter/server/services/validate-upload.spec.js
+++ b/packages/server/__tests__/arpa_reporter/server/services/validate-upload.spec.js
@@ -167,63 +167,86 @@ describe('validate record', () => {
     });
 });
 
-describe('validateIdentifier function', () => {
+describe('validateIdentifier', () => {
     const validateIdentifier = validateUploadModule.__get__('validateIdentifier');
-
-    it('should return an error if recipient is a subrecipient or contractor and UEI is missing', async () => {
-        const recipient = { Entity_Type_2__c: 'Subrecipient' };
-        const errors = validateIdentifier(recipient);
-        expect(errors).to.eql([
+    it('should return an error if recipient is a new subrecipient or contractor and has no UEI', () => {
+        const recipient = {
+            Entity_Type__c: 'Subrecipient',
+            Unique_Entity_Identifier__c: null,
+            EIN__c: '123456789',
+        };
+        const recipientExists = false;
+        const errors = validateIdentifier(recipient, recipientExists);
+        assert.deepStrictEqual(errors, [
             new ValidationError(
-                'UEI is required for all subrecipients and contractors',
+                'UEI is required for all new subrecipients and contractors',
                 { col: 'C', severity: 'err' },
             ),
         ]);
     });
 
-    it('should return an error if recipient is a beneficiary and both EIN and UEI are missing', async () => {
-        const recipient = { Entity_Type_2__c: 'Beneficiary' };
-        const errors = validateIdentifier(recipient);
-        expect(errors).to.eql([
+    it('should return an error if entity type is semicolon-separated list that includes Subrecipient, and it has an UEI', () => {
+        const recipient = {
+            Entity_Type__c: 'Subrecipient;Benificiary',
+            Unique_Entity_Identifier__c: null,
+            EIN__c: '123456789',
+        };
+        const recipientExists = false;
+        const errors = validateIdentifier(recipient, recipientExists);
+        assert.deepStrictEqual(errors, [
             new ValidationError(
-                'At least one of UEI or TIN/EIN must be set for benficiaries, but both are missing',
+                'UEI is required for all new subrecipients and contractors',
+                { col: 'C', severity: 'err' },
+            ),
+        ]);
+    });
+
+    it('should not return an error if recipient is a new subrecipient or contractor and has a UEI', () => {
+        const recipient = {
+            Entity_Type__c: 'Subrecipient',
+            Unique_Entity_Identifier__c: '0123456789ABCDEF',
+            EIN__c: null,
+        };
+        const recipientExists = false;
+        const errors = validateIdentifier(recipient, recipientExists);
+        assert.deepStrictEqual(errors, []);
+    });
+
+    it('should not return an error if recipient is not a new subrecipient or contractor and has a UEI', () => {
+        const recipient = {
+            Entity_Type__c: 'Beneficiary',
+            Unique_Entity_Identifier__c: '0123456789ABCDEF',
+            EIN__c: null,
+        };
+        const recipientExists = true;
+        const errors = validateIdentifier(recipient, recipientExists);
+        assert.deepStrictEqual(errors, []);
+    });
+
+    it('should not return an error if recipient is not a new subrecipient or contractor and has a TIN', () => {
+        const recipient = {
+            Entity_Type__c: 'Beneficiary',
+            Unique_Entity_Identifier__c: null,
+            EIN__c: '123456789',
+        };
+        const recipientExists = true;
+        const errors = validateIdentifier(recipient, recipientExists);
+        assert.deepStrictEqual(errors, []);
+    });
+
+    it('should return an error if recipient is not a new subrecipient or contractor and has neither UEI nor TIN', () => {
+        const recipient = {
+            Entity_Type__c: 'Beneficiary',
+            Unique_Entity_Identifier__c: null,
+            EIN__c: null,
+        };
+        const recipientExists = true;
+        const errors = validateIdentifier(recipient, recipientExists);
+        assert.deepStrictEqual(errors, [
+            new ValidationError(
+                'At least one of UEI or TIN/EIN must be set, but both are missing',
                 { col: 'C, D', severity: 'err' },
             ),
         ]);
-    });
-
-    it('should not return an error if recipient is a beneficiary and EIN is present', async () => {
-        const recipient = { Entity_Type_2__c: 'Beneficiary', EIN__c: '123456789' };
-        const errors = validateIdentifier(recipient);
-        expect(errors).to.eql([]);
-    });
-
-    it('should not return an error if recipient is a beneficiary and UEI is present', async () => {
-        const recipient = { Entity_Type_2__c: 'Beneficiary', Unique_Entity_Identifier__c: '123456789' };
-        const errors = validateIdentifier(recipient);
-        expect(errors).to.eql([]);
-    });
-
-    it('should not return an error if recipient is a subrecipient or contractor and UEI is present', async () => {
-        const recipient = { Entity_Type_2__c: 'Subrecipient', Unique_Entity_Identifier__c: '123456789' };
-        const errors = validateIdentifier(recipient);
-        expect(errors).to.eql([]);
-    });
-
-    it('should return an error if at least one of Contractor and Subrecipient have been selected and no UEI is provided', async () => {
-        const recipient = { Entity_Type_2__c: 'Beneficiary;Contractor' };
-        const errors = validateIdentifier(recipient);
-        expect(errors).to.eql([
-            new ValidationError(
-                'UEI is required for all subrecipients and contractors',
-                { col: 'C', severity: 'err' },
-            ),
-        ]);
-    });
-
-    it('should not return an error if at least one of Contractor and Subrecipient have been selected and a UEI is provided', async () => {
-        const recipient = { Entity_Type_2__c: 'Beneficiary;Contractor', Unique_Entity_Identifier__c: '123456789' };
-        const errors = validateIdentifier(recipient);
-        expect(errors).to.eql([]);
     });
 });

--- a/packages/server/__tests__/arpa_reporter/server/services/validate-upload.spec.js
+++ b/packages/server/__tests__/arpa_reporter/server/services/validate-upload.spec.js
@@ -284,3 +284,37 @@ describe('validateIdentifier', () => {
         ]);
     });
 });
+
+describe('recipientBelongsToUpload', () => {
+    const recipientBelongsToUpload = validateUploadModule.__get__('recipientBelongsToUpload');
+    const upload = { id: '123' };
+
+    it('returns false if existing recipient is not provided', () => {
+        const result = recipientBelongsToUpload(null, upload);
+        expect(result).to.be.false;
+    });
+
+    it('returns false if existing recipient upload_id does not match the upload id', () => {
+        const existingRecipient = { upload_id: '456' };
+        const result = recipientBelongsToUpload(existingRecipient, upload);
+        expect(result).to.be.false;
+    });
+
+    it('returns false if existing recipient updated_at is defined', () => {
+        const existingRecipient = { upload_id: '123', updated_at: new Date() };
+        const result = recipientBelongsToUpload(existingRecipient, upload);
+        expect(result).to.be.false;
+    });
+
+    it('returns true if existing recipient upload_id matches the upload id and updated_at is undefined', () => {
+        const existingRecipient = { upload_id: '123' };
+        const result = recipientBelongsToUpload(existingRecipient, upload);
+        expect(result).to.be.true;
+    });
+
+    it('returns true if existing recipient upload_id matches the upload id and updated_at is null', () => {
+        const existingRecipient = { upload_id: '123', updated_at: null };
+        const result = recipientBelongsToUpload(existingRecipient, upload);
+        expect(result).to.be.true;
+    });
+});

--- a/packages/server/__tests__/arpa_reporter/server/services/validate-upload.spec.js
+++ b/packages/server/__tests__/arpa_reporter/server/services/validate-upload.spec.js
@@ -167,6 +167,40 @@ describe('validate record', () => {
     });
 });
 
+describe('findRecipientInDatabase', () => {
+    const findRecipientInDatabase = validateUploadModule.__get__('findRecipientInDatabase');
+    const recipient = {
+        Unique_Entity_Identifier__c: 'UEI123',
+        EIN__c: 'EIN123',
+    };
+    const trns = {}; // mock transaction object
+
+    afterEach(() => {
+        sinon.restore();
+    });
+
+    it('should return the recipient found by UEI', async () => {
+        const mockFindRecipient = sinon.stub().withArgs('UEI123', null, trns).resolves({ name: 'John' });
+        validateUploadModule.__set__('findRecipient', mockFindRecipient);
+        const result = await findRecipientInDatabase({ recipient, trns }, mockFindRecipient);
+        expect(result).to.deep.equal({ name: 'John' });
+    });
+
+    it('should return the recipient found by EIN', async () => {
+        const mockFindRecipient = sinon.stub().withArgs(null, 'EIN123', trns).resolves({ name: 'Jane' });
+        validateUploadModule.__set__('findRecipient', mockFindRecipient);
+        const result = await findRecipientInDatabase({ recipient, trns }, mockFindRecipient);
+        expect(result).to.deep.equal({ name: 'Jane' });
+    });
+
+    it('should return null if recipient is not found', async () => {
+        const mockFindRecipient = sinon.stub().resolves(null);
+        validateUploadModule.__set__('findRecipient', mockFindRecipient);
+        const result = await findRecipientInDatabase({ recipient, trns }, mockFindRecipient);
+        expect(result).to.be.null;
+    });
+});
+
 describe('validateIdentifier', () => {
     const validateIdentifier = validateUploadModule.__get__('validateIdentifier');
     it('should return an error if recipient is a new subrecipient or contractor and has no UEI', () => {

--- a/packages/server/__tests__/arpa_reporter/server/services/validate-upload.spec.js
+++ b/packages/server/__tests__/arpa_reporter/server/services/validate-upload.spec.js
@@ -205,7 +205,7 @@ describe('validateIdentifier', () => {
     const validateIdentifier = validateUploadModule.__get__('validateIdentifier');
     it('should return an error if recipient is a new subrecipient or contractor and has no UEI', () => {
         const recipient = {
-            Entity_Type__c: 'Subrecipient',
+            Entity_Type_2__c: 'Subrecipient',
             Unique_Entity_Identifier__c: null,
             EIN__c: '123456789',
         };
@@ -221,7 +221,7 @@ describe('validateIdentifier', () => {
 
     it('should return an error if entity type is semicolon-separated list that includes Subrecipient, and it has an UEI', () => {
         const recipient = {
-            Entity_Type__c: 'Subrecipient;Benificiary',
+            Entity_Type_2__c: 'Subrecipient;Benificiary',
             Unique_Entity_Identifier__c: null,
             EIN__c: '123456789',
         };
@@ -237,7 +237,7 @@ describe('validateIdentifier', () => {
 
     it('should not return an error if recipient is a new subrecipient or contractor and has a UEI', () => {
         const recipient = {
-            Entity_Type__c: 'Subrecipient',
+            Entity_Type_2__c: 'Subrecipient',
             Unique_Entity_Identifier__c: '0123456789ABCDEF',
             EIN__c: null,
         };
@@ -248,7 +248,7 @@ describe('validateIdentifier', () => {
 
     it('should not return an error if recipient is not a new subrecipient or contractor and has a UEI', () => {
         const recipient = {
-            Entity_Type__c: 'Beneficiary',
+            Entity_Type_2__c: 'Beneficiary',
             Unique_Entity_Identifier__c: '0123456789ABCDEF',
             EIN__c: null,
         };
@@ -259,7 +259,7 @@ describe('validateIdentifier', () => {
 
     it('should not return an error if recipient is not a new subrecipient or contractor and has a TIN', () => {
         const recipient = {
-            Entity_Type__c: 'Beneficiary',
+            Entity_Type_2__c: 'Beneficiary',
             Unique_Entity_Identifier__c: null,
             EIN__c: '123456789',
         };
@@ -270,7 +270,7 @@ describe('validateIdentifier', () => {
 
     it('should return an error if recipient is not a new subrecipient or contractor and has neither UEI nor TIN', () => {
         const recipient = {
-            Entity_Type__c: 'Beneficiary',
+            Entity_Type_2__c: 'Beneficiary',
             Unique_Entity_Identifier__c: null,
             EIN__c: null,
         };

--- a/packages/server/src/arpa_reporter/services/validate-upload.js
+++ b/packages/server/src/arpa_reporter/services/validate-upload.js
@@ -265,7 +265,7 @@ function validateIdentifier(recipient, recipientExists) {
  * @returns {boolean} - true if the recipient belongs to the upload
  */
 function recipientBelongsToUpload(existingRecipient, upload) {
-    return existingRecipient && existingRecipient.upload_id === upload.id && !existingRecipient.updated_at;
+    return Boolean(existingRecipient) && existingRecipient.upload_id === upload.id && !existingRecipient.updated_at;
 }
 
 /**


### PR DESCRIPTION
UEI is now required for entities of type "Contractor" and "Subrecipient". Update our validation logic to reflect this.

### Ticket #1027 
## Description
Updates our validation logic to reflect new treasury rules.

## Screenshots / Demo Video
Coming soon post confirmation of logic over on https://github.com/usdigitalresponse/usdr-gost/issues/1027

## Testing
Upload a sheet with a Subrecipient row that is missing a UEI but is of type "Subrecipient" - you should see a validation failure

### Automated and Unit Tests
- [x] Added Unit tests

### Manual tests for Reviewer
- [x] Added steps to test feature/functionality manually

## Checklist
- [x] Provided ticket and description
- [x] Provided screenshots/demo
- [x] Provided testing information
- [x] Provided adequate test coverage for all new code
- [x] Added PR reviewers

## NOTE
I am not sure I did the logic correctly for the db update -- see questions over at https://github.com/usdigitalresponse/usdr-gost/issues/1027