### PR TITLE
Revert "chore(deps): bump cloudposse/waf/aws from 0.3.0 to 0.4.0 in /terraform/modules/gost_website"

### DIFF
--- a/terraform/modules/gost_website/waf.tf
+++ b/terraform/modules/gost_website/waf.tf
@@ -18,7 +18,7 @@ locals {
 
 module "waf" {
   source         = "cloudposse/waf/aws"
-  version        = "0.4.0"
+  version        = "0.3.0"
   scope          = "CLOUDFRONT"
   default_action = "allow"
 


### PR DESCRIPTION
Reverts usdigitalresponse/usdr-gost#1613

See [this comment](https://github.com/usdigitalresponse/usdr-gost/pull/1613#issuecomment-1632924004) on the above issue, and [this bug report](https://github.com/cloudposse/terraform-aws-waf/issues/46) filed in the source repository for `cloudposse/waf/aws`.