### PR TITLE
fix: unique entity id requirement emphasis #1027

### DIFF
--- a/packages/server/__tests__/arpa_reporter/server/services/validate-upload.spec.js
+++ b/packages/server/__tests__/arpa_reporter/server/services/validate-upload.spec.js
@@ -320,3 +320,38 @@ describe('updateOrCreateRecipient', () => {
         sinon.assert.notCalled(updateRecipientStub);
     });
 });
+
+describe('validateSubrecipientRecord', () => {
+    const validateSubrecipientRecord = validateUploadModule.__get__('validateSubrecipientRecord');
+    it('returns an empty array and updates the recipient when the record is valid', async () => {
+        const recipient = {
+            Entity_Type_2__c: 'Subrecipient',
+            Unique_Entity_Identifier__c: null,
+            EIN__c: '123456789',
+        };
+        const existingRecipient = undefined;
+        const findRecipientStub = sinon.stub().resolves(existingRecipient);
+        const updateRecipientStub = sinon.stub().resolves();
+
+        const upload = { id: 123 };
+        const recordErrors = [];
+        const trns = 'TRNS123';
+
+        validateUploadModule.__set__('findRecipientInDatabase', findRecipientStub);
+        validateUploadModule.__set__('updateOrCreateRecipient', updateRecipientStub);
+
+        const errors = await validateSubrecipientRecord({
+            upload,
+            record: recipient,
+            recordErrors,
+            trns,
+        });
+        assert.deepStrictEqual(errors, [
+            new ValidationError(
+                'UEI is required for all new subrecipients and contractors',
+                { col: 'C', severity: 'err' },
+            ),
+        ]);
+        sinon.assert.notCalled(updateRecipientStub);
+    });
+});

--- a/packages/server/src/arpa_reporter/services/validate-upload.js
+++ b/packages/server/src/arpa_reporter/services/validate-upload.js
@@ -215,7 +215,7 @@ async function validateSubrecipientRecord({
 }) {
     const errors = [];
     const existingRecipient = await findRecipientInDatabase({ recipient, trns });
-    errors.concat(validateIdentifier(recipient, !existingRecipient));
+    errors.push(...validateIdentifier(recipient, existingRecipient));
 
     // Either: the record has already been validated before this method was invoked, or
     // we found an error above. If it's not valid, don't update or create it


### PR DESCRIPTION
Fixes logic around UEI requirement in validateSubrecipientRecord, and adds a unit test to validate the logic.

### Ticket #1027
## Description
There was an error in the logic of my original fix for 1027. Unfortunately it was not caught because there was no test for the top-level method itself -- just the methods it called. This fixes the logic error and adds unit tests. 

## Screenshots / Demo Video
N/A

## Testing
Upload `NEW 10001 - DHS - EC2_36 - v20230312 - FAIL UEI.xlsm`, provided by Joe in Slack - it should fail. `NEW 10001 - DHS - EC2_36 - v20230312 - CLEAN Beneficiary.xlsm` should pass. 

### Automated and Unit Tests
- [x] Added Unit tests

### Manual tests for Reviewer
- [x] Added steps to test feature/functionality manually

## Checklist
- [x] Provided ticket and description
- [x] Provided screenshots/demo
- [x] Provided testing information
- [x] Provided adequate test coverage for all new code
- [x] Added PR reviewers