### PR TITLE
Configure AWS provider default tags for unified service tagging

### DIFF
--- a/.github/workflows/build-api.yml
+++ b/.github/workflows/build-api.yml
@@ -45,6 +45,8 @@ jobs:
           labels: |
             org.opencontainers.image.title=${{ env.IMAGE_NAME }}
             org.opencontainers.image.version={{date 'YYYYMMDD.HHmm'}}
+            com.datadoghq.tags.service=gost
+            com.datadoghq.tags.version=${{ github.sha }}
       - name: Build and push Docker image
         uses: docker/build-push-action@v3
         with:

--- a/.github/workflows/terraform-ci.yml
+++ b/.github/workflows/terraform-ci.yml
@@ -40,6 +40,7 @@ jobs:
     environment: ${{ needs.select_target_environment.outputs.selected }}
     env:
       TF_PLUGIN_CACHE_DIR: ~/.terraform.d/plugin-cache
+      TF_VAR_version_identifier: ${{ github.sha }}
     concurrency:
       group: run_terraform-${{ needs.select_target_environment.outputs.selected }}
     steps:

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -11,6 +11,19 @@ terraform {
   backend "s3" {}
 }
 
+provider "aws" {
+  default_tags {
+    tags = {
+      env        = var.env
+      management = "terraform"
+      owner      = "grants"
+      repo       = "usdr-gost"
+      service    = "gost"
+      usage      = "workload"
+    }
+  }
+}
+
 data "aws_caller_identity" "current" {}
 
 data "aws_ssm_parameter" "vpc_id" {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -114,6 +114,7 @@ module "api" {
   default_desired_task_count = var.api_default_desired_task_count
   enable_grants_scraper      = var.api_enable_grants_scraper
   enable_grants_digest       = var.api_enable_grants_digest
+  unified_service_tags       = { service = "gost", env = var.env, version = var.version_identifier }
 
   # DNS
   domain_name         = local.api_domain_name

--- a/terraform/modules/gost_api/task.tf
+++ b/terraform/modules/gost_api/task.tf
@@ -1,6 +1,11 @@
 locals {
   api_container_image = "${var.docker_repository}:${var.docker_tag}"
   api_container_port  = 3000
+
+  datadog_env_vars = {
+    for k in coalesce([for k, v in var.unified_service_tags : (v != null ? k : null)]...) :
+    "DD_${upper(k)}" => var.unified_service_tags[k]
+  }
 }
 
 module "api_container_definition" {
@@ -39,6 +44,7 @@ module "api_container_definition" {
       DATA_DIR                  = "/var/data"
       AUDIT_REPORT_BUCKET       = module.arpa_audit_reports_bucket.bucket_id
     },
+    local.datadog_env_vars,
     var.api_container_environment,
   )
 
@@ -79,11 +85,15 @@ module "datadog_container_definition" {
   container_image          = "public.ecr.aws/datadog/agent:latest"
   essential                = false
   readonly_root_filesystem = "false"
+  stop_timeout             = 60
 
-  map_environment = {
-    ECS_FARGATE    = "true",
-    DD_APM_ENABLED = "true",
-  }
+  map_environment = merge(
+    {
+      ECS_FARGATE    = "true",
+      DD_APM_ENABLED = "true",
+    },
+    local.datadog_env_vars,
+  )
   map_secrets = {
     DD_API_KEY = join("", data.aws_ssm_parameter.datadog_api_key.*.arn),
   }

--- a/terraform/modules/gost_api/task.tf
+++ b/terraform/modules/gost_api/task.tf
@@ -3,7 +3,7 @@ locals {
   api_container_port  = 3000
 
   datadog_env_vars = {
-    for k in compact([for k, v in var.unified_service_tags : (v != null ? k : "")]...) :
+    for k in compact([for k, v in var.unified_service_tags : (v != null ? k : "")]) :
     "DD_${upper(k)}" => var.unified_service_tags[k]
   }
 }

--- a/terraform/modules/gost_api/task.tf
+++ b/terraform/modules/gost_api/task.tf
@@ -3,7 +3,7 @@ locals {
   api_container_port  = 3000
 
   datadog_env_vars = {
-    for k in coalesce([for k, v in var.unified_service_tags : (v != null ? k : null)]...) :
+    for k in compact([for k, v in var.unified_service_tags : (v != null ? k : "")]...) :
     "DD_${upper(k)}" => var.unified_service_tags[k]
   }
 }

--- a/terraform/modules/gost_api/variables.tf
+++ b/terraform/modules/gost_api/variables.tf
@@ -168,3 +168,12 @@ variable "enable_grants_digest" {
   type        = bool
   default     = false
 }
+
+variable "unified_service_tags" {
+  description = "Datadog unified service tags to apply to runtime environments."
+  type = object({
+    env     = string
+    service = string
+    version = optional(string)
+  })
+}

--- a/terraform/prod.tfvars
+++ b/terraform/prod.tfvars
@@ -1,4 +1,5 @@
 namespace = "gost-prod"
+env       = "production"
 
 // Common
 ssm_service_parameters_path_prefix    = "/gost/prod"

--- a/terraform/sandbox.tfvars
+++ b/terraform/sandbox.tfvars
@@ -1,4 +1,5 @@
 namespace = "gost-sandbox"
+env       = "sandbox"
 
 // Common
 ssm_service_parameters_path_prefix    = "/gost/sandbox"

--- a/terraform/staging.tfvars
+++ b/terraform/staging.tfvars
@@ -1,4 +1,5 @@
 namespace = "gost-staging"
+env       = "staging"
 
 // Common
 ssm_service_parameters_path_prefix    = "/gost/staging"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -7,6 +7,12 @@ variable "env" {
   type        = string
 }
 
+variable "version_identifier" {
+  description = "Version identifier (e.g. commit SHA) for this deployment."
+  type        = string
+  default     = "dev"
+}
+
 // Common
 variable "permissions_boundary_policy_name" {
   description = "Name of the permissions boundary for service roles"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -2,6 +2,11 @@ variable "namespace" {
   type = string
 }
 
+variable "env" {
+  description = "Value to set as the default env tag on all resources that support tagging."
+  type        = string
+}
+
 // Common
 variable "permissions_boundary_policy_name" {
   description = "Name of the permissions boundary for service roles"


### PR DESCRIPTION
## Description

This PR configures unified service tagging to enable Datadog discovery and metrics correlation. The net code changes involved are simply configuring values for a new `var.env` terraform input variable for each deployment environment (`prod` / `staging` / `sandbox`) and defining a `default_tags` block on the AWS provider.

It's worth mentioning that the Terraform plan (and subsequent apply) for this PR will touch a _lot_ of resources (pretty much all of them) since the default tags will be applied to [every AWS resource type that supports tagging](https://docs.aws.amazon.com/ARG/latest/userguide/supported-resources.html) in this project. Policy conditions that evaluate and allow/reject conditional tags have already been applied to the CI/CD roles we use, and no resources are tagged at runtime, so I don't anticipate any problems related to permissions (to be confirmed by deploying to Staging).

## Screenshots / Demo Video

N/A

## Testing

Not much to do here- once this is deployed to Staging, I will spot-check that resources are tagged as-expected and that they can be used in Datadog queries.

### Automated and Unit Tests
- ~[ ] Added Unit tests~

## Checklist
- [X] Provided ticket and description
- ~[] Provided screenshots/demo~
- [X] Provided testing information
- [X] Provided adequate test coverage for all new code
- [X] Added PR reviewers