### PR TITLE
feat: adds bucket name as env var

### DIFF
--- a/packages/server/.env.example
+++ b/packages/server/.env.example
@@ -38,3 +38,5 @@ NODEMAILER_EMAIL_PW=""
 # This is /var/data on Render
 DATA_DIR="./data"
 
+# S3 bucket for ARPA Audit reports
+AUDIT_REPORT_BUCKET=arpa-audit-reports

--- a/packages/server/src/arpa_reporter/lib/audit-report.js
+++ b/packages/server/src/arpa_reporter/lib/audit-report.js
@@ -11,7 +11,6 @@ const { ARPA_REPORTER_BASE_URL } = require('../environment');
 const email = require('../../lib/email');
 
 const SEVEN_DAYS_IN_SECONDS = 604800;
-const AUDIT_REPORT_BUCKET = 'arpa-audit-reports';
 
 const COLUMN = {
     EC_BUDGET: 'Adopted Budget (EC tabs)',
@@ -196,7 +195,7 @@ function getS3Client() {
 async function presignAndSendEmail(Key, recipientEmail) {
     const s3 = module.exports.getS3Client();
     // Generate presigned url to get the object
-    const signingParams = { Bucket: AUDIT_REPORT_BUCKET, Key, Expires: SEVEN_DAYS_IN_SECONDS };
+    const signingParams = { Bucket: process.env.AUDIT_REPORT_BUCKET, Key, Expires: SEVEN_DAYS_IN_SECONDS };
     const signedUrl = s3.getSignedUrl('getObject', signingParams);
     // Send email once signed URL is created
     email.sendAuditReportEmail(recipientEmail, signedUrl);
@@ -216,7 +215,7 @@ async function generateAndSendEmail(requestHost, recipientEmail) {
         module.exports.presignAndSendEmail(reportKey, recipientEmail);
     };
     const s3 = module.exports.getS3Client();
-    const uploadParams = { Bucket: AUDIT_REPORT_BUCKET, Key: reportKey, Body: report.outputWorkBook };
+    const uploadParams = { Bucket: process.env.AUDIT_REPORT_BUCKET, Key: reportKey, Body: report.outputWorkBook };
     s3.upload(uploadParams, handleUpload);
 }
 

--- a/terraform/modules/gost_api/main.tf
+++ b/terraform/modules/gost_api/main.tf
@@ -6,9 +6,9 @@ module "this" {
   source  = "cloudposse/label/null"
   version = "0.25.0"
 
-  enabled = var.enabled
-  name    = var.namespace
-  tags    = var.tags
+  enabled   = var.enabled
+  namespace = var.namespace
+  tags      = var.tags
 }
 
 module "s3_label" {
@@ -19,5 +19,6 @@ module "s3_label" {
   attributes = [
     data.aws_caller_identity.current.account_id,
     data.aws_region.current.name,
+    "api",
   ]
 }

--- a/terraform/modules/gost_api/task.tf
+++ b/terraform/modules/gost_api/task.tf
@@ -37,6 +37,7 @@ module "api_container_definition" {
       WEBSITE_DOMAIN            = "https://${var.website_domain_name}"
       NOTIFICATIONS_EMAIL       = var.notifications_email_address
       DATA_DIR                  = "/var/data"
+      AUDIT_REPORT_BUCKET       = module.arpa_audit_reports_bucket.bucket_id
     },
     var.api_container_environment,
   )


### PR DESCRIPTION
### Ticket #1132
## Description
- We are unable to access the S3 bucket in AWS because the name of the bucket is different in the code than in the hosted environment. This PR ensures that we can set this as an environment variable which makes it easy to change across hosted environments.

<img width="1167" alt="image" src="https://user-images.githubusercontent.com/6497366/229189751-6467655b-7c52-4fd8-b623-d81fa7dd517b.png">


## Screenshots / Demo Video

## Testing

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [ ] Provided ticket and description
- [ ] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers