### PR TITLE
Search chips

### DIFF
--- a/packages/client/.env.example
+++ b/packages/client/.env.example
@@ -1,2 +1,2 @@
-# there aren't currently any env variables needed on the client
-# so this file is empty!
+# use the in-progress grant table experience
+VUE_APP_USE_NEW_TABLE=true

--- a/packages/client/public/deploy-config.js.example
+++ b/packages/client/public/deploy-config.js.example
@@ -1,2 +1,3 @@
 window.APP_CONFIG = window.APP_CONFIG || {};
 window.APP_CONFIG.apiURLForGOST = "https://example.com/api";
+window.APP_CONFIG.UseNewTable = true;

--- a/packages/client/src/components/EmailSettingsBanner.vue
+++ b/packages/client/src/components/EmailSettingsBanner.vue
@@ -4,7 +4,7 @@
           <b-icon icon="envelope-fill" font-scale="1.5" style="width: 50px; color: #0FA958;"></b-icon>
           <div style="padding-right: 10px; color: #212529;">
           <b>The Grant ID Tool now has email notifications!</b>
-          Fine tune which email you will recieve in <u v-on:click="showProfileSettings()">Settings</u> or turn on all notifications here:
+          Fine tune which email you will receive in <u v-on:click="showProfileSettings()">Settings</u> or turn on all notifications here:
         </div >
         <b-form-checkbox v-model="checked" name="email-opt-in-switch" switch @change="onUserSubscriptionChangeSubmit"/>
       </b-alert>

--- a/packages/client/src/components/GrantsTable.vue
+++ b/packages/client/src/components/GrantsTable.vue
@@ -99,10 +99,28 @@ export default {
       perPage: 50,
       currentPage: 1,
       loading: false,
-      searchFilters: {
-        include: ['Nevada', 'infrastructure'],
-        exclude: ['highways', 'roads', 'streets'],
-      },
+      searchFilters: [
+        {
+          label: 'Include',
+          value: ['Nevada', 'infrastructure'],
+        },
+        {
+          label: 'Exclude',
+          value: ['road', 'highways'],
+        },
+        {
+          label: 'Opp Status',
+          value: ['forecasted', 'posted'],
+        },
+        {
+          label: 'Cost Sharing',
+          value: 'Yes',
+        },
+        {
+          label: 'Review Status',
+          value: ['Interested', 'Supporting'],
+        },
+      ],
       fields: [
         {
           key: 'grant_number',

--- a/packages/client/src/components/GrantsTable.vue
+++ b/packages/client/src/components/GrantsTable.vue
@@ -18,6 +18,11 @@
         </b-button>
       </b-col>
     </b-row>
+    <b-row>
+      <b-col cols="12">
+        <SearchFilter :filterKeys="searchFilters" />
+      </b-col>
+    </b-row>
     <b-row class="mt-3 mb-3" align-h="start" style="position: relative; z-index: 999">
       <b-col v-if="!showInterested && !showRejected && !showResult && !showAssignedToAgency" cols="3">
         <multiselect v-model="reviewStatusFilters" :options="reviewStatusOptions" :multiple="true"
@@ -74,10 +79,11 @@ import { titleize } from '../helpers/form-helpers';
 import GrantDetails from './Modals/GrantDetails.vue';
 import SearchPanel from './Modals/SearchPanel.vue';
 import SavedSearchPanel from './Modals/SavedSearchPanel.vue';
+import SearchFilter from './SearchFilter.vue';
 
 export default {
   components: {
-    GrantDetails, Multiselect, SearchPanel, SavedSearchPanel,
+    GrantDetails, Multiselect, SearchPanel, SavedSearchPanel, SearchFilter,
   },
   props: {
     showMyInterested: Boolean,
@@ -93,6 +99,10 @@ export default {
       perPage: 50,
       currentPage: 1,
       loading: false,
+      searchFilters: {
+        include: ['Nevada', 'infrastructure'],
+        exclude: ['highways', 'roads', 'streets'],
+      },
       fields: [
         {
           key: 'grant_number',
@@ -256,6 +266,7 @@ export default {
     titleize,
     debounceSearchInput: debounce(function bounce(newVal) {
       this.debouncedSearchInput = newVal;
+      this.searchFilters.include = newVal;
     }, 500),
     async paginateGrants() {
       try {

--- a/packages/client/src/components/GrantsTableNext.vue
+++ b/packages/client/src/components/GrantsTableNext.vue
@@ -10,10 +10,17 @@
         </b-input-group>
       </b-col>
       <b-col class="d-flex justify-content-end">
+        <SearchPanel />
+        <SavedSearchPanel />
         <b-button @click="exportCSV" :disabled="loading" variant="outline-secondary">
           <b-icon icon="download" class="mr-1 mb-1" font-scale="0.9" aria-hidden="true" />
           Export to CSV
         </b-button>
+      </b-col>
+    </b-row>
+    <b-row>
+      <b-col cols="12">
+        <SearchFilter :filterKeys="searchFilters" />
       </b-col>
     </b-row>
     <b-row class="mt-3 mb-3" align-h="start" style="position: relative; z-index: 999">
@@ -70,10 +77,13 @@ import { debounce } from 'lodash';
 import Multiselect from 'vue-multiselect';
 import { titleize } from '../helpers/form-helpers';
 import GrantDetails from './Modals/GrantDetails.vue';
+import SearchPanel from './Modals/SearchPanel.vue';
+import SavedSearchPanel from './Modals/SavedSearchPanel.vue';
+import SearchFilter from './SearchFilter.vue';
 
 export default {
   components: {
-    GrantDetails, Multiselect,
+    GrantDetails, Multiselect, SearchPanel, SavedSearchPanel, SearchFilter,
   },
   props: {
     showMyInterested: Boolean,
@@ -89,6 +99,28 @@ export default {
       perPage: 50,
       currentPage: 1,
       loading: false,
+      searchFilters: [
+        {
+          label: 'Include',
+          value: ['Nevada', 'infrastructure'],
+        },
+        {
+          label: 'Exclude',
+          value: ['road', 'highways'],
+        },
+        {
+          label: 'Opp Status',
+          value: ['forecasted', 'posted'],
+        },
+        {
+          label: 'Cost Sharing',
+          value: 'Yes',
+        },
+        {
+          label: 'Review Status',
+          value: ['Interested', 'Supporting'],
+        },
+      ],
       fields: [
         {
           key: 'grant_number',

--- a/packages/client/src/components/SearchFilter.vue
+++ b/packages/client/src/components/SearchFilter.vue
@@ -1,0 +1,42 @@
+<template>
+  <div>
+    <span class="filter-item" v-for="(item, idx) in Object.entries($props.filterKeys)" :key="idx">
+      <strong >{{ item[0] }}: </strong>{{ formatValue(item[1])  }} <b-icon icon="x">&nbsp;</b-icon>
+    </span>
+    <div>
+      <a href="#" v-on:click="clear">Clear all</a>
+    </div>
+  </div>
+</template>
+<script>
+
+export default {
+  props: {
+    filterKeys: {
+      type: Object,
+      required: true,
+    },
+  },
+  data() {
+    return {
+    };
+  },
+  methods: {
+    formatValue(value) {
+      if (Array.isArray(value)) {
+        return value.join(', ');
+      }
+      return value;
+    },
+    clear() {
+    },
+  },
+};
+
+</script>
+<style>
+.filter-item {
+  padding: 0.25rem 0.5rem;
+}
+
+</style>

--- a/packages/client/src/components/SearchFilter.vue
+++ b/packages/client/src/components/SearchFilter.vue
@@ -1,10 +1,12 @@
 <template>
   <div>
-    <span class="filter-item" v-for="(item, idx) in Object.entries($props.filterKeys)" :key="idx">
-      <strong >{{ item[0] }}: </strong>{{ formatValue(item[1])  }} <b-icon icon="x">&nbsp;</b-icon>
-    </span>
-    <div>
-      <a href="#" v-on:click="clear">Clear all</a>
+    <div class="mb-3">
+      <span class="filter-item" v-for="(item, idx) in $props.filterKeys" :key="idx">
+        <strong >{{ item.label }}: </strong>{{ formatValue(item.value)  }} <a href="#" v-on:click.prevent="clearFilter(idx)"><b-icon icon="x" font-scale="1.5">&nbsp;</b-icon></a>
+      </span>
+    </div>
+    <div class="mb-3">
+      <a href="#" v-on:click="clearAll">Clear all</a>
     </div>
   </div>
 </template>
@@ -13,13 +15,10 @@
 export default {
   props: {
     filterKeys: {
-      type: Object,
+      type: Array,
       required: true,
+      validator: (value) => value.every((item) => typeof item.label === 'string'),
     },
-  },
-  data() {
-    return {
-    };
   },
   methods: {
     formatValue(value) {
@@ -28,7 +27,13 @@ export default {
       }
       return value;
     },
-    clear() {
+    clearAll() {
+      this.filterKeys.splice(0, this.filterKeys.length);
+    },
+    clearFilter(index) {
+      // TODO emit event when parent component is handling state
+      // this.$emit('filter:remove', index);
+      this.filterKeys.splice(index, 1);
     },
   },
 };

--- a/packages/client/src/views/Grants.vue
+++ b/packages/client/src/views/Grants.vue
@@ -17,7 +17,7 @@ export default {
   methods: {},
   computed: {
     tableComponent() {
-      const useNewTable = process.env.NODE_ENV === 'development' || process.env.VUE_APP_USE_NEW_TABLE === 'true';
+      const useNewTable = process.env.VUE_APP_USE_NEW_TABLE === 'true' || (window.APP_CONFIG || {}).UseNewTable === true;
       return useNewTable ? GrantsTableNext : GrantsTable;
     },
   },

--- a/packages/client/src/views/Grants.vue
+++ b/packages/client/src/views/Grants.vue
@@ -1,10 +1,11 @@
 <template>
-  <GrantsTable :hideGrantItems="true"/>
+  <component :is="tableComponent" :hideGrantItems="true"/>
 </template>
 
 <script>
 
 import GrantsTable from '@/components/GrantsTable.vue';
+import GrantsTableNext from '@/components/GrantsTableNext.vue';
 
 export default {
   components: { GrantsTable },
@@ -14,5 +15,11 @@ export default {
     };
   },
   methods: {},
+  computed: {
+    tableComponent() {
+      const useNewTable = process.env.NODE_ENV === 'development' || process.env.VUE_APP_USE_NEW_TABLE === 'true';
+      return useNewTable ? GrantsTableNext : GrantsTable;
+    },
+  },
 };
 </script>

--- a/packages/client/src/views/MyGrants.vue
+++ b/packages/client/src/views/MyGrants.vue
@@ -1,16 +1,16 @@
 <template>
   <b-tabs pills align="center" lazy>
     <b-tab title="Interested" active>
-      <GrantsTable :showInterested="true"/>
+      <component :is="tableComponent" :showInterested="true"/>
     </b-tab>
     <b-tab title="Assigned">
-      <GrantsTable :showAssignedToAgency="selectedAgencyId"/>
+      <component :is="tableComponent" :showAssignedToAgency="selectedAgencyId"/>
     </b-tab>
     <b-tab title="Not Applying">
-      <GrantsTable :showRejected="true"/>
+      <component :is="tableComponent" :showRejected="true"/>
     </b-tab>
     <b-tab title="Applied">
-        <GrantsTable :showResult="true"/>
+        <component :is="tableComponent" :showResult="true"/>
     </b-tab>
   </b-tabs>
 </template>
@@ -19,6 +19,7 @@
 import { mapGetters } from 'vuex';
 
 import GrantsTable from '@/components/GrantsTable.vue';
+import GrantsTableNext from '@/components/GrantsTableNext.vue';
 
 export default {
   components: { GrantsTable },
@@ -31,6 +32,10 @@ export default {
     ...mapGetters({
       selectedAgencyId: 'users/selectedAgencyId',
     }),
+    tableComponent() {
+      const useNewTable = process.env.NODE_ENV === 'development' || process.env.VUE_APP_USE_NEW_TABLE === 'true';
+      return useNewTable ? GrantsTableNext : GrantsTable;
+    },
   },
   methods: {},
 };

--- a/packages/client/src/views/MyGrants.vue
+++ b/packages/client/src/views/MyGrants.vue
@@ -33,7 +33,7 @@ export default {
       selectedAgencyId: 'users/selectedAgencyId',
     }),
     tableComponent() {
-      const useNewTable = process.env.NODE_ENV === 'development' || process.env.VUE_APP_USE_NEW_TABLE === 'true';
+      const useNewTable = process.env.VUE_APP_USE_NEW_TABLE === true || (window.APP_CONFIG || {}).UseNewTable === true;
       return useNewTable ? GrantsTableNext : GrantsTable;
     },
   },

--- a/terraform/modules/gost_website/runtime_config.tf
+++ b/terraform/modules/gost_website/runtime_config.tf
@@ -2,7 +2,8 @@ locals {
   deployConfigContents = templatefile(
     "${path.module}/tpl/deploy-config.js",
     {
-      gost_api_domain = var.gost_api_domain,
+      gost_api_domain    = var.gost_api_domain,
+      gost_use_new_table = var.gost_use_new_table,
     }
   )
 }

--- a/terraform/modules/gost_website/storage.tf
+++ b/terraform/modules/gost_website/storage.tf
@@ -28,7 +28,7 @@ locals {
 
 module "cloudfront_to_origin_bucket_access_policy" {
   source  = "cloudposse/iam-policy/aws"
-  version = "0.4.0"
+  version = "1.0.1"
   context = module.s3_label.context
 
   iam_policy_statements = {
@@ -62,7 +62,7 @@ module "cloudfront_to_origin_bucket_access_policy" {
 
 module "github_deploy_to_origin_bucket_policy" {
   source  = "cloudposse/iam-policy/aws"
-  version = "0.4.0"
+  version = "1.0.1"
   context = module.s3_label.context
 
   iam_policy_statements = {

--- a/terraform/modules/gost_website/tpl/deploy-config.js
+++ b/terraform/modules/gost_website/tpl/deploy-config.js
@@ -1,3 +1,3 @@
 window.APP_CONFIG = window.APP_CONFIG || {};
 window.apiURLForGOST = 'https://${gost_api_domain}/';
-window.UseNewTable = ${use_new_table};
+window.APP_CONFIG.UseNewTable = ${gost_use_new_table};

--- a/terraform/modules/gost_website/tpl/deploy-config.js
+++ b/terraform/modules/gost_website/tpl/deploy-config.js
@@ -1,2 +1,3 @@
 window.APP_CONFIG = window.APP_CONFIG || {};
 window.apiURLForGOST = 'https://${gost_api_domain}/';
+window.UseNewTable = ${use_new_table};

--- a/terraform/modules/gost_website/variables.tf
+++ b/terraform/modules/gost_website/variables.tf
@@ -35,6 +35,12 @@ variable "gost_api_domain" {
   type        = string
 }
 
+variable "gost_use_new_table" {
+  description = "Flag to tell client to use the new table experience."
+  type        = bool
+  default     = false
+}
+
 variable "logs_bucket_versioning" {
   description = "Enable versioning for the logs S3 bucket"
   type        = bool


### PR DESCRIPTION
### Ticket #1394
## Description
- Adds a new SearchFilter component which will display the chips for a current filter
- Until the state is handled in the parent, the component will remove by clicking close X or "clear all". This should probably be an emit later down the road.
- Per discussion at standup, I also split out the new search functionality into a copy of the `GrantsTable` component. The new one will display when `NODE_ENV='development'` (which should already be the case for us locally). 

Closes #1394 

## Screenshots / Demo Video

https://github.com/usdigitalresponse/usdr-gost/assets/624510/b1e5cf43-9c70-46da-95c0-30ed280ef098

## Testing
- With `NODE_ENV='development'`, confirm the filter chips display on the My Grants and Grants pages.
- Add/remove data from the `searchFilters`  variable in `GrantsTableNext.vue`. Observe display on the page.

### Automated and Unit Tests
- [ ] Added Unit tests

**I haven't added any unit tests**. I didn't find where/how these component tests are being done; would appreciate if someone could point me to that, or if I should start from scratch.

### Manual tests for Reviewer
- [x] Added steps to test feature/functionality manually

## Checklist
- [x] Provided ticket and description
- [x] Provided screenshots/demo
- [x] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [x] Added PR reviewers