### PR TITLE
fix(server): add validation check for subaward city column

### DIFF
--- a/packages/server/__tests__/arpa_reporter/server/services/validate-upload.spec.js
+++ b/packages/server/__tests__/arpa_reporter/server/services/validate-upload.spec.js
@@ -23,12 +23,24 @@ describe('validate upload', () => {
         const malformedEmail = 'john smith john.smith@email.com';
         const properEmail = 'john.smith@email.com';
 
+        const CITY_KEY = 'Place_of_Performance_City__c';
+        const malformedCity = 'St. Louis';
+        const properCity = 'New York City';
+
         it('Does not raise an error for valid emails', () => {
             assert(validateFieldPattern(EMAIL_KEY, properEmail) === null);
         });
 
         it('Raises an error for invalid emails', () => {
             assert(validateFieldPattern(EMAIL_KEY, malformedEmail) !== null);
+        });
+
+        it('Does not raise an error for valid cities', () => {
+            assert(validateFieldPattern(CITY_KEY, properCity) === null);
+        });
+
+        it('Raises an error for invalid cities', () => {
+            assert(validateFieldPattern(CITY_KEY, malformedCity) !== null);
         });
     });
 });

--- a/packages/server/src/arpa_reporter/services/validate-upload.js
+++ b/packages/server/src/arpa_reporter/services/validate-upload.js
@@ -25,7 +25,7 @@ const SHOULD_NOT_CONTAIN_PERIOD_REGEX_PATTERN = /^[^.]*$/;
 // Note that this only covers cases where the name of the field is what we want to match on.
 const FIELD_NAME_TO_PATTERN = {
     POC_Email_Address__c: { pattern: EMAIL_REGEX_PATTERN, explanation: 'Email must be of the form "user@email.com"' },
-    Place_of_Performance_City__c: { pattern: SHOULD_NOT_CONTAIN_PERIOD_REGEX_PATTERN, explanation: 'Field must not contain an illegal character (i.e. .)' },
+    Place_of_Performance_City__c: { pattern: SHOULD_NOT_CONTAIN_PERIOD_REGEX_PATTERN, explanation: 'Field must not contain a period.' },
 };
 
 // This is a convenience wrapper that lets us use consistent behavior for new validation errors.

--- a/packages/server/src/arpa_reporter/services/validate-upload.js
+++ b/packages/server/src/arpa_reporter/services/validate-upload.js
@@ -19,10 +19,13 @@ const EMAIL_REGEX_PATTERN = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)
 
 const BETA_VALIDATION_MESSAGE = '[BETA] This is a new validation that is running in beta mode (as a warning instead of a blocking error). If you see anything incorrect about this validation, please report it at grants-helpdesk@usdigitalresponse.org';
 
+const SHOULD_NOT_CONTAIN_PERIOD_REGEX_PATTERN = /^[^.]*$/;
+
 // This maps from field name to regular expression that must match on the field.
 // Note that this only covers cases where the name of the field is what we want to match on.
 const FIELD_NAME_TO_PATTERN = {
     POC_Email_Address__c: { pattern: EMAIL_REGEX_PATTERN, explanation: 'Email must be of the form "user@email.com"' },
+    Place_of_Performance_City__c: { pattern: SHOULD_NOT_CONTAIN_PERIOD_REGEX_PATTERN, explanation: 'Field must not contain an illegal character (i.e. .)' },
 };
 
 // This is a convenience wrapper that lets us use consistent behavior for new validation errors.


### PR DESCRIPTION
### Ticket #1347 
## Description
Currently, there is no validation check for the Subaward City column for inclusion of the "." character. If the entries for this column contains a period, the portal kicks back an error in this field. In this PR, we're adding a check to make sure we catch this error before submission.

## Screenshots / Demo Video
* Filled out a worksheet where `Primary Place of Performance City Name` under `Awards > 5000` contains a period:
![image](https://github.com/usdigitalresponse/usdr-gost/assets/14842270/2ba22ff1-e353-4820-bd54-8a70063f66ae)
* Sees validation error that the column contains a period:
![image](https://github.com/usdigitalresponse/usdr-gost/assets/14842270/9040564a-87c1-43a3-a7b1-b4e333bd9774)

## Testing
- Unit test
- End to end testing

### Automated and Unit Tests
- [x] Added Unit tests

### Manual tests for Reviewer
1. Fill out a worksheet where `Primary Place of Performance City Name` under `Awards > 5000` contains a period.
2. Upload worksheet.
3. Sees validation error that the column contains a period.

## Checklist
- [x] Provided ticket and description
- [x] Provided screenshots/demo 
- [x] Provided testing information
- [x] Provided adequate test coverage for all new code
- [x] Added PR reviewers