### PR TITLE
Fix: org.opencontainers.image.version docker label

### DIFF
--- a/.github/workflows/build-api.yml
+++ b/.github/workflows/build-api.yml
@@ -32,6 +32,8 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set date/time-based version string as env var
+        run: echo "DATETIME_VERSION=$(TZ=UTC date +'%Y%m%d.%H%M')" >> $GITHUB_ENV
       - name: Extract metadata for Docker
         id: meta
         uses: docker/metadata-action@v4
@@ -39,12 +41,12 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=sha,enable=true,priority=100,prefix=,suffix=,format=short
-            type=raw,enable=true,priority=200,prefix=,suffix=,value={{date 'YYYYMMDD.HHmm'}}
+            type=raw,enable=true,priority=200,prefix=,suffix=,value=${{ env.DATETIME_VERSION }}
             type=raw,enable=${{ github.event_name != 'pull_request' }},priority=300,value=latest
             type=raw,enable=${{ github.ref == 'refs/heads/main' }},priority=300,value=stable
           labels: |
             org.opencontainers.image.title=${{ env.IMAGE_NAME }}
-            org.opencontainers.image.version=${{date 'YYYYMMDD.HHmm'}}
+            org.opencontainers.image.version=${{ env.DATETIME_VERSION }}
             com.datadoghq.tags.service=gost
             com.datadoghq.tags.version=${{ github.sha }}
       - name: Build and push Docker image

--- a/.github/workflows/build-api.yml
+++ b/.github/workflows/build-api.yml
@@ -44,7 +44,7 @@ jobs:
             type=raw,enable=${{ github.ref == 'refs/heads/main' }},priority=300,value=stable
           labels: |
             org.opencontainers.image.title=${{ env.IMAGE_NAME }}
-            org.opencontainers.image.version={{date 'YYYYMMDD.HHmm'}}
+            org.opencontainers.image.version=${{date 'YYYYMMDD.HHmm'}}
             com.datadoghq.tags.service=gost
             com.datadoghq.tags.version=${{ github.sha }}
       - name: Build and push Docker image


### PR DESCRIPTION
## Description

This PR fixes an issue with the interpolation syntax in the `Build Docker image for GOST API` GitHub actions workflow. Instead of the `org.opencontainers.image.version` docker label being set to an identifier based on the build date/time, images are being built with the label set to a literal value of `"{{date 'YYYYMMDD.HHmm'}}"`.

As an discrete example, running `docker inspect` against the [current image tagged with `latest`](https://github.com/usdigitalresponse/usdr-gost/pkgs/container/usdr-gost-api/109462027?tag=latest) produces the following output (the last line in the JSON output is the important part):
```cli
$ docker inspect ghcr.io/usdigitalresponse/usdr-gost-api:latest|jq '.[0].Config.Labels'
{
  "com.datadoghq.tags.service": "gost",
  "com.datadoghq.tags.version": "a343670373c2a13d9e289a3c5760c55603ef74c4",
  "org.opencontainers.image.created": "2023-07-13T22:11:01.847Z",
  "org.opencontainers.image.description": "USDR-hosted grants management tools",
  "org.opencontainers.image.licenses": "Apache-2.0",
  "org.opencontainers.image.revision": "a343670373c2a13d9e289a3c5760c55603ef74c4",
  "org.opencontainers.image.source": "https://github.com/usdigitalresponse/usdr-gost",
  "org.opencontainers.image.title": "usdigitalresponse/usdr-gost-api",
  "org.opencontainers.image.url": "https://github.com/usdigitalresponse/usdr-gost",
  "org.opencontainers.image.version": "{{date 'YYYYMMDD.HHmm'}}"
}
```

~The problem appears to be caused by a simple interpolation issue in the workflow YAML syntax, which this PR corrects.~ Edit: The first commit to this PR didn't ultimately solve the problem. The second go-around successfully fixed the issue by using a dynamic environment variable instead of the [`{{date}}` global expression](https://github.com/docker/metadata-action#date-format-tztimezone) provided by the [docker/metadata-action](https://github.com/docker/metadata-action) action, which appears to only work when used as a tag interpolation.

## Testing

Not much to do here without actually running the workflow (or using a tool like [act](https://github.com/nektos/act)), but the expected behavior can be verified by inspecting the output from the `Extract metadata for Docker` step of the `Build Docker image for GOST API` workflow that will execute during the CI run for this PR. 

~I'll update here once this is available.~ **Update:** Here's the partial output from the [most recent execution](https://github.com/usdigitalresponse/usdr-gost/actions/runs/5548914012/jobs/10132400647?pr=1645#step:7:82) of the relevant step, which now contains the expected value for the `org.opencontainers.image.version` label:
```
JSON output
  {
    "tags": [
      "ghcr.io/usdigitalresponse/usdr-gost-api:20230713.2339",
      "ghcr.io/usdigitalresponse/usdr-gost-api:0739923"
    ],
    "labels": {
      "com.datadoghq.tags.service": "gost",
      "com.datadoghq.tags.version": "07399231f6238df5007474290101e89e4a58c4a0",
      "org.opencontainers.image.created": "2023-07-13T23:39:49.507Z",
      "org.opencontainers.image.description": "USDR-hosted grants management tools",
      "org.opencontainers.image.licenses": "Apache-2.0",
      "org.opencontainers.image.revision": "07399231f6238df5007474290101e89e4a58c4a0",
      "org.opencontainers.image.source": "https://github.com/usdigitalresponse/usdr-gost",
      "org.opencontainers.image.title": "usdigitalresponse/usdr-gost-api",
      "org.opencontainers.image.url": "https://github.com/usdigitalresponse/usdr-gost",
      "org.opencontainers.image.version": "20230713.2339"
    }
  }
```

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [x] Added steps to test feature/functionality manually

## Checklist
- [x] Provided ticket and description
- [x] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [x] Added PR reviewers