### PR TITLE
[DECISION] Use Github to track technical decisions

### DIFF
--- a/.adr-dir
+++ b/.adr-dir
@@ -1,0 +1,1 @@
+docs/decisions

--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ There are two main parts to the application:
 
 Read more about how to get started developing [here](./docs/getting-started.md).
 
+## Decisions
+
+To see [decision records](https://adr.github.io/) for architectural decisions we have made, check out [this folder](./docs/decisions/).
+
 ## Code of Conduct
 
 This repository falls under [U.S. Digital Response’s Code of Conduct](./CODE_OF_CONDUCT.md), and we will hold all participants in issues, pull requests, discussions, and other spaces related to this project to that Code of Conduct. Please see [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md) for the full code.

--- a/docs/decisions/.markdownlint.yml
+++ b/docs/decisions/.markdownlint.yml
@@ -1,0 +1,19 @@
+default: true
+
+# Allow arbitrary line length
+#
+# Reason: We apply the one-sentence-per-line rule. A sentence may get longer than 80 characters, especially if links are contained.
+#
+# Details: https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md013---line-length
+MD013: false
+
+# Allow duplicate headings
+#
+# Reasons:
+#
+# - The chosen option is considerably often used as title of the ADR (e.g., ADR-0015). Thus, that title repeats.
+# - We use "Examples" multiple times (e.g., ADR-0010).
+# - Markdown lint should support the user and not annoy them.
+#
+# Details: https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md024---multiple-headings-with-the-same-content
+MD024: false

--- a/docs/decisions/0001-decision-record-process.md
+++ b/docs/decisions/0001-decision-record-process.md
@@ -40,7 +40,9 @@ The subject of an ADR should affect one of the following areas:
 - Interfaces
 - Construction techniques
 
-Small changes don't need one, but for larger changes that would introduce a new dependency or affect our overall system architecture, we recommend opening one.
+Small changes don't necessarily need one, but particularly for larger changes that would introduce a new dependency or affect our overall system architecture, we recommend opening one.
+
+In general, create a new ADR when your instincts indicate that having one could be useful – even if it is not ultimately accepted, the resulting discussions still might be valuable.
 
 ### Process
 

--- a/docs/decisions/0001-decision-record-process.md
+++ b/docs/decisions/0001-decision-record-process.md
@@ -1,7 +1,7 @@
 # 1. Decision Record Process
 
-Date: 2023-04-24
-Status: proposed
+Date: 2023-05-03
+Status: accepted
 
 ## Context and Problem Statement
 

--- a/docs/decisions/0001-decision-record-process.md
+++ b/docs/decisions/0001-decision-record-process.md
@@ -1,0 +1,116 @@
+# 1. Decision Record Process
+
+Date: 2023-04-24
+Status: proposed
+
+## Context and Problem Statement
+
+We need to document technical decisions we make on this project for the benefit of future contributors.
+
+## Decision Drivers
+
+- **Clarity** - Identify historical reasoning behind decision-making
+- **Transparency** - Make decisions in the open
+- **Currency** - ADRs reflect the current state of the world, but can be superseded by later decisions. The highest-numbered ADR reflects the most recent decision around a given topic.
+- **Expediency** - We need good decisions, but good good software ships frequently. To balance these two factors, the ADR ensures we move forward in an informed way, but provides a way to self-correct as the world changes.
+
+## Considered Options
+
+- ADRs on Github
+- Informal Conversations
+- Unilateral decision-making
+- Documenting technical decisions on Notion
+
+## Decision Outcome
+
+Below, we describe a way to use Github to write, discuss, and store decisions in the form of markdown files known as ADRs directly within the repository.
+
+### What is an ADR?
+
+An Architecture Decision Record is a text file, with a particular format, and an associated discussion. It is numbered for easy reference, and it has a general format.
+
+### When Should I Create an ADR?
+
+As outlined by Michael Nygard, ADRs represent "architecturally significant" decisions.
+
+The subject of an ADR should affect one of the following areas:
+
+- Structure
+- Dependencies
+- Interfaces
+- Construction techniques
+
+Small changes don't need one, but for larger changes that would introduce a new dependency or affect our overall system architecture, we recommend opening one.
+
+### Process
+
+Please see the below diagram:
+
+```mermaid
+graph TB
+    Draft -- ADR Pull Request Written --> P[Proposed]
+    P--Wait 3 days-->C{Consensus?}
+    C --> |Yes| Merged
+    C --> |No| A{Concerns Addressed?}
+    A --> |Yes| Merged
+    A --> |No| Discussion
+    Discussion --> O{Voting Outcome}
+    O --> |Accepted| Merged
+    O --> |Rejected| Merged
+    Merged --> U[Update other Issues]
+    U-->Close
+```
+
+1. **Start**: To create a new ADR, copy [./templates/template.md](./templates/template.md) into a new file in this directory, named `XXXX-name-of-issue.md` where the `XXXX` part is incremented from the previous ADR. (You can also use [adr-tools](https://github.com/npryce/adr-tools))
+
+1. Fill out all fields, set status to `proposed`, and open a pull request. Begin the pull request with `[PROPOSAL]` to clarify purpose.
+   1. We recommend [Mermaid](https://mermaid-js.github.io) for diagrams! You can simply add a code block of type `mermaid` and it will be picked up automatically.
+   1. If you need to store other files, create a folder with the name `XXXX-files` and put supporting ADR material there.
+
+1. **Wait** Wait for 3 days. In the event of consensus within the expressed timeline, assign an approver and merge.
+
+1. **Concerns** If there are concerns raised in this time period, ensure that those that disagree understand the reasoning behind the decision and address concerns with specific mitigation steps. Request confirmation that concerns have been addressed. If so, merge!
+
+1. **Discuss** In the event that disagreement persists, discuss the decision with the group in the next weekly sync. Take a vote on next steps (opt-outs are OK!), and move forward.
+
+1. **Merge**
+
+   1. If the proposal is **approved** by this vote, set its status to `approved`, and merge the change.
+   2. If it is **rejected**, set its status as `rejected`, and merge anyway for future reference!
+
+1. **Update Other Issues** If people agree in discussion that this issue supersedes another, set the status of the other issue to `superseded`
+
+1. **Close** Close the issue
+
+### Positive Consequences
+
+- Clarity on decisions
+- A history of all decisions made on the project
+- Inclusion of community voices in discussion of important topics
+
+### Negative Consequences
+
+- Folks have to follow a more involved process
+- Might slow things down in the event of major disagreements
+
+## Pros and Cons of Other Options
+
+### Informal Conversations
+
+- Pros: Easier, Faster
+- Cons: Can leave people out
+
+### Unilateral Decision Making
+
+- Pros: The fastest option
+- Cons: Many - less participation and inclusion, fewer perspectives.
+
+### Documenting technical decisions on Notion
+
+- Pros: Other documentation is on Notion
+- Cons: Notion is private, and not everyone has access; Version control is more difficult; Comments are more difficult; code can get out of sync with documentation
+
+## Links <!-- optional -->
+
+- Documentation on the MADR [template](https://github.com/adr/madr)
+- Blog [post](https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions.html) introducing ADRs

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -1,0 +1,60 @@
+# Decisions
+
+This directory contains decision records for the USDR GOST project.
+
+## What are ADRs?
+
+An Architecture Decision Record is a text file, with a particular format, and an associated discussion. It is numbered for easy reference, and it has a general format. ADRs were documented by Michael Nygard in [this blog post](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions) and are now used by many projects.
+
+## When Should I Create an ADR?
+
+As outlined by Michael Nygard, ADRs represent "architecturally significant" decisions.
+
+The subject of an ADR should affect one of the following areas:
+
+- Structure
+- Dependencies
+- Interfaces
+- Construction techniques
+
+Small changes don't need one, but for larger changes that would introduce a new dependency or affect our overall system architecture, we recommend opening one.
+
+## How to: Create a New ADR record for discussion
+
+To create a new ADR, copy the [./templates/template.md](templates/template.md) file to a new file in this directory. The file name should be `NNNN-title-of-decision.md`, where `NNNN` is the next sequential number for the ADR. For example, if the last ADR was `0001-record-architecture-decisions.md`, the next one would be `0002-title-of-decision.md`.
+
+You can also use the [adr-tools](https://github.com/npryce/adr-tools/blob/master/INSTALL.md) CLI to create new ADRs from this template.
+
+Once you've created a new ADR, you can open a PR to discuss it with the team.
+
+## How to: Create an ADR PR
+
+Create a new ADR, then create a PR within the USDR-gost [repo](https://github.com/usdigitalresponse/usdr-gost/) with your change. Solicit comments on the ADR via this PR, then once all comments are resolved, ask someone to approve the PR and merge it. You may need to re-number the ADR if another one has come in while your proposal was being discussed.
+
+See [this ADR](./0001-decision-record-process.md) for details on the process.
+
+## How to: Diagrams in ADRs
+
+We recommend using [Mermaid](https://github.com/mermaid-js/mermaid) to create diagrams in text. Text-based diagrams are easier to diff, version, and scale than traditional diagrams.
+
+Github now natively supports Mermaid diagrams in Markdown files (more [here](https://github.blog/2022-02-14-include-diagrams-markdown-files-mermaid/)), so you can also view the diagrams in the Github UI by simply including a code block with the language set to `mermaid`, for example:
+
+```text
+    ```mermaid
+       testDiagram
+    ```
+```
+
+You can author Mermaid diagrams using the [Mermaid Live Editor](https://mermaid.live/) and then copy the generated Markdown into your ADR. More easily, to preview the diagrams in VSCode, you can install the [Markdown Preview Mermaid Support](https://marketplace.visualstudio.com/items?itemName=bierner.markdown-mermaid) extension to view the diagrams as you write markdown directly.
+
+## Tooling Tips
+
+- **ADR-Tools** : To make working with ADRs a bit easier, you can use the [adr-tools](https://github.com/npryce/adr-tools/blob/master/INSTALL.md) CLI to create new ADRs from the template
+- **MarkdownLint** : To ensure that the ADRs are formatted correctly, you can use [MarkdownLint](https://github.com/DavidAnson/markdownlint), and if you're using VSCode, you can install the [MarkdownLint Extension](https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint)
+- **Markdown Preview Mermaid Support** [Markdown Preview Mermaid Support](https://marketplace.visualstudio.com/items?itemName=bierner.markdown-mermaid) extension to view the diagrams as you write markdown directly.
+
+## References
+
+- More general information about architectural decision records is available at <https://adr.github.io/>.
+
+- Our template is based on MADR, the Markdown Any Decision Records standard, more info here: <https://adr.github.io/madr/>.

--- a/docs/decisions/templates/template.md
+++ b/docs/decisions/templates/template.md
@@ -1,0 +1,69 @@
+# NUMBER. TITLE
+
+Date: DATE
+Status: status <!-- Proposed | Accepted | Rejected | Superceded -->
+
+## Context and Problem Statement
+
+[Describe the context and problem statement, e.g., in free form using two to three sentences. You may want to articulate the problem in form of a question.]
+
+## Decision Drivers <!-- optional -->
+
+- [driver 1, e.g., a force, facing concern, …]
+- [driver 2, e.g., a force, facing concern, …]
+- … <!-- numbers of drivers can vary -->
+
+## Considered Options
+
+- [option 1]
+- [option 2]
+- [option 3]
+- … <!-- numbers of options can vary -->
+
+## Decision Outcome
+
+Chosen option: "[option 1]", because [justification. e.g., only option, which meets k.o. criterion decision driver | which resolves force force | … | comes out best (see below)].
+
+### Positive Consequences <!-- optional -->
+
+- [e.g., improvement of quality attribute satisfaction, follow-up decisions required, …]
+- …
+
+### Negative Consequences <!-- optional -->
+
+- [e.g., compromising quality attribute, follow-up decisions required, …]
+- …
+
+## Pros and Cons of the Options <!-- optional -->
+
+### [option 1]
+
+[example | description | pointer to more information | …] <!-- optional -->
+
+- Good, because [argument a]
+- Good, because [argument b]
+- Bad, because [argument c]
+- … <!-- numbers of pros and cons can vary -->
+
+### [option 2]
+
+[example | description | pointer to more information | …] <!-- optional -->
+
+- Good, because [argument a]
+- Good, because [argument b]
+- Bad, because [argument c]
+- … <!-- numbers of pros and cons can vary -->
+
+### [option 3]
+
+[example | description | pointer to more information | …] <!-- optional -->
+
+- Good, because [argument a]
+- Good, because [argument b]
+- Bad, because [argument c]
+- … <!-- numbers of pros and cons can vary -->
+
+## Links <!-- optional -->
+
+- [Link type](link to adr) <!-- example: Refined by [xxx](yyyymmdd-xxx.md) -->
+- … <!-- numbers of links can vary -->

--- a/docs/decisions/templates/template.md
+++ b/docs/decisions/templates/template.md
@@ -63,6 +63,32 @@ Chosen option: "[option 1]", because [justification. e.g., only option, which me
 - Bad, because [argument c]
 - … <!-- numbers of pros and cons can vary -->
 
+## Code Examples
+
+[If relevant / it would help the discussion, please provide code examples here that would help in comparing the various options on the table.
+
+A few possible options for doing this:
+
+- A link to a gist or proof of concept repository
+- A separate code block using [github code fencing](https://help.github.com/articles/creating-and-highlighting-code-blocks/)
+- If necessary, you can add a new folder within the `docs/decisions` directory titled `000X-decision-name-files` and add necessary code files there.
+Ideally use the same mechanism for storing all files related to a decision - the below examples are meant to show the full set of different options
+]
+
+### Option 1 Code Example <!-- optional -->
+
+```javascript
+console.log('Hello, World!');
+```
+
+### Option 2 Code Example <!-- optional -->
+
+[Link to gist](www.example.com)
+
+### Option 3 Code Example <!-- optional -->
+
+[local link to file](000X-decision-name-files/example.js)
+
 ## Links <!-- optional -->
 
 - [Link type](link to adr) <!-- example: Refined by [xxx](yyyymmdd-xxx.md) -->


### PR DESCRIPTION
### Ticket #1286
## Description
Meta-proposal to use github to document decision records going forward.

## Screenshots / Demo Video
N/A

## Testing
N/A

### Automated and Unit Tests
- [ ] Added Unit tests
N/A

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually
N/A

## Checklist
- [x] Provided ticket and description
- [x] Provided screenshots/demo
- [x] Provided testing information
- [x] Provided adequate test coverage for all new code
- [x] Added PR reviewers