### PR TITLE
feat: adds masking and auth for audit reports

### DIFF
--- a/packages/client/src/arpa_reporter/views/Home.vue
+++ b/packages/client/src/arpa_reporter/views/Home.vue
@@ -77,7 +77,7 @@ export default {
   },
   data() {
     let alert;
-    if (this.$route.query.alert_text) {
+    if (this.$route?.query?.alert_text) {
       /* ok, warn, err */
       alert = {
         text: this.$route.query.alert_text,

--- a/packages/client/src/arpa_reporter/views/Home.vue
+++ b/packages/client/src/arpa_reporter/views/Home.vue
@@ -76,8 +76,17 @@ export default {
     },
   },
   data() {
+    let alert;
+    if (this.$route.query.alert_text) {
+      /* ok, warn, err */
+      alert = {
+        text: this.$route.query.alert_text,
+        level: this.$route.query.alert_level,
+      };
+    }
+
     return {
-      alert: null,
+      alert,
       sending: false,
     };
   },

--- a/packages/server/__tests__/arpa_reporter/server/lib/audit-report.spec.js
+++ b/packages/server/__tests__/arpa_reporter/server/lib/audit-report.spec.js
@@ -32,7 +32,7 @@ describe('audit report generation', () => {
 
         expect(sendFake.calledOnce).to.equal(true);
         expect(sendFake.firstCall.firstArg).to.equal('foo@example.com');
-        expect(sendFake.firstCall.lastArg).to.equal('http://localhost:8080/api/audit_report/1/99/example.xlsx');
+        expect(sendFake.firstCall.lastArg).to.equal(`${process.env.WEBSITE_DOMAIN}/api/audit_report/1/99/example.xlsx`);
     });
     it('generateAndSendEmail generates a report, uploads to s3, and sends an email', async () => {
         const sendFake = sandbox.fake.returns('foo');

--- a/packages/server/__tests__/arpa_reporter/server/routes/audit_report.spec.js
+++ b/packages/server/__tests__/arpa_reporter/server/routes/audit_report.spec.js
@@ -59,7 +59,7 @@ describe('/api/audit_report', () => {
     });
     it('Signed URL - redirects for unauthorized users', async () => {
         const response = await server
-            .get('/api/audit_report/99/example.xlsx');
+            .get('/api/audit_report/0/99/example.xlsx');
 
         expect(response.status).to.equal(302);
         expect(response.headers.location).to.equal('http://localhost:8080/arpa_reporter/login?redirect_to=/api/audit_report/99/example.xlsx&message=Please%20login%20to%20visit%20the%20link.');
@@ -73,11 +73,26 @@ describe('/api/audit_report', () => {
         sandbox.replace(aws, 'getS3Client', s3Fake);
 
         const response = await server
-            .get('/api/audit_report/99/example.xlsx')
+            .get('/api/audit_report/0/99/example.xlsx')
             .set('Cookie', tenantACookie);
 
         expect(response.status).to.equal(302);
         expect(response.headers.location).to.equal(`http://localhost:8080/arpa_reporter?alert_text=The%20audit%20report%20you%20requested%20has%20expired.%20Please%20try%20again%20by%20clicking%20the%20'Send%20Audit%20Report%20By%20Email'.&alert_level=err`);
+    });
+    it('Signed URL - redirects to login page when user is accessing wrong tenant', async () => {
+        const s3InstanceFake = sandbox.fake.returns('just s3');
+        const headObject = sandbox.fake.returns('h object');
+        headObjectFake.promise = sandbox.fake.returns('promise');
+        s3InstanceFake.headObject = sandbox.fake(headObjectFake('error', headObject));
+        const s3Fake = sandbox.fake.returns(s3InstanceFake);
+        sandbox.replace(aws, 'getS3Client', s3Fake);
+
+        const response = await server
+            .get('/api/audit_report/1/99/example.xlsx')
+            .set('Cookie', tenantACookie);
+
+        expect(response.status).to.equal(302);
+        expect(response.headers.location).to.equal(`http://localhost:8080/arpa_reporter/login?redirect_to=/api/audit_report/99/example.xlsx&message=Please%20login%20to%20visit%20the%20link.`);
     });
     it('Signed URL - returns redirect with message when there is an issue generating URL', async () => {
         const s3InstanceFake = sandbox.fake.returns('just s3');
@@ -90,7 +105,7 @@ describe('/api/audit_report', () => {
         sandbox.replace(aws, 'getS3Client', s3Fake);
 
         const response = await server
-            .get('/api/audit_report/99/example.xlsx')
+            .get('/api/audit_report/0/99/example.xlsx')
             .set('Cookie', tenantACookie);
 
         expect(response.status).to.equal(302);
@@ -107,7 +122,7 @@ describe('/api/audit_report', () => {
         sandbox.replace(aws, 'getS3Client', s3Fake);
 
         const response = await server
-            .get('/api/audit_report/99/example.xlsx')
+            .get('/api/audit_report/0/99/example.xlsx')
             .set('Cookie', tenantACookie);
 
         expect(response.status).to.equal(302);

--- a/packages/server/__tests__/arpa_reporter/server/routes/audit_report.spec.js
+++ b/packages/server/__tests__/arpa_reporter/server/routes/audit_report.spec.js
@@ -1,6 +1,24 @@
 const { expect } = require('chai');
+const sinon = require('sinon');
 const { makeTestServer, getSessionCookie } = require('./route_test_helpers');
 const audit_report = require('../../../../src/arpa_reporter/lib/audit-report');
+const aws = require('../../../../src/arpa_reporter/lib/aws-client');
+
+function headObjectFake(type, callback) {
+    if (type === 'error') {
+        return () => { throw new Error('issue with finding s3 object'); };
+    }
+
+    return callback;
+}
+
+function signedUrlFake(type) {
+    if (type === 'error') {
+        return () => { throw new Error('issue with generating signed URL'); };
+    }
+
+    return () => 'http://s3.amazonaws.com/sample.xlsx';
+}
 
 describe('/api/audit_report', () => {
     let server;
@@ -11,6 +29,12 @@ describe('/api/audit_report', () => {
     });
     after(() => {
         server.stop();
+    });
+
+    const sandbox = sinon.createSandbox();
+
+    afterEach(async () => {
+        sandbox.restore();
     });
 
     it('Ensures async audit report generation returns 200', async () => {
@@ -32,5 +56,61 @@ describe('/api/audit_report', () => {
 
         expect(response.status).to.equal(500);
         expect(response._body.error).to.equal('Unable to generate audit report and send email.');
+    });
+    it('Signed URL - redirects for unauthorized users', async () => {
+        const response = await server
+            .get('/api/audit_report/99/example.xlsx');
+
+        expect(response.status).to.equal(302);
+        expect(response.headers.location).to.equal('http://localhost:8080/arpa_reporter/login?redirect_to=/api/audit_report/99/example.xlsx&message=Please%20login%20to%20visit%20the%20link.');
+    });
+    it('Signed URL - redirects when object is not found', async () => {
+        const s3InstanceFake = sandbox.fake.returns('just s3');
+        const headObject = sandbox.fake.returns('h object');
+        headObjectFake.promise = sandbox.fake.returns('promise');
+        s3InstanceFake.headObject = sandbox.fake(headObjectFake('error', headObject));
+        const s3Fake = sandbox.fake.returns(s3InstanceFake);
+        sandbox.replace(aws, 'getS3Client', s3Fake);
+
+        const response = await server
+            .get('/api/audit_report/99/example.xlsx')
+            .set('Cookie', tenantACookie);
+
+        expect(response.status).to.equal(302);
+        expect(response.headers.location).to.equal(`http://localhost:8080/arpa_reporter?alert_text=The%20audit%20report%20you%20requested%20has%20expired.%20Please%20try%20again%20by%20clicking%20the%20'Send%20Audit%20Report%20By%20Email'.&alert_level=err`);
+    });
+    it('Signed URL - returns redirect with message when there is an issue generating URL', async () => {
+        const s3InstanceFake = sandbox.fake.returns('just s3');
+        const objReturnFake = sandbox.fake.returns('some_return');
+        objReturnFake.promise = sandbox.fake.returns('promise return');
+        const headObject = sandbox.fake.returns(objReturnFake);
+        s3InstanceFake.headObject = sandbox.fake(headObjectFake('success', headObject));
+        s3InstanceFake.getSignedUrl = sandbox.fake(signedUrlFake('error'));
+        const s3Fake = sandbox.fake.returns(s3InstanceFake);
+        sandbox.replace(aws, 'getS3Client', s3Fake);
+
+        const response = await server
+            .get('/api/audit_report/99/example.xlsx')
+            .set('Cookie', tenantACookie);
+
+        expect(response.status).to.equal(302);
+        expect(response.headers.location).to.equal(`http://localhost:8080/arpa_reporter?alert_text=Something%20went%20wrong.%20Please%20reach%20out%20to%20grants-helpdesk@usdigitalresponse.org.&alert_level=err`);
+    });
+    it('Signed URL - Success response', async () => {
+        const s3InstanceFake = sandbox.fake.returns('just s3');
+        const objReturnFake = sandbox.fake.returns('some_return');
+        objReturnFake.promise = sandbox.fake.returns('promise return');
+        const headObject = sandbox.fake.returns(objReturnFake);
+        s3InstanceFake.headObject = sandbox.fake(headObjectFake('success', headObject));
+        s3InstanceFake.getSignedUrl = sandbox.fake(signedUrlFake('success'));
+        const s3Fake = sandbox.fake.returns(s3InstanceFake);
+        sandbox.replace(aws, 'getS3Client', s3Fake);
+
+        const response = await server
+            .get('/api/audit_report/99/example.xlsx')
+            .set('Cookie', tenantACookie);
+
+        expect(response.status).to.equal(302);
+        expect(response.headers.location).to.equal(`http://s3.amazonaws.com/sample.xlsx`);
     });
 });

--- a/packages/server/__tests__/arpa_reporter/server/routes/audit_report.spec.js
+++ b/packages/server/__tests__/arpa_reporter/server/routes/audit_report.spec.js
@@ -62,7 +62,7 @@ describe('/api/audit_report', () => {
             .get('/api/audit_report/0/99/example.xlsx');
 
         expect(response.status).to.equal(302);
-        expect(response.headers.location).to.equal('http://localhost:8080/arpa_reporter/login?redirect_to=/api/audit_report/99/example.xlsx&message=Please%20login%20to%20visit%20the%20link.');
+        expect(response.headers.location).to.equal('http://localhost:8080/arpa_reporter/login?redirect_to=/api/audit_report/0/99/example.xlsx&message=Please%20login%20to%20visit%20the%20link.');
     });
     it('Signed URL - redirects when object is not found', async () => {
         const s3InstanceFake = sandbox.fake.returns('just s3');
@@ -92,7 +92,7 @@ describe('/api/audit_report', () => {
             .set('Cookie', tenantACookie);
 
         expect(response.status).to.equal(302);
-        expect(response.headers.location).to.equal(`http://localhost:8080/arpa_reporter/login?redirect_to=/api/audit_report/99/example.xlsx&message=Please%20login%20to%20visit%20the%20link.`);
+        expect(response.headers.location).to.equal(`http://localhost:8080/arpa_reporter/login?redirect_to=/api/audit_report/1/99/example.xlsx&message=Please%20login%20to%20visit%20the%20link.`);
     });
     it('Signed URL - returns redirect with message when there is an issue generating URL', async () => {
         const s3InstanceFake = sandbox.fake.returns('just s3');

--- a/packages/server/__tests__/lib/access-helpers.test.js
+++ b/packages/server/__tests__/lib/access-helpers.test.js
@@ -1,0 +1,91 @@
+const { expect } = require('chai');
+const { getAdminAuthInfo } = require('../../src/lib/access-helpers');
+const db = require('../../src/db');
+const fixtures = require('../db/seeds/fixtures');
+
+async function expectUnauthorized(request) {
+    try {
+        await getAdminAuthInfo(request);
+    } catch (err) {
+        expect(err.message).to.equal('Unauthorized');
+    }
+}
+
+describe('Acces Helper Module', () => {
+    before(async () => {
+        await fixtures.seed(db.knex);
+    });
+
+    after(async () => {
+        await db.knex.destroy();
+    });
+    context('getAdminAuthInfo', () => {
+        it('throws error if no user ID exists in signed cookie', async () => {
+            const requestFake = {
+                signedCookies: {
+                    userId: null,
+                },
+            };
+            await expectUnauthorized(requestFake);
+        });
+        it('throws error if no user is found', async () => {
+            const requestFake = {
+                signedCookies: {
+                    userId: 123456,
+                },
+            };
+            await expectUnauthorized(requestFake);
+        });
+        it('throws error if found user is not an admin', async () => {
+            const requestFake = {
+                signedCookies: {
+                    userId: fixtures.users.staffUser.id,
+                },
+            };
+            await expectUnauthorized(requestFake);
+        });
+        it('throws error if requestedAgency is not part of user.tenant_id', async () => {
+            const requestFake = {
+                signedCookies: {
+                    userId: fixtures.users.adminUser.id,
+                },
+                params: {
+                    organizationId: fixtures.agencies.fleetServices.id,
+                },
+            };
+            await expectUnauthorized(requestFake);
+        });
+        it('succeeds for admin user without any organization passed in', async () => {
+            const requestFake = {
+                signedCookies: {
+                    userId: fixtures.users.adminUser.id,
+                },
+                params: {
+                    organizationId: null,
+                },
+            };
+            const result = await getAdminAuthInfo(requestFake);
+
+            expect(Object.keys(result)[0]).to.equal('user');
+            expect(result.user.id).to.equal(fixtures.users.adminUser.id);
+            expect(Object.keys(result)[1]).to.equal('selectedAgency');
+            expect(result.selectedAgency).to.equal(fixtures.agencies.accountancy.id);
+        });
+        it('succeeds for admin user with a valid organization passed in', async () => {
+            const requestFake = {
+                signedCookies: {
+                    userId: fixtures.users.adminUser.id,
+                },
+                params: {
+                    organizationId: fixtures.agencies.subAccountancy.id,
+                },
+            };
+            const result = await getAdminAuthInfo(requestFake);
+
+            expect(Object.keys(result)[0]).to.equal('user');
+            expect(result.user.id).to.equal(fixtures.users.adminUser.id);
+            expect(Object.keys(result)[1]).to.equal('selectedAgency');
+            expect(result.selectedAgency).to.equal(fixtures.agencies.subAccountancy.id);
+        });
+    });
+});

--- a/packages/server/__tests__/lib/redirect_validation.test.js
+++ b/packages/server/__tests__/lib/redirect_validation.test.js
@@ -1,0 +1,37 @@
+const { expect } = require('chai');
+const { validatePostLoginRedirectPath } = require('../../src/lib/redirect_validation');
+
+describe('Redirect Validation Module', () => {
+    context('redirect valiadtion', () => {
+        it('returns null if no url is passed in', async () => {
+            const result_empty = validatePostLoginRedirectPath('');
+            const result_null = validatePostLoginRedirectPath(null);
+            const result_undefined = validatePostLoginRedirectPath();
+
+            expect(result_empty).to.equal(null);
+            expect(result_null).to.equal(null);
+            expect(result_undefined).to.equal(null);
+        });
+        it('returns URL if part of safe URL list', async () => {
+            const grantsModalUrl = '#/grants?manageSettings=true';
+            const auditReportUrl = '/api/audit_report/3/99/some-example-file.xlsx';
+            const result_grants_modal = validatePostLoginRedirectPath(grantsModalUrl);
+            const result_audit_report = validatePostLoginRedirectPath(auditReportUrl);
+
+            expect(result_grants_modal).to.equal(grantsModalUrl);
+            expect(result_audit_report).to.equal(auditReportUrl);
+        });
+        it('returns null if string that does not start with / is passed in', async () => {
+            const str1 = 'abcdefg123';
+            const result_str1 = validatePostLoginRedirectPath(str1);
+
+            expect(result_str1).to.equal(null);
+        });
+        it('returns null if a non-safe /api route is passed in', async () => {
+            const apiRoute = '/api/abcdefg123';
+            const result_api_route = validatePostLoginRedirectPath(apiRoute);
+
+            expect(result_api_route).to.equal(null);
+        });
+    });
+});

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -32,8 +32,9 @@
     "test:arpa": "NODE_ENV=test __tests__/run_arpa_reporter_tests.sh",
     "test:db": "NODE_ENV=test mocha --timeout 10000 __tests__/db/*.test.js",
     "test:email": "NODE_ENV=test mocha __tests__/email/*.test.js",
+    "test:lib": "NODE_ENV=test mocha __tests__/lib/*.test.js",
     "test:userimport": "NODE_ENV=test SUPPRESS_EMAIL=true mocha --exit --bail --require __tests__/api/fixtures.js __tests__/db/userImporter._test_.js",
-    "test": "yarn test:apis && yarn test:arpa && yarn test:db && yarn test:userimport && yarn test:agencyimport && yarn test:email"
+    "test": "yarn test:apis && yarn test:arpa && yarn test:db && yarn test:userimport && yarn test:agencyimport && yarn test:email && yarn test:lib"
   },
   "dependencies": {
     "adm-zip": "0.5.9",

--- a/packages/server/src/arpa_reporter/lib/audit-report.js
+++ b/packages/server/src/arpa_reporter/lib/audit-report.js
@@ -9,6 +9,7 @@ const { recordsForReportingPeriod, mostRecentProjectRecords } = require('../serv
 const { usedForTreasuryExport } = require('../db/uploads');
 const { ARPA_REPORTER_BASE_URL } = require('../environment');
 const email = require('../../lib/email');
+const { useTenantId } = require('../use-request');
 
 const COLUMN = {
     EC_BUDGET: 'Adopted Budget (EC tabs)',
@@ -156,7 +157,7 @@ async function generate(requestHost) {
 
     return {
         periodId,
-        filename: `audit report ${moment().format('yy-MM-DD')}.xlsx`,
+        filename: `audit-report-${moment().format('yy-MM-DD')}.xlsx`,
         outputWorkBook: XLSX.write(workbook, { bookType: 'xlsx', type: 'buffer' }),
     };
 }
@@ -167,10 +168,11 @@ async function sendEmailWithLink(periodId, filename, recipientEmail) {
 }
 
 async function generateAndSendEmail(requestHost, recipientEmail) {
+    const tenantId = useTenantId();
     // Generate the report
     const report = await module.exports.generate(requestHost);
     // Upload to S3 and send email link
-    const reportKey = `${report.periodId}/${report.filename}`;
+    const reportKey = `${tenantId}/${report.periodId}/${report.filename}`;
     const handleUpload = (err, data) => {
         if (err) {
             console.log(`Failed to upload audit report ${err}`);

--- a/packages/server/src/arpa_reporter/lib/audit-report.js
+++ b/packages/server/src/arpa_reporter/lib/audit-report.js
@@ -163,8 +163,8 @@ async function generate(requestHost) {
     };
 }
 
-async function sendEmailWithLink(periodId, filename, recipientEmail) {
-    const url = `${process.env.WEBSITE_DOMAIN}/api/audit_report/${periodId}/${filename}`;
+async function sendEmailWithLink(fileKey, recipientEmail) {
+    const url = `${process.env.WEBSITE_DOMAIN}/api/audit_report/${fileKey}`;
     email.sendAuditReportEmail(recipientEmail, url);
 }
 
@@ -180,7 +180,7 @@ async function generateAndSendEmail(requestHost, recipientEmail) {
             return;
         }
         console.log(data);
-        module.exports.sendEmailWithLink(report.periodId, report.filename, recipientEmail);
+        module.exports.sendEmailWithLink(reportKey, recipientEmail);
     };
     const s3 = aws.getS3Client();
     const uploadParams = {

--- a/packages/server/src/arpa_reporter/lib/audit-report.js
+++ b/packages/server/src/arpa_reporter/lib/audit-report.js
@@ -1,4 +1,5 @@
 const moment = require('moment');
+const { v4 } = require('uuid');
 const XLSX = require('xlsx');
 const asyncBatch = require('async-batch').default;
 const aws = require('./aws-client');
@@ -157,7 +158,7 @@ async function generate(requestHost) {
 
     return {
         periodId,
-        filename: `audit-report-${moment().format('yy-MM-DD')}.xlsx`,
+        filename: `audit-report-${moment().format('yy-MM-DD')}-${v4()}.xlsx`,
         outputWorkBook: XLSX.write(workbook, { bookType: 'xlsx', type: 'buffer' }),
     };
 }

--- a/packages/server/src/arpa_reporter/lib/aws-client.js
+++ b/packages/server/src/arpa_reporter/lib/aws-client.js
@@ -1,0 +1,34 @@
+const AWS = require('aws-sdk');
+
+function getS3Client() {
+    /*
+        TODO: Move this client generation to a separate module that handles creating all AWS clients.
+        Captured in ticket here: https://github.com/usdigitalresponse/usdr-gost/issues/1161
+    */
+
+    let s3;
+    if (process.env.LOCALSTACK_HOSTNAME) {
+        /*
+            1. Make sure the local environment has awslocal installed.
+            2. Use the commands to create a bucket to test with.
+                - awslocal s3api create-bucket --bucket arpa-audit-reports --region us-west-2 --create-bucket-configuration '{"LocationConstraint": "us-west-2"}'
+            3. Access bucket resource metadata through the following URL.
+                - awslocal s3api list-buckets
+                - awslocal s3api list-objects --bucket arpa-audit-reports
+        */
+        console.log('------------ USING LOCALSTACK ------------');
+        const endpoint = new AWS.Endpoint(`http://${process.env.LOCALSTACK_HOSTNAME}:${process.env.EDGE_PORT || 4566}`);
+        s3 = new AWS.S3({
+            region: process.env.AWS_DEFAULT_REGION || 'us-west-2',
+            endpoint,
+            s3ForcePathStyle: true,
+        });
+    } else {
+        s3 = new AWS.S3();
+    }
+    return s3;
+}
+
+module.exports = {
+    getS3Client,
+};

--- a/packages/server/src/arpa_reporter/routes/audit-report.js
+++ b/packages/server/src/arpa_reporter/routes/audit-report.js
@@ -18,7 +18,7 @@ router.get('/:tenantId/:periodId/:filename', async (req, res) => {
             throw new Error('Unauthorized');
         }
     } catch (error) {
-        res.redirect(encodeURI(`${process.env.WEBSITE_DOMAIN}/arpa_reporter/login?redirect_to=/api/audit_report/${req.params.periodId}/${req.params.filename}&message=Please login to visit the link.`));
+        res.redirect(encodeURI(`${process.env.WEBSITE_DOMAIN}/arpa_reporter/login?redirect_to=/api/audit_report/${req.params.tenantId}/${req.params.periodId}/${req.params.filename}&message=Please login to visit the link.`));
         return;
     }
 

--- a/packages/server/src/arpa_reporter/routes/audit-report.js
+++ b/packages/server/src/arpa_reporter/routes/audit-report.js
@@ -9,11 +9,14 @@ const audit_report = require('../lib/audit-report');
 const { useUser } = require('../use-request');
 const aws = require('../lib/aws-client');
 
-router.get('/:periodId/:filename', async (req, res) => {
+router.get('/:tenantId/:periodId/:filename', async (req, res) => {
     let user;
     try {
         const info = await getAdminAuthInfo(req);
         user = info.user;
+        if (user.tenant_id !== Number(req.params.tenantId)) {
+            throw new Error('Unauthorized');
+        }
     } catch (error) {
         res.redirect(encodeURI(`${process.env.WEBSITE_DOMAIN}/arpa_reporter/login?redirect_to=/api/audit_report/${req.params.periodId}/${req.params.filename}&message=Please login to visit the link.`));
         return;

--- a/packages/server/src/arpa_reporter/routes/audit-report.js
+++ b/packages/server/src/arpa_reporter/routes/audit-report.js
@@ -27,7 +27,7 @@ router.get('/:periodId/:filename', async (req, res) => {
         await s3.headObject(baseParams).promise();
     } catch (error) {
         console.log(error);
-        res.redirect(`${process.env.WEBSITE_DOMAIN}/arpa_reporter?alert_text=The audit report you requested does not exist. Please try again by clicking the 'Send Audit Report By Email'.&alert_level=err`);
+        res.redirect(encodeURI(`${process.env.WEBSITE_DOMAIN}/arpa_reporter?alert_text=The audit report you requested has expired. Please try again by clicking the 'Send Audit Report By Email'.&alert_level=err`));
         return;
     }
 

--- a/packages/server/src/arpa_reporter/routes/audit-report.js
+++ b/packages/server/src/arpa_reporter/routes/audit-report.js
@@ -37,6 +37,7 @@ router.get('/:periodId/:filename', async (req, res) => {
     } catch (error) {
         console.log(error);
         res.redirect(`${process.env.WEBSITE_DOMAIN}/arpa_reporter?alert_text=Something went wrong. Please reach out to grants-helpdesk@usdigitalresponse.org.&alert_level=err`);
+        return;
     }
     res.redirect(signedUrl);
 });

--- a/packages/server/src/lib/redirect_validation.js
+++ b/packages/server/src/lib/redirect_validation.js
@@ -7,7 +7,7 @@
 function matchesSafeUrl(url) {
     const safeUrls = [
         /^#\/grants\?manageSettings=true$/,
-        /^\/api\/audit_report\/\d+\/.*\.xlsx$/,
+        /^\/api\/audit_report\/\d+\/\d+\/.*\.xlsx$/,
     ];
 
     for (const regex of safeUrls) {

--- a/packages/server/src/lib/redirect_validation.js
+++ b/packages/server/src/lib/redirect_validation.js
@@ -3,17 +3,29 @@
 // should be discarded (and redirect to default page); if argument is valid, the
 // redirect URL is returned. In the future, this function could also transform
 // the URL if needed.
-function validatePostLoginRedirectPath(url) {
+
+function matchesSafeUrl(url) {
     const safeUrls = [
-        '#/grants?manageSettings=true',
+        /^#\/grants\?manageSettings=true$/,
+        /^\/api\/audit_report\/\d+\/.*\.xlsx$/,
     ];
 
+    for (const regex of safeUrls) {
+        if (url.match(regex)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+function validatePostLoginRedirectPath(url) {
     if (!url) {
         return null;
     }
 
     // Ensures we have a allowlist of redirect URLs that are always safe.
-    if (safeUrls.includes(url)) {
+    if (matchesSafeUrl(url)) {
         return url;
     }
 


### PR DESCRIPTION
### Ticket #1132
## Description
- Ensures that only logged-in users can receive a presigned S3 URL to the audit report

## Screenshots / Demo Video

## Testing

### Automated and Unit Tests
- [x] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [x] Provided ticket and description
- [x] Provided screenshots/demo
- [ ] Provided testing information
- [x] Provided adequate test coverage for all new code
- [x] Added PR reviewers