### PR TITLE
fix: Ensures zero-agency-id can upload documents correctly

### DIFF
--- a/packages/client/src/arpa_reporter/views/NewUpload.vue
+++ b/packages/client/src/arpa_reporter/views/NewUpload.vue
@@ -119,7 +119,7 @@ export default {
       const uploadFormData = new FormData();
       uploadFormData.append('spreadsheet', data.spreadsheet[0]);
       Object.entries(_.omit(data, ['spreadsheet'])).forEach(([key, value]) => {
-        if (value) {
+        if (value !== undefined || value !== null) {
           uploadFormData.append(key, value);
         }
       });

--- a/packages/client/src/arpa_reporter/views/NewUpload.vue
+++ b/packages/client/src/arpa_reporter/views/NewUpload.vue
@@ -119,7 +119,7 @@ export default {
       const uploadFormData = new FormData();
       uploadFormData.append('spreadsheet', data.spreadsheet[0]);
       Object.entries(_.omit(data, ['spreadsheet'])).forEach(([key, value]) => {
-        if (value !== undefined || value !== null) {
+        if (value !== undefined && value !== null) {
           uploadFormData.append(key, value);
         }
       });


### PR DESCRIPTION
### Ticket #<Enter Number Here To Auto-Link>
## Description
- There was a bug where uploaded documents had a `null` agencyId.

## Screenshots / Demo Video

### Before
<img width="329" alt="image" src="https://user-images.githubusercontent.com/6497366/226757266-99d61951-1db0-460f-af38-2c182f03bd93.png">

### After
<img width="345" alt="image" src="https://user-images.githubusercontent.com/6497366/226757160-2c4893dc-ce0c-46eb-8ef9-038c5da9c60c.png">


## Testing

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [ ] Provided ticket and description
- [ ] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers