### PR TITLE
fix: set WAF default action to allow traffic after processing rules

### DIFF
--- a/terraform/modules/gost_website/waf.tf
+++ b/terraform/modules/gost_website/waf.tf
@@ -17,9 +17,10 @@ locals {
 }
 
 module "waf" {
-  source  = "cloudposse/waf/aws"
-  version = "0.2.0"
-  scope   = "CLOUDFRONT"
+  source         = "cloudposse/waf/aws"
+  version        = "0.2.0"
+  scope          = "CLOUDFRONT"
+  default_action = "allow"
 
   managed_rule_group_statement_rules = local.expanded_rules
 


### PR DESCRIPTION
### Ticket #1167 
## Description
I missed that the `default_action` parameter is set to `block` in this particular module.  This PR sets it to `allow` traffic once rules have been processed.

## Screenshots / Demo Video

## Testing

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [ ] Provided ticket and description
- [ ] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers