### PR TITLE
fix: Cloudfront only accepts globally scoped ARNs for WAFv2

### DIFF
--- a/terraform/modules/gost_website/waf.tf
+++ b/terraform/modules/gost_website/waf.tf
@@ -19,6 +19,7 @@ locals {
 module "waf" {
   source  = "cloudposse/waf/aws"
   version = "0.2.0"
+  scope   = "CLOUDFRONT"
 
   managed_rule_group_statement_rules = local.expanded_rules
 


### PR DESCRIPTION
### Ticket #1167 
## Description
See title.  The module's default value was set to `REGIONAL` which is incompatible when using WAFv2 with Cloudfront.

## Screenshots / Demo Video

## Testing

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [ ] Provided ticket and description
- [ ] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers