### PR TITLE
feat: ensures string-fixed has valdiation

### DIFF
--- a/packages/server/src/arpa_reporter/services/validate-upload.js
+++ b/packages/server/src/arpa_reporter/services/validate-upload.js
@@ -347,7 +347,7 @@ async function validateRecord({ upload, record, typeRules: rules }) {
 
             // make sure max length is not too long
             if (rule.maxLength) {
-                if (rule.dataType === 'String' && String(record[key]).length > rule.maxLength) {
+                if ((rule.dataType === 'String' || rule.dataType === 'String-Fixed') && String(record[key]).length > rule.maxLength) {
                     errors.push(new ValidationError(
                         `Value for ${key} cannot be longer than ${rule.maxLength} (currently, ${String(record[key]).length})`,
                         { col: rule.columnName, severity: 'err' },

--- a/packages/server/src/arpa_reporter/services/validation-rules.js
+++ b/packages/server/src/arpa_reporter/services/validation-rules.js
@@ -133,7 +133,7 @@ function generateRules() {
             rule.validationFormatters = [];
             rule.persistentFormatters = [];
 
-            if (rule.dataType === 'String') {
+            if (rule.dataType === 'String' || rule.dataType === 'String-Fixed') {
                 rule.validationFormatters.push(recordValueFormatters.makeString);
                 rule.persistentFormatters.push(recordValueFormatters.trimWhitespace);
             }


### PR DESCRIPTION
### Ticket #1648 
## Description
There are a few fields in templateRules.json that have the `dataType === 'String-Fixed'`. These fields do not get their whitespace trimmed and are not validated for their max-length.

The purpose of this PR is to ensure:
1. There are validation errors that are sent to the user if these fields exceed their max-length
2. They are persisted with whitespace trimmed on both ends of the field.

## Screenshots / Demo Video

## Testing

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [ ] Provided ticket and description
- [ ] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers