### PR TITLE
Treasury Exports - Implements async report generation

### DIFF
--- a/packages/client/src/arpa_reporter/views/Home.vue
+++ b/packages/client/src/arpa_reporter/views/Home.vue
@@ -8,6 +8,13 @@
         <DownloadButton :href="downloadTreasuryReportURL()" class="btn btn-primary btn-block">Download Treasury Report</DownloadButton>
       </div>
 
+      <div class="col" v-if="this.$route.query.async_treasury_download && isAdmin">
+        <button class="btn btn-primary btn-block" @click="sendTreasuryReport" :disabled="sending">
+          <span v-if="sending">Sending...</span>
+          <span v-else>Send Treasury Report by Email</span>
+        </button>
+      </div>
+
       <div class="col" v-if="this.$route.query.sync_audit_download && isAdmin">
         <DownloadButton :href="downloadAuditReportURL()" class="btn btn-info btn-block">Download Audit Report</DownloadButton>
       </div>
@@ -128,6 +135,34 @@ export default {
     downloadTreasuryReportURL() {
       const periodId = this.$store.getters.viewPeriod.id || 0;
       return apiURL(`/api/exports?period_id=${periodId}`);
+    },
+    async sendTreasuryReport() {
+      this.sending = true;
+
+      try {
+        const result = await getJson('/api/exports?async=true');
+
+        if (result.error) {
+          this.alert = {
+            text: 'Something went wrong. Unable to send an email containing the treasury report. Reach out to grants-helpdesk@usdigitalresponse.org if this happens again.',
+            level: 'err',
+          };
+          console.log(result.error);
+        } else {
+          this.alert = {
+            text: 'Sent. Please note, it could take up to 1 hour for this email to arrive.',
+            level: 'ok',
+          };
+        }
+      } catch (error) {
+        // we got an error from the backend, but the backend didn't send reasons
+        this.alert = {
+          text: 'Something went wrong. Unable to send an email containing the treasury report. Reach out to grants-helpdesk@usdigitalresponse.org if this happens again.',
+          level: 'err',
+        };
+      }
+
+      this.sending = false;
     },
     startUpload() {
       if (this.viewingOpenPeriod) {

--- a/packages/server/__tests__/arpa_reporter/server/lib/audit-report.spec.js
+++ b/packages/server/__tests__/arpa_reporter/server/lib/audit-report.spec.js
@@ -31,9 +31,9 @@ describe('audit report generation', () => {
         await audit_report.sendEmailWithLink('1/99/example.xlsx', 'foo@example.com');
 
         expect(sendFake.calledOnce).to.equal(true);
-        expect(sendFake.firstCall.firstArg).to.equal('foo@example.com');
-        expect(sendFake.firstCall.secondArg).to.equal(`${process.env.API_DOMAIN}/api/audit_report/1/99/example.xlsx`);
-        expect(sendFake.firstCall.lastArg).to.equal('audit');
+        expect(sendFake.firstCall.args[0]).to.equal('foo@example.com');
+        expect(sendFake.firstCall.args[1]).to.equal(`${process.env.API_DOMAIN}/api/audit_report/1/99/example.xlsx`);
+        expect(sendFake.firstCall.args[2]).to.equal('audit');
     });
     it('generateAndSendEmail generates a report, uploads to s3, and sends an email', async () => {
         const sendFake = sandbox.fake.returns('foo');

--- a/packages/server/__tests__/arpa_reporter/server/lib/audit-report.spec.js
+++ b/packages/server/__tests__/arpa_reporter/server/lib/audit-report.spec.js
@@ -26,17 +26,18 @@ describe('audit report generation', () => {
     });
     it('sendEmailWithLink creates a presigned url and sends email to recipient', async () => {
         const sendFake = sandbox.fake.returns('foo');
-        sandbox.replace(email, 'sendAuditReportEmail', sendFake);
+        sandbox.replace(email, 'sendAsyncReportEmail', sendFake);
 
         await audit_report.sendEmailWithLink('1/99/example.xlsx', 'foo@example.com');
 
         expect(sendFake.calledOnce).to.equal(true);
         expect(sendFake.firstCall.firstArg).to.equal('foo@example.com');
-        expect(sendFake.firstCall.lastArg).to.equal(`${process.env.API_DOMAIN}/api/audit_report/1/99/example.xlsx`);
+        expect(sendFake.firstCall.secondArg).to.equal(`${process.env.API_DOMAIN}/api/audit_report/1/99/example.xlsx`);
+        expect(sendFake.firstCall.lastArg).to.equal('audit');
     });
     it('generateAndSendEmail generates a report, uploads to s3, and sends an email', async () => {
         const sendFake = sandbox.fake.returns('foo');
-        sandbox.replace(email, 'sendAuditReportEmail', sendFake);
+        sandbox.replace(email, 'sendAsyncReportEmail', sendFake);
 
         const sendEmailFake = sandbox.fake.returns('foo2');
         sandbox.replace(audit_report, 'sendEmailWithLink', sendEmailFake);
@@ -75,7 +76,7 @@ describe('audit report generation', () => {
     });
     it('generateAndSendEmail does not send an email if upload fails', async () => {
         const sendFake = sandbox.fake.returns('foo');
-        sandbox.replace(email, 'sendAuditReportEmail', sendFake);
+        sandbox.replace(email, 'sendAsyncReportEmail', sendFake);
 
         const sendEmailFake = sandbox.fake.returns('foo2');
         sandbox.replace(audit_report, 'sendEmailWithLink', sendEmailFake);

--- a/packages/server/__tests__/arpa_reporter/server/routes/exports.spec.js
+++ b/packages/server/__tests__/arpa_reporter/server/routes/exports.spec.js
@@ -1,4 +1,25 @@
+const { expect } = require('chai');
+const sinon = require('sinon');
+
 const { makeTestServer, getSessionCookie } = require('./route_test_helpers');
+const arpa = require('../../../../src/arpa_reporter/services/generate-arpa-report');
+const aws = require('../../../../src/lib/gost-aws');
+
+function headObjectFake(type, callback) {
+    if (type === 'error') {
+        return () => { throw new Error('issue with finding s3 object'); };
+    }
+
+    return callback;
+}
+
+function signedUrlFake(type) {
+    if (type === 'error') {
+        return () => { throw new Error('issue with generating signed URL'); };
+    }
+
+    return () => 'http://s3.amazonaws.com/sample.xlsx';
+}
 
 describe('/api/exports', () => {
     let server;
@@ -11,6 +32,12 @@ describe('/api/exports', () => {
     });
     after(() => {
         server.stop();
+    });
+
+    const sandbox = sinon.createSandbox();
+
+    afterEach(async () => {
+        sandbox.restore();
     });
 
     it('returns a response for default period id', async () => {
@@ -47,6 +74,98 @@ describe('/api/exports', () => {
             .set('Cookie', tenantBCookie)
             .expect(200)
             .expect('Content-Disposition', /attachment; filename="California/);
+    });
+
+    it('Ensures async treasury report generation returns 200', async () => {
+        arpa.generateAndSendEmail = () => 'success';
+
+        await server
+            .get('/api/exports?async=true')
+            .set('Cookie', tenantACookie)
+            .expect(200);
+    });
+    it('Ensures async treasury report generation returns an error property when there is an issue', async () => {
+        arpa.generateAndSendEmail = () => {
+            throw new Error('Some error message');
+        };
+
+        const response = await server
+            .get('/api/exports?async=true')
+            .set('Cookie', tenantACookie);
+
+        expect(response.status).to.equal(500);
+        expect(response._body.error).to.equal('Unable to generate treasury report and send email.');
+    });
+    it('Signed URL - redirects for unauthorized users', async () => {
+        const response = await server
+            .get('/api/exports/0/99/example.xlsx');
+
+        expect(response.status).to.equal(302);
+        expect(response.headers.location).to.equal('http://localhost:8080/arpa_reporter/login?redirect_to=/api/exports/0/99/example.xlsx&message=Please%20login%20to%20visit%20the%20link.');
+    });
+    it('Signed URL - redirects when object is not found', async () => {
+        const s3InstanceFake = sandbox.fake.returns('just s3');
+        const headObject = sandbox.fake.returns('h object');
+        headObjectFake.promise = sandbox.fake.returns('promise');
+        s3InstanceFake.headObject = sandbox.fake(headObjectFake('error', headObject));
+        const s3Fake = sandbox.fake.returns(s3InstanceFake);
+        sandbox.replace(aws, 'getS3Client', s3Fake);
+
+        const response = await server
+            .get('/api/exports/0/99/example.xlsx')
+            .set('Cookie', tenantACookie);
+
+        expect(response.status).to.equal(302);
+        expect(response.headers.location).to.equal(`http://localhost:8080/arpa_reporter?alert_text=The%20treasury%20report%20you%20requested%20has%20expired.%20Please%20try%20again%20by%20clicking%20the%20'Send%20Treasury%20Report%20By%20Email'.&alert_level=err`);
+    });
+    it('Signed URL - redirects to login page when user is accessing wrong tenant', async () => {
+        const s3InstanceFake = sandbox.fake.returns('just s3');
+        const headObject = sandbox.fake.returns('h object');
+        headObjectFake.promise = sandbox.fake.returns('promise');
+        s3InstanceFake.headObject = sandbox.fake(headObjectFake('error', headObject));
+        const s3Fake = sandbox.fake.returns(s3InstanceFake);
+        sandbox.replace(aws, 'getS3Client', s3Fake);
+
+        const response = await server
+            .get('/api/exports/1/99/example.xlsx')
+            .set('Cookie', tenantACookie);
+
+        expect(response.status).to.equal(302);
+        expect(response.headers.location).to.equal(`http://localhost:8080/arpa_reporter/login?redirect_to=/api/exports/1/99/example.xlsx&message=Please%20login%20to%20visit%20the%20link.`);
+    });
+    it('Signed URL - returns redirect with message when there is an issue generating URL', async () => {
+        const s3InstanceFake = sandbox.fake.returns('just s3');
+        const objReturnFake = sandbox.fake.returns('some_return');
+        objReturnFake.promise = sandbox.fake.returns('promise return');
+        const headObject = sandbox.fake.returns(objReturnFake);
+        s3InstanceFake.send = sandbox.fake(headObjectFake('success', headObject));
+        sandbox.replace(aws, 'getSignedUrl', sandbox.fake(signedUrlFake('error')));
+        const s3Fake = sandbox.fake.returns(s3InstanceFake);
+        sandbox.replace(aws, 'getS3Client', s3Fake);
+
+        const response = await server
+            .get('/api/exports/0/99/example.xlsx')
+            .set('Cookie', tenantACookie);
+
+        expect(response.status).to.equal(302);
+        expect(response.headers.location).to.equal(`http://localhost:8080/arpa_reporter?alert_text=Something%20went%20wrong.%20Please%20reach%20out%20to%20grants-helpdesk@usdigitalresponse.org.&alert_level=err`);
+    });
+    it('Signed URL - Success response', async () => {
+        const s3InstanceFake = sandbox.fake.returns('just s3');
+        const objReturnFake = sandbox.fake.returns('some_return');
+        objReturnFake.promise = sandbox.fake.returns('promise return');
+        const headObject = sandbox.fake.returns(objReturnFake);
+        s3InstanceFake.send = sandbox.fake(headObjectFake('success', headObject));
+        sandbox.replace(aws, 'getSignedUrl', sandbox.fake(signedUrlFake('success')));
+        const s3Fake = sandbox.fake.returns(s3InstanceFake);
+        sandbox.replace(aws, 'getS3Client', s3Fake);
+
+        const response = await server
+            .get('/api/exports/0/99/example.xlsx')
+            .set('Cookie', tenantACookie);
+
+        expect(response.status).to.equal(302);
+        expect(response.headers.location).to.equal(`http://s3.amazonaws.com/sample.xlsx`);
     });
 });
 

--- a/packages/server/__tests__/email/email.test.js
+++ b/packages/server/__tests__/email/email.test.js
@@ -249,15 +249,26 @@ describe('Email sender', () => {
             expect(sendFake.secondCall.args[0].subject).to.equal('Grant Assigned to State Board of Accountancy');
         });
     });
-    context('audit report email', () => {
-        it('sendAuditReportEmail delivers an email with the signedURL', async () => {
+    context('async report email', () => {
+        it('sendAsyncReportEmail delivers an email with the signedURL for audit report', async () => {
             const sendFake = sinon.fake.returns('foo');
             sinon.replace(email, 'deliverEmail', sendFake);
 
-            await email.sendAuditReportEmail('foo@example.com', 'https://example.usdigitalresponse.org');
+            await email.sendAsyncReportEmail('foo@example.com', 'https://example.usdigitalresponse.org', email.ASYNC_REPORT_TYPES.audit);
             expect(sendFake.calledOnce).to.equal(true);
             expect(sendFake.firstCall.firstArg.subject).to.equal('Your audit report is ready for download');
             expect(sendFake.firstCall.firstArg.emailPlain).to.equal('Your audit report is ready for download. Paste this link into your browser to download it: https://example.usdigitalresponse.org This link will remain active for 7 days.');
+            expect(sendFake.firstCall.firstArg.toAddress).to.equal('foo@example.com');
+            expect(sendFake.firstCall.firstArg.emailHTML).contains('https://example.usdigitalresponse.org');
+        });
+        it('sendAsyncReportEmail delivers an email with the signedURL for treasury report', async () => {
+            const sendFake = sinon.fake.returns('foo');
+            sinon.replace(email, 'deliverEmail', sendFake);
+
+            await email.sendAsyncReportEmail('foo@example.com', 'https://example.usdigitalresponse.org', email.ASYNC_REPORT_TYPES.treasury);
+            expect(sendFake.calledOnce).to.equal(true);
+            expect(sendFake.firstCall.firstArg.subject).to.equal('Your treasury report is ready for download');
+            expect(sendFake.firstCall.firstArg.emailPlain).to.equal('Your treasury report is ready for download. Paste this link into your browser to download it: https://example.usdigitalresponse.org This link will remain active for 7 days.');
             expect(sendFake.firstCall.firstArg.toAddress).to.equal('foo@example.com');
             expect(sendFake.firstCall.firstArg.emailHTML).contains('https://example.usdigitalresponse.org');
         });

--- a/packages/server/src/arpa_reporter/db/settings.js
+++ b/packages/server/src/arpa_reporter/db/settings.js
@@ -20,8 +20,8 @@ async function getCurrentReportingPeriodID(trns = knex) {
         .then((r) => r[0].current_reporting_period_id);
 }
 
-async function applicationSettings(trns = knex) {
-    const tenantId = useTenantId();
+async function applicationSettings(tenantId = undefined, trns = knex) {
+    tenantId = tenantId || useTenantId();
 
     return trns('application_settings')
         .join(

--- a/packages/server/src/arpa_reporter/db/uploads.js
+++ b/packages/server/src/arpa_reporter/db/uploads.js
@@ -45,8 +45,8 @@ function getUpload(id, trns = knex) {
         .then((r) => r[0]);
 }
 
-function usedForTreasuryExport(periodId, trns = knex) {
-    const tenantId = useTenantId();
+function usedForTreasuryExport(periodId, tenantId = undefined, trns = knex) {
+    tenantId = tenantId || useTenantId();
     requiredArgument(periodId, 'periodId must be specified in validForReportingPeriod');
 
     return baseQuery(trns)

--- a/packages/server/src/arpa_reporter/lib/audit-report.js
+++ b/packages/server/src/arpa_reporter/lib/audit-report.js
@@ -166,7 +166,7 @@ async function generate(requestHost) {
 
 async function sendEmailWithLink(fileKey, recipientEmail) {
     const url = `${process.env.API_DOMAIN}/api/audit_report/${fileKey}`;
-    email.sendAuditReportEmail(recipientEmail, url);
+    email.sendAsyncReportEmail(recipientEmail, url, email.ASYNC_REPORT_TYPES.audit);
 }
 
 async function generateAndSendEmail(requestHost, recipientEmail) {

--- a/packages/server/src/arpa_reporter/routes/exports.js
+++ b/packages/server/src/arpa_reporter/routes/exports.js
@@ -1,12 +1,50 @@
 const express = require('express');
 
 const router = express.Router();
+const { HeadObjectCommand, GetObjectCommand } = require('@aws-sdk/client-s3');
 const _ = require('lodash');
 
-const { requireUser } = require('../../lib/access-helpers');
+const aws = require('../../lib/gost-aws');
+const { requireUser, getAdminAuthInfo } = require('../../lib/access-helpers');
 const arpa = require('../services/generate-arpa-report');
 const { getReportingPeriodID, getReportingPeriod } = require('../db/reporting-periods');
-const { useTenantId } = require('../use-request');
+const { useTenantId, useUser } = require('../use-request');
+
+router.get('/:tenantId/:periodId/:filename', async (req, res) => {
+    let user;
+    try {
+        const info = await getAdminAuthInfo(req);
+        user = info.user;
+        if (user.tenant_id !== Number(req.params.tenantId)) {
+            throw new Error('Unauthorized');
+        }
+    } catch (error) {
+        res.redirect(encodeURI(`${process.env.WEBSITE_DOMAIN}/arpa_reporter/login?redirect_to=/api/exports/${req.params.tenantId}/${req.params.periodId}/${req.params.filename}&message=Please login to visit the link.`));
+        return;
+    }
+
+    const s3 = aws.getS3Client();
+    const Key = `${user.tenant_id}/${req.params.periodId}/${req.params.filename}`;
+    const baseParams = { Bucket: process.env.AUDIT_REPORT_BUCKET, Key };
+
+    try {
+        await s3.send(new HeadObjectCommand(baseParams));
+    } catch (error) {
+        console.log(error);
+        res.redirect(encodeURI(`${process.env.WEBSITE_DOMAIN}/arpa_reporter?alert_text=The treasury report you requested has expired. Please try again by clicking the 'Send Treasury Report By Email'.&alert_level=err`));
+        return;
+    }
+
+    let signedUrl;
+    try {
+        signedUrl = await aws.getSignedUrl(s3, new GetObjectCommand(baseParams), { expiresIn: 60 });
+    } catch (error) {
+        console.log(error);
+        res.redirect(`${process.env.WEBSITE_DOMAIN}/arpa_reporter?alert_text=Something went wrong. Please reach out to grants-helpdesk@usdigitalresponse.org.&alert_level=err`);
+        return;
+    }
+    res.redirect(signedUrl);
+});
 
 router.get('/', requireUser, async (req, res) => {
     const periodId = await getReportingPeriodID(req.query.period_id);
@@ -15,8 +53,24 @@ router.get('/', requireUser, async (req, res) => {
         res.status(404).json({ error: 'invalid reporting period' });
         return;
     }
-
     const tenantId = useTenantId();
+
+    if (req.query.async) {
+        // Special handling for async treasury report generation and sending.
+        console.log('/api/exports?async=true GET');
+        console.log('Generating Async treasury report');
+        try {
+            const user = useUser();
+            arpa.generateAndSendEmail(user.email, periodId, tenantId);
+            res.json({ success: true });
+            return;
+        } catch (error) {
+            console.log(`Failed to generate and send treasury report ${error}`);
+            res.status(500).json({ error: 'Unable to generate treasury report and send email.' });
+            return;
+        }
+    }
+
     const report = await arpa.generateReport(periodId, tenantId);
 
     if (_.isError(report)) {

--- a/packages/server/src/arpa_reporter/routes/exports.js
+++ b/packages/server/src/arpa_reporter/routes/exports.js
@@ -6,6 +6,7 @@ const _ = require('lodash');
 const { requireUser } = require('../../lib/access-helpers');
 const arpa = require('../services/generate-arpa-report');
 const { getReportingPeriodID, getReportingPeriod } = require('../db/reporting-periods');
+const { useTenantId } = require('../use-request');
 
 router.get('/', requireUser, async (req, res) => {
     const periodId = await getReportingPeriodID(req.query.period_id);
@@ -15,7 +16,8 @@ router.get('/', requireUser, async (req, res) => {
         return;
     }
 
-    const report = await arpa.generateReport(periodId);
+    const tenantId = useTenantId();
+    const report = await arpa.generateReport(periodId, tenantId);
 
     if (_.isError(report)) {
         res.status(500).send(report.message);

--- a/packages/server/src/arpa_reporter/services/generate-arpa-report.js
+++ b/packages/server/src/arpa_reporter/services/generate-arpa-report.js
@@ -18,6 +18,7 @@ const {
     zip4,
 } = require('../lib/format');
 const { requiredArgument } = require('../lib/preconditions');
+const { useTenantId } = require('../use-request');
 
 const BOM = '\ufeff'; // UTF-8 byte order mark
 const EC_CODE_REGEX = /^(\d.\d\d?)/;
@@ -940,7 +941,7 @@ async function setCSVData(data) {
 }
 
 async function generateReport(periodId, tenantId) {
-    requiredArgument(tenantId, 'must specify tenantId');
+    tenantId = tenantId || useTenantId();
     requiredArgument(periodId, 'must specify periodId');
     const records = await recordsForReportingPeriod(periodId, tenantId);
 

--- a/packages/server/src/arpa_reporter/services/generate-arpa-report.js
+++ b/packages/server/src/arpa_reporter/services/generate-arpa-report.js
@@ -918,7 +918,6 @@ async function setCSVData(data) {
 
     if (!Array.isArray(csvData)) {
         console.dir({ name, func });
-        console.dir(csvData);
         throw new Error(`CSV Data from ${name} was not an array!`);
     }
 

--- a/packages/server/src/arpa_reporter/services/records.js
+++ b/packages/server/src/arpa_reporter/services/records.js
@@ -188,11 +188,11 @@ async function recordsForUpload(upload) {
     return recordPromise;
 }
 
-async function recordsForReportingPeriod(periodId) {
+async function recordsForReportingPeriod(periodId, tenantId = undefined) {
     log(`recordsForReportingPeriod(${periodId})`);
     requiredArgument(periodId, 'must specify periodId in recordsForReportingPeriod');
 
-    const uploads = await usedForTreasuryExport(periodId);
+    const uploads = await usedForTreasuryExport(periodId, tenantId);
     const groupedRecords = await asyncBatch(uploads, recordsForUpload, 2);
     return groupedRecords.flat();
 }

--- a/packages/server/src/lib/email.js
+++ b/packages/server/src/lib/email.js
@@ -10,6 +10,10 @@ const db = require('../db');
 const { notificationType } = require('./email/constants');
 
 const expiryMinutes = 30;
+const ASYNC_REPORT_TYPES = {
+    audit: 'audit',
+    treasury: 'treasury',
+};
 
 async function deliverEmail({
     toAddress,
@@ -270,11 +274,11 @@ async function buildAndSendGrantDigest() {
     console.log(`Successfully built and sent grants digest emails for ${openDate}`);
 }
 
-async function sendAuditReportEmail(recipient, signedUrl) {
+async function sendAsyncReportEmail(recipient, signedUrl, reportType) {
     const formattedBodyTemplate = fileSystem.readFileSync(path.join(__dirname, '../static/email_templates/_formatted_body.html'));
 
     const formattedBody = mustache.render(formattedBodyTemplate.toString(), {
-        body_title: 'Your audit report is ready for download',
+        body_title: `Your ${reportType} report is ready for download`,
         body_detail: `<p><a href=${signedUrl}><b>Click here</b></a> to download your file<br>Or, paste this link into your browser:<br><b>${signedUrl}</b><br><br>This link will remain active for 7 days.</p>`,
     });
 
@@ -282,15 +286,15 @@ async function sendAuditReportEmail(recipient, signedUrl) {
         formattedBody,
         {
             tool_name: 'Grants Reporter Tool',
-            title: 'Your audit report is ready for download',
+            title: `Your ${reportType} report is ready for download`,
         },
     );
 
     return module.exports.deliverEmail({
         toAddress: recipient,
         emailHTML,
-        emailPlain: `Your audit report is ready for download. Paste this link into your browser to download it: ${signedUrl} This link will remain active for 7 days.`,
-        subject: 'Your audit report is ready for download',
+        emailPlain: `Your ${reportType} report is ready for download. Paste this link into your browser to download it: ${signedUrl} This link will remain active for 7 days.`,
+        subject: `Your ${reportType} report is ready for download`,
     });
 }
 
@@ -306,5 +310,6 @@ module.exports = {
     getGrantDetail,
     addBaseBranding,
     buildDigestBody,
-    sendAuditReportEmail,
+    sendAsyncReportEmail,
+    ASYNC_REPORT_TYPES,
 };


### PR DESCRIPTION
### Ticket #1580 
## Description
This PR does the following:
1. Makes treasury report generation async and sends the user a signed S3 URL via email. Note: this is behind a query-parameter feature flag for the time being.
2. Ensures that treasury report generation does not depend on having an express js request/response context. It can be called independently by passing in the needed `tenantId` or `periodId` via CloudShell or other services.
3. Ensures that we are not passing in an unlimited number promises to be executed simultaneously. Currently starting with a limit of 2.

## Screenshots / Demo Video
https://www.loom.com/share/ff1d5449c53a4545b1295e06229a5bbc

### Before
![image](https://github.com/usdigitalresponse/usdr-gost/assets/6497366/21b052ce-45ed-45df-a1d4-c1b35c30f23d)

### After
![image](https://github.com/usdigitalresponse/usdr-gost/assets/6497366/efd68a0c-3a46-46fb-8781-baf1638c47ba)

## Testing

### Automated and Unit Tests
- [x] Added Unit tests

### Manual tests for Reviewer
- [x] Added steps to test feature/functionality manually

- Go to http://localhost:8080/arpa_reports?async_treasury_report=true
- Hit the "Send Treasury Report By Email" button
- Navigate to your local SES temp storage and identify the latest sent message json
- Navigate to the URL in the email that begins with http://localhost:3000/api/exports....
- Confirm that you get redirected to a signed localstack URL and the file downloads.

## Checklist
- [x] Provided ticket and description
- [x] Provided screenshots/demo
- [x] Provided testing information
- [x] Provided adequate test coverage for all new code
- [x] Added PR reviewers