### PR TITLE
Fix left padding on UpcomingClosingDates

### DIFF
--- a/packages/client/src/views/UpcomingClosingDates.vue
+++ b/packages/client/src/views/UpcomingClosingDates.vue
@@ -75,6 +75,7 @@ export default {
           // col for Grants and interested agencies
           key: 'title',
           label: '',
+          tdClass: 'pl-1',
           thStyle: { width: '80%' },
         },
         {


### PR DESCRIPTION
Closes #279

## Description

We want the `/UpcomingClosingDates` page to look similar to `/RecentActivity`. Because RecentActivity makes use of an icon that is left-aligned, and the left column on UpcomingClosingDates is text, we just adjust the `<td>` for the left-most title column to have less padding and align visually with the header.

## Screenshots / Demo Video

The updated `/UpcomingClosingDates` page:

<img width="1362" alt="Screenshot 2023-03-31 at 2 34 39 PM" src="https://user-images.githubusercontent.com/846194/229236943-4610131d-1d24-4945-a1fc-b30476ad0b36.png">

The `RecentActivity` page for comparison:

<img width="1362" alt="Screenshot 2023-03-31 at 2 34 26 PM" src="https://user-images.githubusercontent.com/846194/229236912-e323a036-8ada-4dcd-b099-111820fde57a.png">

### Manual tests for Reviewer
- [x] Visit both pages and ensure the alignment is consistent.

## Checklist
- [x] Provided ticket and description
- [x] Provided screenshots/demo
- [x] Provided testing information
- [x] Added PR reviewers