### PR TITLE
fix: #1386 - Default Sort Validated Desc

### DIFF
--- a/packages/client/src/arpa_reporter/views/Uploads.vue
+++ b/packages/client/src/arpa_reporter/views/Uploads.vue
@@ -16,6 +16,10 @@
       :columns="columns"
       :rows="rows"
       :group-options="groupOptions"
+      :sort-options="{
+        enabled: true,
+        initialSortBy: defaultSortOrder
+      }"
       styleClass="vgt-table table table-striped table-bordered"
       ref="uploadsTable"
       >
@@ -89,6 +93,12 @@ export default {
     groupOptions() {
       return {
         enabled: this.groupByAgency,
+      };
+    },
+    defaultSortOrder() {
+      return {
+        field: 'validated_at',
+        type: 'desc',
       };
     },
     rows() {
@@ -196,7 +206,7 @@ export default {
   methods: {
     resetFilters() {
       this.$refs.uploadsTable.reset();
-      this.$refs.uploadsTable.changeSort([]);
+      this.$refs.uploadsTable.changeSort([this.defaultSortOrder]);
     },
     shortUuid,
     async loadExportedUploads() {

--- a/packages/client/tests/unit/arpa_reporter/views/Uploads.spec.js
+++ b/packages/client/tests/unit/arpa_reporter/views/Uploads.spec.js
@@ -26,6 +26,48 @@ describe('Uploads.vue', () => {
     });
     expect(wrapper.text()).to.include('No uploads');
   });
+
+  it('renders with data and defaults to descending sorting', async () => {
+    const store = new Vuex.Store({
+      state: {
+        agencies: [],
+        allUploads: [{
+          agency_code: 'USDR',
+          agency_id: 0,
+          created_at: new Date().toISOString(),
+          created_by: 'test@usdigitalresponse.org',
+          ec_code: '0',
+          filename: 'TEST_UPLOAD.xlsm',
+          id: '00000000-0000-0000-0000-000000000000',
+          notes: null,
+          reporting_period_id: 64,
+          tenant_id: 1,
+          user_id: 1,
+          validated_at: new Date().toISOString(),
+          validated_by: 1,
+        }],
+      },
+      getters: {
+        periodNames: () => ['September, 2020', 'December, 2020'],
+        agencyName: () => () => 'Test Agency',
+      },
+    });
+
+    const wrapper = mount(Uploads, {
+      store,
+      localVue,
+      stubs: ['router-link'],
+    });
+    expect(wrapper.text()).to.include('00000000');
+
+    const validatedCol = wrapper.find('#vgt-table').findAll('th').at(6);
+    // table sorting doesn't happen until the next tick. this can be found in the
+    // good table test cases
+    // https://github.com/xaksis/vue-good-table/blob/master/test/unit/specs/Table.spec.js#L78
+    await wrapper.vm.$nextTick();
+    expect(validatedCol.classes()).to.include('sorting-desc');
+    expect(validatedCol.classes()).to.include('sortable');
+  });
 });
 
 // NOTE: This file was copied from tests/unit/views/Uploads.spec.js (git @ ada8bfdc98) in the arpa-reporter repo on 2022-09-23T20:05:47.735Z


### PR DESCRIPTION
Ensure that uploads are automatically sorted by latest validated at the top (#1386)

* added default sorting order to the Uploads page

* added test case for checking the Upload validated at sort dependency

### Ticket #1386 
## Description
Updated the default sort order to sort by Validated At descending.

## Screenshots / Demo Video

## Testing
Ran manual tests as per the below instructions.
Also added a unit test case.

### Automated and Unit Tests
- [x] Added Unit tests

### Manual tests for Reviewer
- Check the page
- Change sorting multiple times
- Click "Reset Filters"
- Check sort
- Click "Group by agency?"
- Check sort
- Click "Reset Filters"
- Click "Only exported to treasury?"
- Check sorting

## Checklist
- [ ] Provided ticket and description
- [ ] Provided screenshots/demo
- [x] Provided testing information
- [x] Provided adequate test coverage for all new code
- [ ] Added PR reviewers