### PR TITLE
fix(server): default to zero for null values in columns for new reports

### DIFF
--- a/packages/server/src/arpa_reporter/lib/audit-report.js
+++ b/packages/server/src/arpa_reporter/lib/audit-report.js
@@ -131,10 +131,10 @@ async function getProjectSummaryGroupedByProjectRow(data) {
     // set values in each column
     records.forEach(async (r) => {
         const reportingPeriodEndDate = reportingPeriods.filter((reportingPeriod) => r.upload.reporting_period_id === reportingPeriod.id)[0].end_date;
-        row[`${reportingPeriodEndDate} Total Aggregate Expenditures`] += r.content.Total_Expenditures__c;
-        row[`${reportingPeriodEndDate} Total Aggregate Obligations`] += r.content.Total_Obligations__c;
-        row[`${reportingPeriodEndDate} Total Obligations for Awards Greater or Equal to $50k`] += record.content.Award_Amount__c;
-        row[`${reportingPeriodEndDate} Total Expenditures for Awards Greater or Equal to $50k`] += record.content.Expenditure_Amount__c;
+        row[`${reportingPeriodEndDate} Total Aggregate Expenditures`] += (r.content.Total_Expenditures__c || 0);
+        row[`${reportingPeriodEndDate} Total Aggregate Obligations`] += (r.content.Total_Obligations__c || 0);
+        row[`${reportingPeriodEndDate} Total Obligations for Awards Greater or Equal to $50k`] += (record.content.Award_Amount__c || 0);
+        row[`${reportingPeriodEndDate} Total Expenditures for Awards Greater or Equal to $50k`] += (record.content.Expenditure_Amount__c || 0);
     });
 
     return row;


### PR DESCRIPTION
## Description
When constructing the new summaries report for records grouped by project, we originally added the values from the record without checking whether it's null or not (as this check is not done in the [original audit report generation](https://github.com/usdigitalresponse/usdr-gost/blob/_staging/packages/server/src/arpa_reporter/lib/audit-report.js#L86)). As a result, this causes the summation to result in NaN, which throws an error when opening the report. [See slack thread for context.](https://usdigitalresponse.slack.com/archives/C031R1Y49KL/p1689792789275749)

This PR resolves any null values to 0 if the value we're adding doesn't exist.

## Screenshots / Demo Video
[See slack thread for demo of the issue.](https://usdigitalresponse.slack.com/archives/C031R1Y49KL/p1689792789275749)

## Testing

### Manual tests for Reviewer
* Before the fix - Downloaded the audit report and opened the workbook: a fixed banner indicates there's an issue with opening/parsing the workbook:
![image](https://github.com/usdigitalresponse/usdr-gost/assets/14842270/ef912809-55e6-4088-bafb-a6e178f41fda)
* After the fix - Downloaded the audit report and opened the workbook: does not result in the workbook fixed banner, and the NaN cells do not exist:
![image](https://github.com/usdigitalresponse/usdr-gost/assets/14842270/9e29a381-5e11-4c5c-a002-63bcd24292f7)

## Checklist
- [x] Provided ticket and description
- [x] Provided screenshots/demo
- [x] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [x] Added PR reviewers