### PR TITLE
1450 - Saved Search List Drawer

### DIFF
--- a/packages/client/src/components/GrantsTable.vue
+++ b/packages/client/src/components/GrantsTable.vue
@@ -11,6 +11,7 @@
       </b-col>
       <b-col class="d-flex justify-content-end">
         <SearchPanel />
+        <SavedSearchPanel />
         <b-button @click="exportCSV" :disabled="loading" variant="outline-secondary">
           <b-icon icon="download" class="mr-1 mb-1" font-scale="0.9" aria-hidden="true" />
           Export to CSV
@@ -72,9 +73,12 @@ import Multiselect from 'vue-multiselect';
 import { titleize } from '../helpers/form-helpers';
 import GrantDetails from './Modals/GrantDetails.vue';
 import SearchPanel from './Modals/SearchPanel.vue';
+import SavedSearchPanel from './Modals/SavedSearchPanel.vue';
 
 export default {
-  components: { GrantDetails, Multiselect, SearchPanel },
+  components: {
+    GrantDetails, Multiselect, SearchPanel, SavedSearchPanel,
+  },
   props: {
     showMyInterested: Boolean,
     showInterested: Boolean,

--- a/packages/client/src/components/Modals/SavedSearchPanel.vue
+++ b/packages/client/src/components/Modals/SavedSearchPanel.vue
@@ -1,0 +1,97 @@
+<template>
+  <div>
+    <b-button v-b-toggle.saved-search-panel variant="outline-secondary">
+      My Saved Searches
+    </b-button>
+    <b-sidebar
+      id="saved-search-panel"
+      class="saved-search-panel"
+      right
+      shadow
+    >
+    <template #header="{ hide }">
+      <div class="saved-search-title">Saved Searches</div>
+      <div @click="hide">
+        <svg viewBox="0 0 16 16" width="1em" height="1em" focusable="false" role="img" aria-label="x" xmlns="http://www.w3.org/2000/svg" fill="currentColor" class="bi-x b-icon bi header-close-button"><g><path d="M4.646 4.646a.5.5 0 0 1 .708 0L8 7.293l2.646-2.647a.5.5 0 0 1 .708.708L8.707 8l2.647 2.646a.5.5 0 0 1-.708.708L8 8.707l-2.646 2.647a.5.5 0 0 1-.708-.708L7.293 8 4.646 5.354a.5.5 0 0 1 0-.708z"></path></g></svg>
+      </div>
+    </template>
+    <div class="saved-search-empty-state">
+      <h4>No saved searches</h4>
+      <span>Save search criteria to easily apply or share a search</span>
+    </div>
+    <template #footer="{ hide }">
+     <div class="d-flex text-light align-items-center px-3 py-2">
+      <b-button size="sm" @click="hide" variant="outline-primary" class="borderless-button">Close</b-button>
+     </div>
+    </template>
+    </b-sidebar>
+  </div>
+</template>
+
+<script>
+import { mapActions, mapGetters } from 'vuex';
+import { VBToggle } from 'bootstrap-vue';
+
+export default {
+  props: {
+    showModal: Boolean,
+  },
+  directives: {
+    'v-b-toggle': VBToggle,
+  },
+  data() {
+    return {};
+  },
+  validations: {},
+  watch: {},
+  computed: {
+    ...mapGetters({}),
+  },
+  mounted() {
+  },
+  methods: {
+    ...mapActions({}),
+  },
+};
+</script>
+<style>
+.saved-search-title{
+  font-style: normal;
+  font-weight: 700;
+  font-size: 20px;
+  line-height: 120%;
+}
+.header-close-button{
+  cursor: pointer;
+}
+.b-sidebar-header{
+  justify-content: space-between;
+  border-bottom: solid #DAE0E5;
+}
+.b-sidebar-body{
+  display: flex;
+}
+.b-sidebar-footer{
+  display: flex;
+  justify-content: end;
+  border-top: solid #DAE0E5;
+}
+.saved-search-empty-state{
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  font-style: normal;
+}
+.saved-search-empty-state > h4{
+  font-weight: 700;
+  font-size: 16px;
+  line-height: 120%;
+}
+.saved-search-empty-state > span{
+  font-weight: 500;
+  font-size: 14px;
+  line-height: 150%;
+}
+</style>

--- a/packages/client/src/components/Modals/SavedSearchPanel.vue
+++ b/packages/client/src/components/Modals/SavedSearchPanel.vue
@@ -11,9 +11,9 @@
     >
     <template #header="{ hide }">
       <div class="saved-search-title">Saved Searches</div>
-      <div @click="hide">
-        <svg viewBox="0 0 16 16" width="1em" height="1em" focusable="false" role="img" aria-label="x" xmlns="http://www.w3.org/2000/svg" fill="currentColor" class="bi-x b-icon bi header-close-button"><g><path d="M4.646 4.646a.5.5 0 0 1 .708 0L8 7.293l2.646-2.647a.5.5 0 0 1 .708.708L8.707 8l2.647 2.646a.5.5 0 0 1-.708.708L8 8.707l-2.646 2.647a.5.5 0 0 1-.708-.708L7.293 8 4.646 5.354a.5.5 0 0 1 0-.708z"></path></g></svg>
-      </div>
+      <b-button type="button" class="close" aria-label="Close" @click="hide">
+       <span aria-hidden="true">&times;</span>
+      </b-button>
     </template>
     <div class="saved-search-empty-state">
       <h4>No saved searches</h4>
@@ -61,8 +61,8 @@ export default {
   font-size: 20px;
   line-height: 120%;
 }
-.header-close-button{
-  cursor: pointer;
+.b-sidebar.b-sidebar-right > .b-sidebar-header .close{
+  margin-right: 0px;
 }
 .b-sidebar-header{
   justify-content: space-between;


### PR DESCRIPTION
### Ticket #1450
## Description
Saved search list drawer modal opens on click of "My Saved Searches" button. Closes on click of close buttons in header and footer. Currently displaying empty state content.

## Screenshots / Demo Video
<img width="1680" alt="Screenshot 2023-06-11 at 8 41 31 PM" src="https://github.com/usdigitalresponse/usdr-gost/assets/12160369/bb6d2ad9-3aa5-4d02-a848-159832a27e0f">
<img width="1679" alt="Screenshot 2023-06-11 at 8 41 52 PM" src="https://github.com/usdigitalresponse/usdr-gost/assets/12160369/2d578a72-ab75-4ab9-b61e-ca4afcc10151">


## Testing

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [ ] Provided ticket and description
- [ ] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers