### PR TITLE
Fix: #1395 delete agencies (short term solution)

### DIFF
--- a/packages/client/src/components/Modals/EditAgency.vue
+++ b/packages/client/src/components/Modals/EditAgency.vue
@@ -197,7 +197,7 @@ export default {
       const msgBoxConfirmResult = await this.$bvModal.msgBoxConfirm(
         'Are you sure you want to delete this agency? This cannot be undone. '
       + 'If the agency has children, reassign child agencies to continue deletion.',
-        { okTitle: 'Delete', okVariant: 'danger', title: 'Delete Agency' }
+        { okTitle: 'Delete', okVariant: 'danger', title: 'Delete Agency' },
       );
       if (msgBoxConfirmResult === true) {
         await this.deleteAgency({

--- a/packages/client/src/components/Modals/EditAgency.vue
+++ b/packages/client/src/components/Modals/EditAgency.vue
@@ -194,23 +194,28 @@ export default {
       if (this.$v.formData.$invalid) {
         return;
       }
-      await this.$bvModal.msgBoxConfirm(
-        'Are you sure you want to delete this agency? This cannot be undone. If the agency has children,'
-      + ' reassign child agencies to continue deletion.',
-      ).then(() => {
-        this.deleteAgency({
+      const msgBoxConfirmResult = await this.$bvModal.msgBoxConfirm(
+        'Are you sure you want to delete this agency? This cannot be undone. '
+      + 'If the agency has children, reassign child agencies to continue deletion.',
+        { okTitle: 'Delete', okVariant: 'danger', title: 'Delete Agency' }
+      );
+      if (msgBoxConfirmResult === true) {
+        await this.deleteAgency({
           agencyId: this.agency.id,
           parent: this.agency.parent,
           name: this.agency.name,
           abbreviation: this.agency.abbreviation,
           warningThreshold: this.formData.warningThreshold,
           dangerThreshold: this.formData.dangerThreshold,
+        }).then(() => {
+          this.resetModal();
+        }).catch(async (e) => {
+          await this.$bvModal.msgBoxOk(`Could not delete agency: ${e.message}`, {
+            title: 'Error',
+            bodyTextVariant: 'danger',
+          });
         });
-        this.resetModal();
-      })
-        .catch((err) => {
-          console.log(` ${err}`);
-        });
+      }
     },
     async handleSubmit() {
       if (this.$v.formData.$invalid) {

--- a/packages/client/src/store/modules/agencies.js
+++ b/packages/client/src/store/modules/agencies.js
@@ -20,10 +20,10 @@ export default {
       await fetchApi.post('/api/organizations/:organizationId/agencies/', body);
       dispatch('fetchAgencies');
     },
-    deleteAgency({ dispatch }, {
+    async deleteAgency({ dispatch }, {
       agencyId, parent, name, abbreviation, warningThreshold, dangerThreshold,
     }) {
-      fetchApi.deleteRequest(`/api/organizations/:organizationId/agencies/del/${agencyId}`, {
+      await fetchApi.deleteRequest(`/api/organizations/:organizationId/agencies/del/${agencyId}`, {
         parent,
         name,
         abbreviation,

--- a/packages/server/__tests__/api/agencies.test.js
+++ b/packages/server/__tests__/api/agencies.test.js
@@ -3,6 +3,10 @@ const sinon = require('sinon');
 const { getSessionCookie, makeTestServer } = require('./utils');
 const emailService = require('../../src/lib/email/service-email');
 const email = require('../../src/lib/email');
+const {
+    createAgency, createUser, deleteUser, deleteAgency,
+} = require('../../src/db');
+const fixtures = require('../db/seeds/fixtures');
 
 describe('`/api/organizations/:organizationId/agencies` endpoint', () => {
     const agencies = {
@@ -76,6 +80,94 @@ describe('`/api/organizations/:organizationId/agencies` endpoint', () => {
         it('is forbidden for an agency outside this user\'s tenant', async () => {
             const response = await fetchApi('/agencies', agencies.admin.offLimits, fetchOptions.admin);
             expect(response.statusText).to.equal('Forbidden');
+        });
+    });
+
+    context('DELETE /api/organizations/:organizationId/agencies/del/:agency', () => {
+        let admin;
+        let deleteRequest;
+        let agency;
+        before(async () => {
+            admin = await createUser({
+                name: 'Test Admin',
+                email: 'admin@example.com',
+                agency_id: 0,
+                tenant_id: 1,
+                role_id: fixtures.roles.adminRole.id,
+            });
+            agency = await createAgency({
+                name: 'Agency To Delete',
+                abbreviation: 'ATD',
+                code: 'ATD',
+                parent: 0,
+                tenant_id: 1,
+                warning_threshold: 12,
+                danger_threshold: 34,
+            }, admin.id);
+            deleteRequest = async (agencyToDelete) => fetchApi(
+                `/agencies/del/${agencyToDelete.id}`,
+                admin.agency_id,
+                {
+                    headers: {
+                        cookie: await getSessionCookie(admin.id),
+                        'Content-Type': 'application/json',
+                    },
+                    method: 'delete',
+                    body: JSON.stringify({
+                        warningThreshold: 12, dangerThreshold: 34, ...agencyToDelete,
+                    }),
+                },
+            );
+        });
+
+        it('issues 400 Bad Request when agency has users', async () => {
+            const blockingUser = await createUser({
+                name: 'Some One',
+                email: 'staff@example.com',
+                agency_id: agency.id,
+                tenant_id: agency.tenant_id,
+                role_id: fixtures.roles.staffRole.id,
+            });
+            const response = await deleteRequest(agency);
+            expect(response.status).to.equal(400);
+            expect(await response.text()).to.equal('agency has assigned users');
+            // Cleanup
+            await deleteUser(blockingUser.id);
+        });
+
+        it('issues 400 Bad Request when agency has sub-agencies', async () => {
+            const subAgency = await createAgency({
+                name: 'Child of Agency To Delete',
+                abbreviation: 'COATD',
+                code: 'COATD',
+                parent: agency.id,
+                tenant_id: agency.tenant_id,
+                warning_threshold: 12,
+                danger_threshold: 34,
+            }, admin.id);
+            const response = await deleteRequest(agency);
+            expect(response.status).to.equal(400);
+            expect(await response.text()).to.equal('agency has sub-agencies');
+            // Cleanup
+            const {
+                id, parent, name, abbreviation, warning_threshold, danger_threshold,
+            } = subAgency;
+            await deleteAgency(id, parent, name, abbreviation, warning_threshold, danger_threshold);
+        });
+
+        it('issues 200 OK when agency has no users or sub-agencies', async () => {
+            const subAgency = await createAgency({
+                name: 'Another Child of Agency To Delete',
+                abbreviation: 'ACOATD',
+                code: 'ACOATD',
+                parent: agency.id,
+                tenant_id: agency.tenant_id,
+                warning_threshold: 12,
+                danger_threshold: 34,
+            }, admin.id);
+            console.log(JSON.stringify(subAgency));
+            const response = await deleteRequest(subAgency);
+            expect(response.status).to.equal(200);
         });
     });
 

--- a/packages/server/__tests__/api/agencies.test.js
+++ b/packages/server/__tests__/api/agencies.test.js
@@ -119,6 +119,13 @@ describe('`/api/organizations/:organizationId/agencies` endpoint', () => {
                 },
             );
         });
+        after(async () => {
+            const {
+                id, parent, name, abbreviation, warning_threshold, danger_threshold,
+            } = agency;
+            await deleteAgency(id, parent, name, abbreviation, warning_threshold, danger_threshold);
+            await deleteUser(admin.id);
+        });
 
         it('issues 400 Bad Request when agency has users', async () => {
             const blockingUser = await createUser({

--- a/packages/server/src/routes/agencies.js
+++ b/packages/server/src/routes/agencies.js
@@ -81,7 +81,7 @@ router.delete('/del/:agency', requireAdminUser, async (req, res) => {
         parent, name, abbreviation, warningThreshold, dangerThreshold,
     } = req.body;
     const result = await deleteAgency(agency, parent, name, abbreviation, warningThreshold, dangerThreshold);
-    res.json(result);
+    return res.json(result);
 });
 
 router.put('/name/:agency', requireAdminUser, async (req, res) => {

--- a/packages/server/src/routes/agencies.js
+++ b/packages/server/src/routes/agencies.js
@@ -22,6 +22,8 @@ const {
     setAgencyParent,
     setAgencyCode,
     deleteAgency,
+    getUsersByAgency,
+    getAgencyTree,
 } = require('../db');
 const AgencyImporter = require('../lib/agencyImporter');
 const email = require('../lib/email');
@@ -65,10 +67,14 @@ router.delete('/del/:agency', requireAdminUser, async (req, res) => {
     const { agency } = req.params;
     const { user } = req.session;
 
-    const allowed = isUserAuthorized(user, agency);
-    if (!allowed) {
-        res.sendStatus(403);
-        return;
+    if (!isUserAuthorized(user, agency)) {
+        return res.sendStatus(403);
+    }
+    if ((await getUsersByAgency(agency)).length > 0) {
+        return res.status(400).send('agency has assigned users');
+    }
+    if ((await getAgencyTree(agency)).length > 1) {
+        return res.status(400).send('agency has sub-agencies');
     }
 
     const {


### PR DESCRIPTION
### Ticket #1395 #1431

Fixes #1431 

## Description

This PR implements the [short-term fix](https://github.com/usdigitalresponse/usdr-gost/issues/1395#issuecomment-1561730199) recommended for #1395. As described in that issue, users cannot delete agencies while they have associated users or sub-agencies. While these restrictions are expected behavior, the API currently does not check for these conditions or handle errors thrown when attempting to delete an agency with associated users and/or sub-agencies, nor does it inform users that the delete operation failed. This PR addresses those issues in the following ways:
- In the API: Before attempting to delete an agency from the database, the endpoint handler checks whether there are currently associated users or sub-agencies. If these conditions are met, the API responds with a 400 (Bad Request), along with a message stating the reason why the agency is not eligible for deletion (either `agency has assigned users` or `agency has sub-agencies`).
- In the UI: When a request to delete an agency is not successful, a [Vue modal message box](https://bootstrap-vue.org/docs/components/modal#modal-message-boxes) is displayed, which contains a message informing the user of the error and a single OK button.

Additionally, while working on this fix, I found another issue (#1431). In an exciting twist, it seems that selecting the "Cancel" option provided by the "Are you sure you want to delete this agency?" confirmation dialogue was not being honored, meaning that regardless of the user's selection, a request would always be issued to delete the agency. This PR follows the "Option 1" approach from that issue and continues to provide "OK" and "Cancel" options to the user, ensuring that a `DELETE` request is only sent when the user selects "OK".

## Screenshots / Demo Video


https://github.com/usdigitalresponse/usdr-gost/assets/1851017/02c737e1-6fec-49b5-8708-1b66e962cd3b



## Testing

1. Create a new agency
2. Create another agency, with the agency created in Step 1 as the parent
3. Create a user associated with the agency created in Step 1
4. Open the edit modal for the agency created in Step 1, and click the "Admin Delete Agency" button. 
5. Click "Cancel", and confirm the agency was not deleted.
6. Click "Admin Delete Agency" again, then click "OK". You should get an error because the agency has associated users.
7. Delete the user created in Step 3.
8. Do the same actions as in Step 6, but this time, the error should inform that there are associated sub-agencies.
9. Delete the sub-agency created in Step 2.
10. Do the same actions as in Steps 6 and 8. This time, the modal should close with no error.
11. Confirm that the agency created in Step 1 has been deleted.

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [X] Provided ticket and description
- [X] Provided screenshots/demo
- [X] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers