### PR TITLE
fix: enable versioning for the Website CDN logs S3 bucket

### DIFF
--- a/terraform/modules/gost_website/storage.tf
+++ b/terraform/modules/gost_website/storage.tf
@@ -105,7 +105,7 @@ module "logs_bucket" {
   name    = "logs"
 
   acl                          = "private"
-  versioning_enabled           = false
+  versioning_enabled           = var.logs_bucket_versioning
   sse_algorithm                = "AES256"
   allow_ssl_requests_only      = true
   allow_encrypted_uploads_only = true

--- a/terraform/modules/gost_website/variables.tf
+++ b/terraform/modules/gost_website/variables.tf
@@ -35,6 +35,12 @@ variable "gost_api_domain" {
   type        = string
 }
 
+variable "logs_bucket_versioning" {
+  description = "Enable versioning for the logs S3 bucket"
+  type        = bool
+  default     = true
+}
+
 variable "origin_bucket_dist_path" {
   description = "Path to the directory where website build files should be stored in the S3 origin bucket."
   default     = "/dist"


### PR DESCRIPTION
### Ticket #1166 
## Description
@TylerHendrickson the simple route to resolve this would be to just flip the bool to `true` in the module but I'm going to propose exposing it as an input variable so that it can be flipped on/off per environment (if needed).

## Screenshots / Demo Video

## Testing

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [ ] Provided ticket and description
- [ ] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers