### PR TITLE
Fix: #877 Coalesce to no-op statement for dynamic execute query

### DIFF
--- a/packages/server/migrations/20230219162719_migrate_varchar_columns_to_text.js
+++ b/packages/server/migrations/20230219162719_migrate_varchar_columns_to_text.js
@@ -7,23 +7,25 @@ exports.up = async function (knex) {
         DO $bulkmigration$
         BEGIN
         EXECUTE (
-        SELECT
-            string_agg(
-                format (
-                'ALTER TABLE %I ALTER COLUMN %I TYPE text',
-                c.table_name,
-                c.column_name
-                ),
-            E';\n')
-        FROM information_schema.columns c
-            JOIN information_schema.tables t
-            ON t.table_schema = c.table_schema
-            AND t.table_name = c.table_name
-            AND t.table_type = 'BASE TABLE'
-        WHERE c.data_type = 'character varying'
-            AND c.table_schema NOT IN ('information_schema', 'pg_catalog')
-            AND c.table_name NOT IN ('migrations')
-        );
+            SELECT coalesce(
+                string_agg(
+                    format (
+                    'ALTER TABLE %I ALTER COLUMN %I TYPE text',
+                    c.table_name,
+                    c.column_name
+                    ),
+                E';\n'),
+                'select 1'
+            )
+            FROM information_schema.columns c
+                JOIN information_schema.tables t
+                ON t.table_schema = c.table_schema
+                AND t.table_name = c.table_name
+                AND t.table_type = 'BASE TABLE'
+            WHERE c.data_type = 'character varying'
+                AND c.table_schema NOT IN ('information_schema', 'pg_catalog')
+                AND c.table_name NOT IN ('migrations')
+            );
         END
         $bulkmigration$;
     `);


### PR DESCRIPTION
### Ticket #877
## Description

This PR fixes a slight issue with the original implementation of #877 in PR #988 that caused the database migration to fail when there are no columns of type `varchar` that can be migrated to `text`. In this condition, the dynamic `alter table ... alter column ...` statements produced for each existing `varchar` column would yield a null result, causing the execution to fail with `query string argument of EXECUTE is null`.

The solution provided by this PR modifies the `select` expression that aggregates the dynamic `alter table ... alter column ...` statements so that it coalesces to a "no-op" query (simply `select 1;`) that gets provided to the as the "dynamic" argument to the `execute` rather than a null value.

In other words, this:
```sql
EXECUTE (
  SELECT 
    string_agg( ... ) # Aggregated dynamic ALTER TABLE ... ALTER COLUMN ... queries that may be null
  FROM ...
);
```
becomes this:
```sql
EXECUTE (
  SELECT coalesce(
    string_agg( ... ), # Aggregated dynamic ALTER TABLE ... ALTER COLUMN ... queries that may be null
    'select 1'         # Fallback to no-op when above string_agg is null
  )
  FROM ...
);
```

## Testing

To test, I migrated the db to the revision prior to `20230219162719_migrate_varchar_columns_to_text.js` (`20230212213443_add_notes.js`), then ran the former migration, ensuring that there were no `varchar` columns in the database. Then:
1. In a `psql` shell: `alter table grants alter column grant_id type varchar(255);`
2. On the `app` docker container: `yarn knex migrate:down` to go back to `20230219162719_migrate_varchar_columns_to_text.js`
3. In `psql`, verify that `grants.grant_id` column is (still) `varchar(255)`.
4. On the `app` docker container: `yarn db:migrate` to run the migration again.
5. In `psql`, verify that `grants.grant_id` column is (once again) `text`.

### Automated and Unit Tests
- ~~[ ] Added Unit tests~~

### Manual tests for Reviewer
- [X] Added steps to test feature/functionality manually

## Checklist
- [X] Provided ticket and description
- [X] Provided screenshots/demo
- [X] Provided testing information
- [X] Provided adequate test coverage for all new code
- [X] Added PR reviewers