### PR TITLE
fix: update to use synchronous s3 file signing

### DIFF
--- a/packages/server/__tests__/arpa_reporter/server/routes/audit_report.spec.js
+++ b/packages/server/__tests__/arpa_reporter/server/routes/audit_report.spec.js
@@ -100,7 +100,7 @@ describe('/api/audit_report', () => {
         objReturnFake.promise = sandbox.fake.returns('promise return');
         const headObject = sandbox.fake.returns(objReturnFake);
         s3InstanceFake.headObject = sandbox.fake(headObjectFake('success', headObject));
-        s3InstanceFake.getSignedUrl = sandbox.fake(signedUrlFake('error'));
+        s3InstanceFake.getSignedUrlPromise = sandbox.fake(signedUrlFake('error'));
         const s3Fake = sandbox.fake.returns(s3InstanceFake);
         sandbox.replace(aws, 'getS3Client', s3Fake);
 
@@ -117,7 +117,7 @@ describe('/api/audit_report', () => {
         objReturnFake.promise = sandbox.fake.returns('promise return');
         const headObject = sandbox.fake.returns(objReturnFake);
         s3InstanceFake.headObject = sandbox.fake(headObjectFake('success', headObject));
-        s3InstanceFake.getSignedUrl = sandbox.fake(signedUrlFake('success'));
+        s3InstanceFake.getSignedUrlPromise = sandbox.fake(signedUrlFake('success'));
         const s3Fake = sandbox.fake.returns(s3InstanceFake);
         sandbox.replace(aws, 'getS3Client', s3Fake);
 

--- a/packages/server/src/arpa_reporter/routes/audit-report.js
+++ b/packages/server/src/arpa_reporter/routes/audit-report.js
@@ -36,7 +36,7 @@ router.get('/:tenantId/:periodId/:filename', async (req, res) => {
 
     let signedUrl;
     try {
-        signedUrl = await s3.getSignedUrl('getObject', { ...baseParams, Expires: 60 });
+        signedUrl = await s3.getSignedUrlPromise('getObject', { ...baseParams, Expires: 60 });
     } catch (error) {
         console.log(error);
         res.redirect(`${process.env.WEBSITE_DOMAIN}/arpa_reporter?alert_text=Something went wrong. Please reach out to grants-helpdesk@usdigitalresponse.org.&alert_level=err`);


### PR DESCRIPTION
### Ticket #1132
## Description
- File signing in Staging was not working the same as the local environment. It turns out that there is some inconsistent behavior in the `getSignedUrl` function.

## Screenshots / Demo Video

## Testing

### Automated and Unit Tests
- [x] Added Unit tests

### Manual tests for Reviewer

SSH into the staging server and try to retrieve the URL for the file.
```
const aws = require('../lib/aws-client');
const Key = `1/6/audit-report-2023-04-03-xxxx-aa99-4389-8f79-002e69ad2afa.xlsx`;
const baseParams = { Bucket: process.env.AUDIT_REPORT_BUCKET, Key };
const signedUrl2 = await s3.getSignedUrl('getObject', { ...baseParams, Expires: 60 })
> signedUrl2
'https://s3.us-west-2.amazonaws.com/'
const signedUrl4 = await s3.getSignedUrlPromise('getObject', {...baseParams, Expires: 60})
> signedUrl4
'https://xxxx-xxxx-us-xxx-x-api.s3.us-west-2.amazonaws.com/1/6/audit-report-2023-04-03-xxxx-aa99-4389-8f79-002e69ad2afa.xlsx?.....
```
- [x] Added steps to test feature/functionality manually

## Checklist
- [x] Provided ticket and description
- [ ] Provided screenshots/demo
- [x] Provided testing information
- [x] Provided adequate test coverage for all new code
- [x] Added PR reviewers