### PR TITLE
fix: WAFv2 needs to be referenced by ARN instead of ID

### DIFF
--- a/terraform/modules/gost_website/cdn.tf
+++ b/terraform/modules/gost_website/cdn.tf
@@ -38,7 +38,7 @@ module "cdn" {
   enabled             = true
   aliases             = [var.domain_name]
   default_root_object = "index.html"
-  web_acl_id          = module.waf.id
+  web_acl_id          = module.waf.arn
 
   // Optimized for North America
   // See https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/PriceClass.html


### PR DESCRIPTION
### Ticket #1167 
## Description
@TylerHendrickson this is a break/fix for the WAF integration with the Cloudfront CDN. WAFv2 needs to be reference by the ARN instead of the ID (which is now considered standard for using their old WAF).  This *should* fix the broke deploy that just failed to staging.

## Screenshots / Demo Video

## Testing

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [ ] Provided ticket and description
- [ ] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers