### PR TITLE
fix: #1050 Add logic to check improperly formatted dates

### DIFF
--- a/packages/server/__tests__/arpa_reporter/server/services/validate-upload.spec.js
+++ b/packages/server/__tests__/arpa_reporter/server/services/validate-upload.spec.js
@@ -65,6 +65,28 @@ describe('validate record', () => {
         Number_Affordable_Housing_Units__c: 0,
     };
 
+    const VALID_AWARDS_50K = {
+        Recipient_UEI__c: 'ABCDEFGHIJK',
+        Recipient_EIN__c: '00-0000000',
+        Entity_Type_2__c: 'Contractor',
+        Project_Identification_Number__c: 1,
+        Award_No__c: '000',
+        Award_Type__c: 'Contract: Blanket Purchase Agreement',
+        Award_Amount__c: 10,
+        Award_Date__c: '3/29/2022',
+        Primary_Sector__c: 'Family or child care',
+        Purpose_of_Funds__c: 'Sample purpose',
+        Period_of_Performance_Start__c: '2022-02-01T05:00:00.000Z',
+        Period_of_Performance_End__c: '2022-08-31T04:00:00.000Z',
+        Place_of_Performance_Address_1__c: 'Somewhere Else',
+        Place_of_Performance_Address_2__c: 'Area 51',
+        Place_of_Performance_City__c: 'Somewhere',
+        State_Abbreviated__c: 'RI',
+        Place_of_Performance_Zip__c: '02920',
+        Description__c: 'Sample description',
+        Subaward_Changed__c: 'No',
+    };
+
     it('validates a valid project succesfully', () => validateRecord({
         upload: { ec_code: '2.16' },
         record: VALID_EC2_PROJECT,
@@ -106,6 +128,38 @@ describe('validate record', () => {
                 assert(generatedErrors.length === 1);
                 assert(generatedErrors[0].severity === 'err');
                 assert.equal(generatedErrors[0].message, `Expected a number, but the value was 'N/A'`);
+            },
+            (thrownException) => { assert.fail(`Unexpected error while validating record: ${thrownException}`); },
+        );
+    });
+
+    it('validates a valid award successfully', () => {
+        const project = _.clone(VALID_AWARDS_50K);
+        return validateRecord({
+            upload: { ec_code: '2.16' },
+            record: project,
+            typeRules: ALL_RULES.awards50k,
+        }).then(
+            (generatedErrors) => {
+                assert(generatedErrors.length === 0,
+                    `Unexpected error when validating record: ${generatedErrors}`);
+            },
+            (thrownException) => { assert.fail(`Unexpected error while validating record: ${thrownException}`); },
+        );
+    });
+
+    it('throws error for a bad date', () => {
+        const project = _.clone(VALID_AWARDS_50K);
+        project.Award_Date__c = '3/292022';
+        return validateRecord({
+            upload: { ec_code: '2.16' },
+            record: project,
+            typeRules: ALL_RULES.awards50k,
+        }).then(
+            (generatedErrors) => {
+                assert(generatedErrors.length === 1);
+                assert(generatedErrors[0].severity === 'err');
+                assert.equal(generatedErrors[0].message, `Data entered in cell is "3/292022", which is not a valid date.`);
             },
             (thrownException) => { assert.fail(`Unexpected error while validating record: ${thrownException}`); },
         );

--- a/packages/server/src/arpa_reporter/services/validate-upload.js
+++ b/packages/server/src/arpa_reporter/services/validate-upload.js
@@ -311,6 +311,15 @@ async function validateRecord({ upload, record, typeRules: rules }) {
                 }
             }
 
+            if (rule.dataType === 'Date') {
+                if (value && typeof value === 'string' && Number.isNaN(Date.parse(value))) {
+                    errors.push(new ValidationError(
+                        `Data entered in cell is "${value}", which is not a valid date.`,
+                        { severity: 'err', col: rule.columnName },
+                    ));
+                }
+            }
+
             if (rule.dataType === 'String') {
                 const patternError = validateFieldPattern(key, value);
                 if (patternError) {


### PR DESCRIPTION
### Ticket #1050
## Description
Excel may have dates that it views as valid, but are not valid. One such example is "03/292022". We can add date checks to the template directly, but we want backup checks in the backend for all dates.

In this PR, a new validation rule was added for all `Date` types.

## Screenshots / Demo Video
![image](https://github.com/usdigitalresponse/usdr-gost/assets/842982/710ef3bf-8bb3-4833-ae2f-e593def0d19a)

## Testing
- Download the `NEW 10002 - DHS - EC2_32 - v20230523 - Date Format.xlsm` file from Google drive in the Test Templates directory
- Upload the template
- Wait for the validation error

### Automated and Unit Tests
- [x] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [x] Provided ticket and description
- [x] Provided screenshots/demo
- [x] Provided testing information
- [x] Provided adequate test coverage for all new code
- [x] Added PR reviewers