### PR TITLE
feat: adds an s3 bucket to store arpa reporting data

### DIFF
--- a/terraform/modules/gost_api/main.tf
+++ b/terraform/modules/gost_api/main.tf
@@ -10,3 +10,14 @@ module "this" {
   name    = var.namespace
   tags    = var.tags
 }
+
+module "s3_label" {
+  source  = "cloudposse/label/null"
+  version = "0.25.0"
+
+  context = module.this.context
+  attributes = [
+    data.aws_caller_identity.current.account_id,
+    data.aws_region.current.name,
+  ]
+}

--- a/terraform/modules/gost_api/storage.tf
+++ b/terraform/modules/gost_api/storage.tf
@@ -23,3 +23,37 @@ module "efs_data_volume" {
     }
   }
 }
+
+module "arpa_audit_reports_bucket" {
+  source  = "cloudposse/s3-bucket/aws"
+  version = "3.0.0"
+  context = module.s3_label.context
+  name    = "arpa_audit_reports"
+
+  acl                          = "private"
+  versioning_enabled           = true
+  sse_algorithm                = "AES256"
+  allow_ssl_requests_only      = true
+  allow_encrypted_uploads_only = true
+  source_policy_documents      = []
+
+  lifecycle_configuration_rules = [
+    {
+      enabled                                = true
+      id                                     = "rule-1"
+      filter_and                             = null
+      abort_incomplete_multipart_upload_days = 1
+      transition                             = [{ days = null }]
+      expiration                             = { days = null }
+      noncurrent_version_transition = [
+        {
+          days          = 30
+          storage_class = "GLACIER"
+        },
+      ]
+      noncurrent_version_expiration = {
+        days = 2557 # 7 years (includes 2 leap days)
+      }
+    }
+  ]
+}

--- a/terraform/modules/gost_api/storage.tf
+++ b/terraform/modules/gost_api/storage.tf
@@ -39,6 +39,7 @@ module "arpa_audit_reports_bucket" {
 
   lifecycle_configuration_rules = [
     {
+      enabled                                = true
       id                                     = "rule-1"
       filter_and                             = null
       abort_incomplete_multipart_upload_days = 1

--- a/terraform/modules/gost_api/storage.tf
+++ b/terraform/modules/gost_api/storage.tf
@@ -41,19 +41,9 @@ module "arpa_audit_reports_bucket" {
     {
       enabled                                = true
       id                                     = "rule-1"
-      filter_and                             = null
       abort_incomplete_multipart_upload_days = 1
-      transition                             = [{ days = null }]
-      expiration                             = { days = null }
-      noncurrent_version_transition = [
-        {
-          days          = 30
-          storage_class = "GLACIER"
-        },
-      ]
-      noncurrent_version_expiration = {
-        days = 7
-      }
+      expiration                             = { days = 14 }
+      noncurrent_version_expiration          = { days = 7 }
     }
   ]
 }

--- a/terraform/modules/gost_api/storage.tf
+++ b/terraform/modules/gost_api/storage.tf
@@ -24,20 +24,6 @@ module "efs_data_volume" {
   }
 }
 
-data "aws_region" "current" {}
-data "aws_caller_identity" "current" {}
-
-module "s3_label" {
-  source  = "cloudposse/label/null"
-  version = "0.25.0"
-
-  context = module.this.context
-  attributes = [
-    data.aws_caller_identity.current.account_id,
-    data.aws_region.current.name,
-  ]
-}
-
 module "arpa_audit_reports_bucket" {
   source  = "cloudposse/s3-bucket/aws"
   version = "3.0.0"

--- a/terraform/modules/gost_api/storage.tf
+++ b/terraform/modules/gost_api/storage.tf
@@ -39,11 +39,32 @@ module "arpa_audit_reports_bucket" {
 
   lifecycle_configuration_rules = [
     {
-      enabled                                = true
       id                                     = "rule-1"
+      filter_and                             = null
       abort_incomplete_multipart_upload_days = 1
       expiration                             = { days = 14 }
+      transition                             = null
       noncurrent_version_expiration          = { days = 7 }
+      noncurrent_version_transition          = null
     }
   ]
+}
+
+module "access_arpa_reports_bucket_policy" {
+  source  = "cloudposse/iam-policy/aws"
+  version = "0.4.0"
+  context = module.s3_label.context
+
+  name = "access_arpa_reports_bucket"
+
+  iam_policy_statements = {
+    ReadWriteBucketObjects = {
+      effect = "Allow"
+      actions = [
+        "s3:PutObject",
+        "s3:GetObject",
+      ]
+      resources = ["${module.arpa_audit_reports_bucket.bucket_arn}/*"]
+    }
+  }
 }

--- a/terraform/modules/gost_api/storage.tf
+++ b/terraform/modules/gost_api/storage.tf
@@ -24,6 +24,20 @@ module "efs_data_volume" {
   }
 }
 
+data "aws_region" "current" {}
+data "aws_caller_identity" "current" {}
+
+module "s3_label" {
+  source  = "cloudposse/label/null"
+  version = "0.25.0"
+
+  context = module.this.context
+  attributes = [
+    data.aws_caller_identity.current.account_id,
+    data.aws_region.current.name,
+  ]
+}
+
 module "arpa_audit_reports_bucket" {
   source  = "cloudposse/s3-bucket/aws"
   version = "3.0.0"
@@ -52,7 +66,7 @@ module "arpa_audit_reports_bucket" {
         },
       ]
       noncurrent_version_expiration = {
-        days = 2557 # 7 years (includes 2 leap days)
+        days = 7
       }
     }
   ]

--- a/terraform/modules/gost_api/task.tf
+++ b/terraform/modules/gost_api/task.tf
@@ -187,9 +187,9 @@ resource "aws_iam_role" "task" {
 
 resource "aws_iam_role_policy" "task" {
   for_each = !var.enabled ? {} : {
-    connect-to-postgres = module.connect_to_postgres_policy.json
-    ecs-exec            = module.ecs_exec_policy.json
-    send-emails         = module.send_emails_policy.json
+    connect-to-postgres   = module.connect_to_postgres_policy.json
+    ecs-exec              = module.ecs_exec_policy.json
+    send-emails           = module.send_emails_policy.json
     rw-arpa-audit-reports = module.access_arpa_reports_bucket_policy.json
   }
 

--- a/terraform/modules/gost_api/task.tf
+++ b/terraform/modules/gost_api/task.tf
@@ -190,6 +190,7 @@ resource "aws_iam_role_policy" "task" {
     connect-to-postgres = module.connect_to_postgres_policy.json
     ecs-exec            = module.ecs_exec_policy.json
     send-emails         = module.send_emails_policy.json
+    rw-arpa-audit-reports = module.access_arpa_reports_bucket_policy.json
   }
 
   name   = each.key


### PR DESCRIPTION
### Ticket #1132 
## Description
- Adds an S3 bucket to store audit-report files

## Screenshots / Demo Video

## Testing
- Confirmed the terraform validate and and plan CI action is able to create the correct resources.

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [ ] Provided ticket and description
- [ ] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers