### PR TITLE
feat: enable async treasury download by default

### DIFF
--- a/packages/client/src/arpa_reporter/views/Home.vue
+++ b/packages/client/src/arpa_reporter/views/Home.vue
@@ -4,11 +4,11 @@
       <AlertBox v-if="alert" :text="alert.text" :level="alert.level" v-on:dismiss="clearAlert" />
     </div>
     <div class="row mt-5 mb-5" v-if="viewingOpenPeriod">
-      <div class="col" v-if="isAdmin">
+      <div class="col" v-if="this.$route.query.sync_treasury_download && isAdmin">
         <DownloadButton :href="downloadTreasuryReportURL()" class="btn btn-primary btn-block">Download Treasury Report</DownloadButton>
       </div>
 
-      <div class="col" v-if="this.$route.query.async_treasury_download && isAdmin">
+      <div class="col" v-if="isAdmin">
         <button class="btn btn-primary btn-block" @click="sendTreasuryReport" :disabled="sending">
           <span v-if="sending">Sending...</span>
           <span v-else>Send Treasury Report by Email</span>


### PR DESCRIPTION
### Ticket #1571 
## Description
- Enables the feature flag to open async treasury download more widely to all partners by default
- Allows ability to synchronously download treasury report if needed via query parameter.

## Screenshots / Demo Video

### Before
<img width="1174" alt="image" src="https://github.com/usdigitalresponse/usdr-gost/assets/6497366/0afea49d-f03c-4b4a-8b8d-cfaa883a7ad3">

### After
<img width="1581" alt="image" src="https://github.com/usdigitalresponse/usdr-gost/assets/6497366/6c2edaf4-9f21-4214-a2ab-46e4bf01e90a">


## Testing
Ran server locally and point to `localhost:8080/arpa_reporter`

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [x] Added steps to test feature/functionality manually

## Checklist
- [x] Provided ticket and description
- [x] Provided screenshots/demo
- [x] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [x] Added PR reviewers