### PR TITLE
fix: #1268 

### DIFF
--- a/packages/server/__tests__/arpa_reporter/server/db/uploads.spec.js
+++ b/packages/server/__tests__/arpa_reporter/server/db/uploads.spec.js
@@ -1,5 +1,6 @@
 const uploads = requireSrc(__filename);
 const assert = require('assert');
+const fixtures = require('../fixtures/fixtures');
 const { withTenantId } = require('../helpers/with-tenant-id');
 const { knex } = require('../mocha_init');
 
@@ -40,6 +41,29 @@ describe('db/uploads.js', () => {
                 upload.reporting_period_id = 12345;
                 assert.rejects(async () => withTenantId(TENANT_ID, uploads.createUpload(upload)));
             });
+        });
+    });
+
+    context('usedForTreasuryExport', () => {
+        before(async () => {
+            await fixtures.seed(knex);
+        });
+
+        after(async () => {
+            await fixtures.clean(knex);
+            await knex.destroy(knex);
+        });
+
+        it('should only have two results', async () => {
+            const rows = await withTenantId(fixtures.TENANT_ID, async () => {
+                const r = await uploads.usedForTreasuryExport(fixtures.reportingPeriods.q1_2021.id);
+                return r;
+            });
+            const uploadsFiltered = Object.values(fixtures.uploads)
+                .filter((f) => f.tenant_id === fixtures.TENANT_ID)
+                .filter((f) => f.invalidated_at === null)
+                .filter((f) => f.reporting_period_id === fixtures.reportingPeriods.q1_2021.id);
+            assert.equal(rows.length, uploadsFiltered.length);
         });
     });
 });

--- a/packages/server/__tests__/arpa_reporter/server/fixtures/fixtures.js
+++ b/packages/server/__tests__/arpa_reporter/server/fixtures/fixtures.js
@@ -1,0 +1,110 @@
+const { agencies, users } = require('../../../db/seeds/fixtures');
+
+const TENANT_ID = 0;
+
+const TABLES = {
+    reporting_periods: 'reporting_periods',
+    uploads: 'uploads',
+};
+
+const reportingPeriods = {
+    q1_2021: {
+        id: 1,
+        name: 'Quarterly 1',
+        start_date: '2021-01-01',
+        end_date: '2021-03-31',
+        certified_at: null,
+        certified_by: null,
+        tenant_id: TENANT_ID,
+        template_filename: '',
+    },
+    q2_2021: {
+        id: 2,
+        name: 'Quarterly 2',
+        start_date: '2021-04-01',
+        end_date: '2021-06-30',
+        certified_at: null,
+        certified_by: null,
+        tenant_id: TENANT_ID,
+        template_filename: '',
+    },
+};
+
+const uploads = {
+    upload1: {
+        filename: 'test-filename-1.xlsm',
+        reporting_period_id: reportingPeriods.q1_2021.id,
+        user_id: users.adminUser.id,
+        agency_id: agencies.accountancy.id,
+        validated_at: '2022-01-01',
+        ec_code: '1.1',
+        tenant_id: TENANT_ID,
+        id: '00000000-0000-0000-0000-000000000000',
+        notes: null,
+    },
+    upload2: {
+        filename: 'test-filename-2.xlsm',
+        reporting_period_id: reportingPeriods.q1_2021.id,
+        user_id: users.adminUser.id,
+        agency_id: agencies.accountancy.id,
+        ec_code: '1.1',
+        tenant_id: TENANT_ID,
+        id: '00000000-0000-0000-0000-000000000001',
+        notes: null,
+    },
+    upload3: {
+        filename: 'test-filename-3.xlsm',
+        reporting_period_id: reportingPeriods.q1_2021.id,
+        user_id: users.adminUser.id,
+        agency_id: agencies.accountancy.id,
+        ec_code: '1.1',
+        tenant_id: TENANT_ID + 1,
+        id: '00000000-0000-0000-0000-000000000002',
+        notes: null,
+    },
+    upload4_invalidated: {
+        filename: 'test-filename-4.xlsm',
+        reporting_period_id: reportingPeriods.q1_2021.id,
+        user_id: users.adminUser.id,
+        agency_id: agencies.accountancy.id,
+        invalidated_at: '2023-03-02',
+        invalidated_by: users.staffUser.id,
+        ec_code: '1.1',
+        tenant_id: TENANT_ID,
+        id: '00000000-0000-0000-0000-000000000003',
+        notes: null,
+    },
+    upload5_new_quarter: {
+        filename: 'test-filename-5.xlsm',
+        reporting_period_id: reportingPeriods.q2_2021.id,
+        user_id: users.adminUser.id,
+        agency_id: agencies.accountancy.id,
+        ec_code: '1.1',
+        tenant_id: TENANT_ID,
+        id: '00000000-0000-0000-0000-000000000004',
+        notes: null,
+    },
+};
+
+module.exports = {
+    TABLES,
+    reportingPeriods,
+    uploads,
+    TENANT_ID,
+};
+
+module.exports.clean = async (knex) => {
+    await knex.raw('TRUNCATE TABLE users CASCADE');
+    await knex.raw('TRUNCATE TABLE uploads CASCADE');
+    await knex.raw('TRUNCATE TABLE reporting_periods CASCADE');
+};
+
+module.exports.seed = async (knex) => {
+    await knex.raw('TRUNCATE TABLE users CASCADE');
+    await knex.raw('TRUNCATE TABLE uploads CASCADE');
+    await knex.raw('TRUNCATE TABLE reporting_periods CASCADE');
+
+    await knex('users').insert(Object.values(users));
+    await knex('reporting_periods').insert(Object.values(reportingPeriods));
+    await knex('uploads').insert(Object.values(uploads));
+};

--- a/packages/server/__tests__/arpa_reporter/server/fixtures/fixtures.js
+++ b/packages/server/__tests__/arpa_reporter/server/fixtures/fixtures.js
@@ -36,11 +36,14 @@ const uploads = {
         reporting_period_id: reportingPeriods.q1_2021.id,
         user_id: users.adminUser.id,
         agency_id: agencies.accountancy.id,
-        validated_at: '2022-01-01',
         ec_code: '1.1',
         tenant_id: TENANT_ID,
         id: '00000000-0000-0000-0000-000000000000',
         notes: null,
+        validated_at: '2022-01-01',
+        validated_by: users.adminUser.id,
+        invalidated_at: null,
+        invalidated_by: null,
     },
     upload2: {
         filename: 'test-filename-2.xlsm',
@@ -51,6 +54,10 @@ const uploads = {
         tenant_id: TENANT_ID,
         id: '00000000-0000-0000-0000-000000000001',
         notes: null,
+        validated_at: null,
+        validated_by: null,
+        invalidated_at: null,
+        invalidated_by: null,
     },
     upload3: {
         filename: 'test-filename-3.xlsm',
@@ -61,18 +68,24 @@ const uploads = {
         tenant_id: TENANT_ID + 1,
         id: '00000000-0000-0000-0000-000000000002',
         notes: null,
+        validated_at: null,
+        validated_by: null,
+        invalidated_at: null,
+        invalidated_by: null,
     },
     upload4_invalidated: {
         filename: 'test-filename-4.xlsm',
         reporting_period_id: reportingPeriods.q1_2021.id,
         user_id: users.adminUser.id,
         agency_id: agencies.accountancy.id,
-        invalidated_at: '2023-03-02',
-        invalidated_by: users.staffUser.id,
         ec_code: '1.1',
         tenant_id: TENANT_ID,
         id: '00000000-0000-0000-0000-000000000003',
         notes: null,
+        validated_at: null,
+        validated_by: null,
+        invalidated_at: '2023-03-02',
+        invalidated_by: users.staffUser.id,
     },
     upload5_new_quarter: {
         filename: 'test-filename-5.xlsm',
@@ -83,6 +96,10 @@ const uploads = {
         tenant_id: TENANT_ID,
         id: '00000000-0000-0000-0000-000000000004',
         notes: null,
+        validated_at: null,
+        validated_by: null,
+        invalidated_at: null,
+        invalidated_by: null,
     },
 };
 
@@ -91,20 +108,14 @@ module.exports = {
     reportingPeriods,
     uploads,
     TENANT_ID,
+    users,
 };
 
 module.exports.clean = async (knex) => {
-    await knex.raw('TRUNCATE TABLE users CASCADE');
     await knex.raw('TRUNCATE TABLE uploads CASCADE');
-    await knex.raw('TRUNCATE TABLE reporting_periods CASCADE');
 };
 
 module.exports.seed = async (knex) => {
-    await knex.raw('TRUNCATE TABLE users CASCADE');
     await knex.raw('TRUNCATE TABLE uploads CASCADE');
-    await knex.raw('TRUNCATE TABLE reporting_periods CASCADE');
-
-    await knex('users').insert(Object.values(users));
-    await knex('reporting_periods').insert(Object.values(reportingPeriods));
     await knex('uploads').insert(Object.values(uploads));
 };

--- a/packages/server/__tests__/arpa_reporter/server/routes/uploads.spec.js
+++ b/packages/server/__tests__/arpa_reporter/server/routes/uploads.spec.js
@@ -1,0 +1,45 @@
+const assert = require('assert');
+const sinon = require('sinon');
+const { makeTestServer, getSessionCookie } = require('./route_test_helpers');
+const fixtures = require('../fixtures/fixtures');
+const { knex } = require('../mocha_init');
+
+describe('/api/invalidate', () => {
+    let server;
+    let tenantACookie;
+
+    before(async () => {
+        await fixtures.seed(knex);
+        server = await makeTestServer();
+        tenantACookie = await getSessionCookie('mbroussard+unit-test-admin@usdigitalresponse.org');
+    });
+    after(async () => {
+        server.stop();
+        await fixtures.clean(knex);
+    });
+
+    const sandbox = sinon.createSandbox();
+
+    afterEach(async () => {
+        sandbox.restore();
+    });
+
+    it('Ensures async audit report generation returns 200', async () => {
+        const { upload1 } = fixtures.uploads;
+
+        await server
+            .post(`/api/uploads/${upload1.id}/invalidate`)
+            .set('Cookie', tenantACookie)
+            .expect(200);
+
+        const rows = await knex('uploads')
+            .where('id', upload1.id)
+            .select('uploads.*');
+
+        const row = rows[0];
+        assert(row.invalidated_by !== null);
+        assert(row.invalidated_at !== null);
+        assert(row.validated_at !== null);
+        assert(row.validated_by !== null);
+    });
+});

--- a/packages/server/__tests__/arpa_reporter/server/services/validate-upload.spec.js
+++ b/packages/server/__tests__/arpa_reporter/server/services/validate-upload.spec.js
@@ -3,6 +3,8 @@ const assert = require('assert');
 const rewire = require('rewire');
 const sinon = require('sinon');
 const { expect } = require('chai');
+const fixtures = require('../fixtures/fixtures');
+const { knex } = require('../mocha_init');
 
 const { getRules } = require('../../../../src/arpa_reporter/services/validation-rules');
 const { EXPENDITURE_CATEGORIES } = require('../../../../src/arpa_reporter/lib/format');
@@ -410,7 +412,6 @@ describe('validateSubrecipientRecord', () => {
     });
 });
 
-/*
 describe('invalidate', () => {
     before(async () => {
         await fixtures.seed(knex);
@@ -418,19 +419,19 @@ describe('invalidate', () => {
 
     after(async () => {
         await fixtures.clean(knex);
-        //await knex.destroy(knex);
     });
 
     it('should invalidate', async () => {
-        const rows = await withTenantId(fixtures.TENANT_ID, async () => {
-            const r = await uploads.usedForTreasuryExport(fixtures.reportingPeriods.q1_2021.id);
-            return r;
-        });
-        const uploadsFiltered = Object.values(fixtures.uploads)
-            .filter((f) => f.tenant_id === fixtures.TENANT_ID)
-            .filter((f) => f.invalidated_at === null)
-            .filter((f) => f.reporting_period_id === fixtures.reportingPeriods.q1_2021.id);
-        assert.equal(rows.length, uploadsFiltered.length);
+        const { upload1 } = fixtures.uploads;
+        const user = fixtures.users.staffUser;
+        await validateUploadModule.invalidateUpload(upload1, user);
+        const rows = await knex('uploads')
+            .where('id', upload1.id)
+            .select('uploads.*');
+        const row = rows[0];
+        assert.equal(row.invalidated_by, user.id);
+        assert(row.invalidated_at !== null);
+        assert(row.validated_at !== null);
+        assert(row.validated_by !== null);
     });
 });
-*/

--- a/packages/server/__tests__/arpa_reporter/server/services/validate-upload.spec.js
+++ b/packages/server/__tests__/arpa_reporter/server/services/validate-upload.spec.js
@@ -409,3 +409,28 @@ describe('validateSubrecipientRecord', () => {
         sinon.assert.notCalled(updateRecipientStub);
     });
 });
+
+/*
+describe('invalidate', () => {
+    before(async () => {
+        await fixtures.seed(knex);
+    });
+
+    after(async () => {
+        await fixtures.clean(knex);
+        //await knex.destroy(knex);
+    });
+
+    it('should invalidate', async () => {
+        const rows = await withTenantId(fixtures.TENANT_ID, async () => {
+            const r = await uploads.usedForTreasuryExport(fixtures.reportingPeriods.q1_2021.id);
+            return r;
+        });
+        const uploadsFiltered = Object.values(fixtures.uploads)
+            .filter((f) => f.tenant_id === fixtures.TENANT_ID)
+            .filter((f) => f.invalidated_at === null)
+            .filter((f) => f.reporting_period_id === fixtures.reportingPeriods.q1_2021.id);
+        assert.equal(rows.length, uploadsFiltered.length);
+    });
+});
+*/

--- a/packages/server/migrations/20230619215513_add_exclude_for_uploads.js
+++ b/packages/server/migrations/20230619215513_add_exclude_for_uploads.js
@@ -1,0 +1,24 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function (knex) {
+    return knex.schema
+        .alterTable('uploads', (table) => {
+            table.timestamp('invalidated_at');
+            table.integer('invalidated_by');
+            table.foreign('invalidated_by').references('users.id').onDelete('SET NULL');
+        });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function (knex) {
+    return knex.schema
+        .alterTable('uploads', (table) => {
+            table.dropColumn('invalidated_at');
+            table.dropColumn('invalidated_by');
+        });
+};

--- a/packages/server/src/arpa_reporter/db/uploads.js
+++ b/packages/server/src/arpa_reporter/db/uploads.js
@@ -54,11 +54,13 @@ function usedForTreasuryExport(periodId, trns = knex) {
             'SELECT agency_id, ec_code, reporting_period_id, MAX(created_at) AS most_recent '
       + 'FROM uploads WHERE validated_at IS NOT NULL '
       + 'AND tenant_id = :tenantId '
+      + 'AND invalidated_at IS NULL '
       + 'GROUP BY agency_id, ec_code, reporting_period_id',
             { tenantId },
         ))
         .where('uploads.reporting_period_id', periodId)
         .where('uploads.tenant_id', tenantId)
+        .where('uploads.invalidated_at', null)
         .innerJoin('agency_max_val', function () {
             this.on('uploads.created_at', '=', 'agency_max_val.most_recent')
                 .andOn('uploads.agency_id', '=', 'agency_max_val.agency_id')
@@ -134,6 +136,8 @@ async function markValidated(uploadId, userId, trns = knex) {
         .update({
             validated_at: trns.fn.now(),
             validated_by: userId,
+            invalidated_at: null,
+            invalidated_by: null,
         })
         .returning('*')
         .then((rows) => rows[0]);
@@ -145,6 +149,19 @@ async function markNotValidated(uploadId, trns = knex) {
         .update({
             validated_at: null,
             validated_by: null,
+            invalidated_at: null,
+            invalidated_by: null,
+        })
+        .returning('*')
+        .then((rows) => rows[0]);
+}
+
+async function markInvalidated(uploadId, userId, trns = knex) {
+    return trns('uploads')
+        .where('id', uploadId)
+        .update({
+            invalidated_at: trns.fn.now(),
+            invalidated_by: userId,
         })
         .returning('*')
         .then((rows) => rows[0]);
@@ -161,6 +178,7 @@ module.exports = {
     setEcCode,
     markValidated,
     markNotValidated,
+    markInvalidated,
     usedForTreasuryExport,
 };
 

--- a/packages/server/src/arpa_reporter/services/validate-upload.js
+++ b/packages/server/src/arpa_reporter/services/validate-upload.js
@@ -1,5 +1,5 @@
 const {
-    setEcCode, markValidated, markNotValidated,
+    setEcCode, markValidated, markNotValidated, markInvalidated,
 } = require('../db/uploads');
 const knex = require('../../db/connection');
 const { createRecipient, findRecipient, updateRecipient } = require('../db/arpa-subrecipients');
@@ -654,8 +654,36 @@ async function validateUpload(upload, user, trns = null) {
     return flatErrors;
 }
 
+async function invalidateUpload(upload, user, trns = null) {
+    const errors = [];
+
+    const ourTransaction = !trns;
+    if (ourTransaction) {
+        trns = await knex.transaction();
+    }
+
+    // if we successfully validated for the first time, let's mark it!
+    try {
+        await markInvalidated(upload.id, user.id);
+    } catch (e) {
+        errors.push(new ValidationError(`failed to mark upload: ${e.message}`));
+    }
+
+    // depending on whether we validated or not, lets commit/rollback. we MUST do
+    // this or bad things happen. this is why there are try/catch blocks around
+    // every other function call above here
+    if (ourTransaction) {
+        await trns.commit();
+        trns = knex;
+    }
+
+    // finally, return our errors
+    return errors;
+}
+
 module.exports = {
     validateUpload,
+    invalidateUpload,
 };
 
 // NOTE: This file was copied from src/server/services/validate-upload.js (git @ ada8bfdc98) in the arpa-reporter repo on 2022-09-23T20:05:47.735Z


### PR DESCRIPTION
### Ticket #1268 
## Description
This is only the backend piece. This PR adds an invalidated_at and invalidated_by to the uploads table. These can then be excluded by various reporting, such as the audit report.

## Screenshots / Demo Video

## Testing
This is just the backend portion, but can be tested by manually setting the `invalidated_at` and `invalidated_by` column and running the audit report.

### Automated and Unit Tests
- [x] Added Unit tests - Partially done

### Manual tests for Reviewer
- [x] Added steps to test feature/functionality manually

## Checklist
- [x] Provided ticket and description
- [ ] Provided screenshots/demo
- [x] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [x] Added PR reviewers