### PR TITLE
fix: Error in validating Project ID on Awards > 50000 (1244)

### DIFF
--- a/packages/server/src/arpa_reporter/environment.js
+++ b/packages/server/src/arpa_reporter/environment.js
@@ -24,7 +24,7 @@ const PERIOD_TEMPLATES_DIR = join(UPLOAD_DIR, 'period_templates');
 const SERVER_CODE_DIR = __dirname;
 const SERVER_DATA_DIR = join(SERVER_CODE_DIR, 'data');
 
-const EMPTY_TEMPLATE_NAME = 'ARPA SFRF Reporting Workbook v20230312.xlsm';
+const EMPTY_TEMPLATE_NAME = 'ARPA SFRF Reporting Workbook v20230417.xlsm';
 
 const { COOKIE_SECRET } = process.env;
 

--- a/packages/server/src/arpa_reporter/lib/templateRules.json
+++ b/packages/server/src/arpa_reporter/lib/templateRules.json
@@ -1,7 +1,7 @@
 {
   "logic": {
     "version": {
-      "version": "v:20230312",
+      "version": "v:20230417",
       "key": "version",
       "index": 0,
       "required": false,
@@ -7019,7 +7019,7 @@
       "key": "Project_Identification_Number__c",
       "index": 6,
       "required": true,
-      "dataType": "Numeric",
+      "dataType": "String",
       "maxLength": 20,
       "listVals": [],
       "columnName": "G",


### PR DESCRIPTION
### Ticket #1244 

## Description
New input template update to change field type from number to text.

## Screenshots / Demo Video
Created a "GH1244 - 10002 - DHS - EC2_32 - v20230417 - DIRTY.xlsm" with value "C725V423000171" for "product ID" - ran validation before and after this update - saw failure and then success: 

<img width="1560" alt="Screenshot 2023-04-17 at 6 19 39 PM" src="https://user-images.githubusercontent.com/120750336/232623076-9446292b-1321-4649-b8b7-a8819498fd32.png">


## Testing
Run against "GH1244 - 10002 - DHS - EC2_32 - v20230417 - DIRTY.xlsm" featuring the value "C725V423000171" for "product ID" and it failed 

### Automated and Unit Tests
- [ ] Added Unit tests
N/A for this change - we haven't historically been testing this sort of change with unit tests, though we could/should going forward

### Manual tests for Reviewer
- [x] Added steps to test feature/functionality manually

## Checklist
- [x] Provided ticket and description
- [x] Provided screenshots/demo
- [x] Provided testing information
- [x] Provided adequate test coverage for all new code
- [x] Added PR reviewers