### PR TITLE
email settings banner

### DIFF
--- a/packages/client/src/components/EmailSettingsBanner.vue
+++ b/packages/client/src/components/EmailSettingsBanner.vue
@@ -49,7 +49,6 @@ export default {
       const updatedPreferences = {
         GRANT_ASSIGNMENT: 'UNSUBSCRIBED',
         GRANT_DIGEST: 'UNSUBSCRIBED',
-        GRANT_INTEREST: 'UNSUBSCRIBED',
       };
       if (isOptIn) {
         Object.keys(updatedPreferences).forEach((notificationType) => { updatedPreferences[notificationType] = 'SUBSCRIBED'; });
@@ -61,6 +60,8 @@ export default {
     },
     setToggleIfAllIsSubscribedTo() {
       // Set default toggle to true only if all email preferences are already subscribed to.
+      const userEmailPreferences = this.loggedInUser.emailPreferences;
+      delete userEmailPreferences.GRANT_INTEREST; // ignore grant interest since it's not a setting in User Preferences UI yet.
       const isAllSubscribedTo = Object.values(this.loggedInUser.emailPreferences).every((optInValue) => optInValue === 'SUBSCRIBED');
       if (isAllSubscribedTo) {
         this.checked = true;

--- a/packages/client/src/components/EmailSettingsBanner.vue
+++ b/packages/client/src/components/EmailSettingsBanner.vue
@@ -1,0 +1,83 @@
+<template>
+    <div>
+      <b-alert style="display: flex;" variant="success" show v-model="showBanner" dismissible>
+          <b-icon icon="envelope-fill" font-scale="1.5" style="padding-right: 10px;"></b-icon>
+          <div style="padding-right: 10px;">
+          <b>The Grant ID Tool now has email notifications!</b>
+          Fine tune which email you will recieve in Settings or turn on all notifications here:
+        </div >
+        <b-form-checkbox v-model="checked" name="email-opt-in-switch" switch @change="onUserSubscriptionChangeSubmit"/>
+      </b-alert>
+      <b-alert
+        id="email-settings-banner"
+        ref="modal"
+        title="Email Settings Banner"
+        @show="resetModal"
+        @hidden="resetModal"
+        ok-only
+      >
+      </b-alert>
+    </div>
+  </template>
+
+<script>
+import { mapActions, mapGetters } from 'vuex';
+// import { required, numeric, minValue } from 'vuelidate/lib/validators';
+
+export default {
+  props: {
+    showBanner: Boolean,
+  },
+  data() {
+    return {
+      checked: true,
+    };
+  },
+  validations: {
+    formData: {
+    },
+  },
+  watch: {
+    showModal() {
+      this.$bvModal.show('profile-settings-modal');
+    },
+  },
+  computed: {
+    ...mapGetters({
+      loggedInUser: 'users/loggedInUser',
+    }),
+    agencies() {
+      if (!this.loggedInUser) {
+        return [];
+      }
+      return this.loggedInUser.agency.subagencies;
+    },
+  },
+  mounted() {
+    if (this.$route.query.manageSettings === 'true') {
+      this.$emit('update:showModal', true);
+    }
+  },
+  methods: {
+    ...mapActions({
+      updateEmailSubscriptionPreferences: 'users/updateEmailSubscriptionPreferences',
+    }),
+    resetModal() {
+      this.$emit('update:showModal', false);
+    },
+    onUserSubscriptionChangeSubmit(isOptIn) {
+      const updatedPreferences = {
+        GRANT_ASSIGNMENT: 'UNSUBSCRIBED',
+        GRANT_DIGEST: 'UNSUBSCRIBED',
+      };
+      if (isOptIn) {
+        Object.keys(updatedPreferences).forEach((notificationType) => { updatedPreferences[notificationType] = 'SUBSCRIBED'; });
+      }
+      this.updateEmailSubscriptionPreferences({
+        userId: this.loggedInUser.id,
+        preferences: updatedPreferences,
+      });
+    },
+  },
+};
+</script>

--- a/packages/client/src/components/EmailSettingsBanner.vue
+++ b/packages/client/src/components/EmailSettingsBanner.vue
@@ -1,6 +1,6 @@
 <template>
     <div>
-      <b-alert style="display: flex;  text-align: center;" variant="success" show v-model="showBanner" dismissible>
+      <b-alert style="display: flex;  text-align: center; max-width: 1100px;" variant="success" show v-model="showBanner" dismissible>
           <b-icon icon="envelope-fill" font-scale="1.5" style="width: 50px; color: #0FA958;"></b-icon>
           <div style="padding-right: 10px; color: #212529;">
           <b>The Grant ID Tool now has email notifications!</b>

--- a/packages/client/src/components/EmailSettingsBanner.vue
+++ b/packages/client/src/components/EmailSettingsBanner.vue
@@ -30,7 +30,7 @@ export default {
   },
   data() {
     return {
-      checked: true,
+      checked: false,
     };
   },
   computed: {

--- a/packages/client/src/components/EmailSettingsBanner.vue
+++ b/packages/client/src/components/EmailSettingsBanner.vue
@@ -49,6 +49,7 @@ export default {
       const updatedPreferences = {
         GRANT_ASSIGNMENT: 'UNSUBSCRIBED',
         GRANT_DIGEST: 'UNSUBSCRIBED',
+        GRANT_INTEREST: 'UNSUBSCRIBED',
       };
       if (isOptIn) {
         Object.keys(updatedPreferences).forEach((notificationType) => { updatedPreferences[notificationType] = 'SUBSCRIBED'; });
@@ -58,6 +59,16 @@ export default {
         preferences: updatedPreferences,
       });
     },
+    setToggleIfAllIsSubscribedTo() {
+      // Set default toggle to true only if all email preferences are already subscribed to.
+      const isAllSubscribedTo = Object.values(this.loggedInUser.emailPreferences).every((optInValue) => optInValue === 'SUBSCRIBED');
+      if (isAllSubscribedTo) {
+        this.checked = true;
+      }
+    },
+  },
+  mounted() {
+    this.setToggleIfAllIsSubscribedTo();
   },
 };
 </script>

--- a/packages/client/src/components/EmailSettingsBanner.vue
+++ b/packages/client/src/components/EmailSettingsBanner.vue
@@ -1,10 +1,10 @@
 <template>
     <div>
-      <b-alert style="display: flex;" variant="success" show v-model="showBanner" dismissible>
-          <b-icon icon="envelope-fill" font-scale="1.5" style="padding-right: 10px;"></b-icon>
+      <b-alert style="display: flex;  text-align: center;" variant="success" show v-model="showBanner" dismissible>
+          <b-icon icon="envelope-fill" font-scale="1.5" style="width: 50px;" ></b-icon>
           <div style="padding-right: 10px;">
           <b>The Grant ID Tool now has email notifications!</b>
-          Fine tune which email you will recieve in Settings or turn on all notifications here:
+          Fine tune which email you will recieve in <u v-on:click="showProfileSettings()">Settings</u> or turn on all notifications here:
         </div >
         <b-form-checkbox v-model="checked" name="email-opt-in-switch" switch @change="onUserSubscriptionChangeSubmit"/>
       </b-alert>
@@ -22,41 +22,21 @@
 
 <script>
 import { mapActions, mapGetters } from 'vuex';
-// import { required, numeric, minValue } from 'vuelidate/lib/validators';
 
 export default {
   props: {
     showBanner: Boolean,
+    showProfileSettings: Function,
   },
   data() {
     return {
       checked: true,
     };
   },
-  validations: {
-    formData: {
-    },
-  },
-  watch: {
-    showModal() {
-      this.$bvModal.show('profile-settings-modal');
-    },
-  },
   computed: {
     ...mapGetters({
       loggedInUser: 'users/loggedInUser',
     }),
-    agencies() {
-      if (!this.loggedInUser) {
-        return [];
-      }
-      return this.loggedInUser.agency.subagencies;
-    },
-  },
-  mounted() {
-    if (this.$route.query.manageSettings === 'true') {
-      this.$emit('update:showModal', true);
-    }
   },
   methods: {
     ...mapActions({

--- a/packages/client/src/components/EmailSettingsBanner.vue
+++ b/packages/client/src/components/EmailSettingsBanner.vue
@@ -1,8 +1,8 @@
 <template>
     <div>
       <b-alert style="display: flex;  text-align: center;" variant="success" show v-model="showBanner" dismissible>
-          <b-icon icon="envelope-fill" font-scale="1.5" style="width: 50px;" ></b-icon>
-          <div style="padding-right: 10px;">
+          <b-icon icon="envelope-fill" font-scale="1.5" style="width: 50px; color: #0FA958;"></b-icon>
+          <div style="padding-right: 10px; color: #212529;">
           <b>The Grant ID Tool now has email notifications!</b>
           Fine tune which email you will recieve in <u v-on:click="showProfileSettings()">Settings</u> or turn on all notifications here:
         </div >

--- a/packages/client/src/components/Layout.vue
+++ b/packages/client/src/components/Layout.vue
@@ -41,7 +41,7 @@
     </b-nav>
 
     <div style="margin-top: 10px">
-      <section class="container-fluid">
+      <section class="container-fluid" style="display: flex; justify-content: center;">
         <AlertBox v-for="(alert, alertId) in alerts" :key="alertId" v-bind="alert" v-on:dismiss="dismissAlert(alertId)" />
         <EmailSettingsBanner
         :showBanner.sync="showOptInEmailBanner"

--- a/packages/client/src/components/Layout.vue
+++ b/packages/client/src/components/Layout.vue
@@ -43,6 +43,9 @@
     <div style="margin-top: 10px">
       <section class="container-fluid">
         <AlertBox v-for="(alert, alertId) in alerts" :key="alertId" v-bind="alert" v-on:dismiss="dismissAlert(alertId)" />
+        <EmailSettingsBanner
+        :showBanner.sync="showOptInEmailBanner"
+        />
       </section>
 
       <router-view />
@@ -55,6 +58,7 @@
 <script>
 import { mapGetters } from 'vuex';
 import ProfileSettingsModal from '@/components/Modals/ProfileSettings.vue';
+import EmailSettingsBanner from '@/components/EmailSettingsBanner.vue';
 import AlertBox from '../arpa_reporter/components/AlertBox.vue';
 
 export default {
@@ -62,10 +66,12 @@ export default {
   components: {
     AlertBox,
     ProfileSettingsModal,
+    EmailSettingsBanner,
   },
   data() {
     return {
       showProfileSettingModal: false,
+      showOptInEmailBanner: true,
     };
   },
   computed: {

--- a/packages/client/src/components/Layout.vue
+++ b/packages/client/src/components/Layout.vue
@@ -45,6 +45,7 @@
         <AlertBox v-for="(alert, alertId) in alerts" :key="alertId" v-bind="alert" v-on:dismiss="dismissAlert(alertId)" />
         <EmailSettingsBanner
         :showBanner.sync="showOptInEmailBanner"
+        :showProfileSettings="settingsClicked"
         />
       </section>
 


### PR DESCRIPTION
### Ticket #936
## Description
Banner for letting users know that they can easily change their email subscriptions
## Screenshots / Demo Video
<img width="1512" alt="Screenshot 2023-03-29 at 2 40 08 PM" src="https://user-images.githubusercontent.com/3173822/228662106-a15fe28c-be67-491e-a112-96208afd87e4.png">


## Testing
manual testing steps:
- banner should show up when running app
- dismissed x button on banner should close the app
- settings should link to email preferences page to change them
- toggle should change email preferences for both grants and arpa tool
### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [x] Provided ticket and description
- [x] Provided screenshots/demo
- [x] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers