### PR TITLE
Hide multiselect labels on grants table and grant details

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -10,7 +10,8 @@ With Docker and Docker Compose installed on your workstation, complete the follo
 steps to prepare your environment:
 
 1. If you have not already done so, copy the file at `packages/server/.env.example`
-  to `packages/server/.env`.
+  to `packages/server/.env`, and copy the file at `packages/client/.env.example`
+  to `packages/client/.env`
 2. Set the following environment variables in `packages/server/.env` accordingly:
   - `POSTGRES_URL=postgresql://postgres:password123@postgres:5432/usdr_grants`
   - `POSTGRES_TEST_URL=postgresql://postgres:password123@postgres:5432/usdr_grants_test`

--- a/docs/setup-mac.md
+++ b/docs/setup-mac.md
@@ -43,7 +43,7 @@ Install ASDF using the instructions [here](https://asdf-vm.com/guide/getting-sta
 
 ### Gmail Setup
 
-See [./setup-email.md](./setup-email.md) for instructions on setting up Gmail to send emails.
+See [./setup-gmail.md](./setup-gmail.md) for instructions on setting up Gmail to send emails.
 
 ## Installation
 

--- a/packages/client/src/components/GrantsTable.vue
+++ b/packages/client/src/components/GrantsTable.vue
@@ -19,22 +19,22 @@
     <b-row class="mt-3 mb-3" align-h="start" style="position: relative; z-index: 999">
       <b-col v-if="!showInterested && !showRejected && !showResult && !showAssignedToAgency" cols="3">
         <multiselect v-model="reviewStatusFilters" :options="reviewStatusOptions" :multiple="true"
-          :close-on-select="false" :clear-on-select="false" placeholder="Review Status">
+          :close-on-select="false" :clear-on-select="false" placeholder="Review Status" :show-labels="false">
         </multiselect>
       </b-col>
       <b-col cols="3">
         <multiselect v-model="opportunityStatusFilters" :options="opportunityStatusOptions" :multiple="true"
-                     :close-on-select="false" :clear-on-select="false" placeholder="Opportunity Status">
+                     :close-on-select="false" :clear-on-select="false" placeholder="Opportunity Status" :show-labels="false">
         </multiselect>
       </b-col>
       <b-col cols="3">
         <multiselect v-model="opportunityCategoryFilters" :options="opportunityCategoryOptions" :multiple="true"
-                     :close-on-select="false" :clear-on-select="false" placeholder="Opportunity Category">
+                     :close-on-select="false" :clear-on-select="false" placeholder="Opportunity Category" :show-labels="false">
         </multiselect>
       </b-col>
       <b-col cols="2">
         <multiselect v-model="costSharingFilter" :options="costSharingOptions" :multiple="false"
-                     :close-on-select="true" :clear-on-select="false" placeholder="Cost Sharing">
+                     :close-on-select="true" :clear-on-select="false" placeholder="Cost Sharing" :show-labels="false">
         </multiselect>
       </b-col>
     </b-row>

--- a/packages/client/src/components/Modals/GrantDetails.vue
+++ b/packages/client/src/components/Modals/GrantDetails.vue
@@ -73,7 +73,7 @@
         <h4>Assigned Agencies</h4>
           <multiselect v-model="selectedAgencies" :options="agencies" :multiple="true" :close-on-select="false"
             :clear-on-select="false" placeholder="Select agencies" label="name" track-by="id"
-            style="width: 300px; margin: 0 16px;"
+            style="width: 300px; margin: 0 16px;" :show-labels="false"
           >
           </multiselect>
           <b-button variant="outline-success" @click="assignAgenciesToGrant">Assign</b-button>


### PR DESCRIPTION
### Ticket #984
## Description
Hide multiselect labels which aren't necessary and cause overlap issues on smaller screens for certain components.

fixes usdigitalresponse/usdr-gost#984

## Screenshots / Demo Video
<img width="412" alt="image" src="https://user-images.githubusercontent.com/624510/228109984-edd8a3bc-d7d1-4e1d-a8cf-d814d4c986c9.png">

## Testing
Open the various Multiselects (4 on main grants table, 1 on grant details) and observe that "Press enter to select" label is gone. 

I didn't write a unit test since there aren't existing tests for these components (right?), and I think the Cypress stuff is just getting started. But if anyone would prefer I'd include one here, I'm happy to do so. 

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [x] Added steps to test feature/functionality manually

## Checklist
- [x] Provided ticket and description
- [x] Provided screenshots/demo
- [x] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [x] Added PR reviewers