### PR TITLE
fix: make sorting most recent

### DIFF
--- a/packages/server/__tests__/db/db.test.js
+++ b/packages/server/__tests__/db/db.test.js
@@ -45,12 +45,12 @@ describe('db', () => {
             });
             const rows = await db.getSavedSearches(fixtures.users.staffUser.id, { perPage: 2, currentPage: 1 });
             expect(rows.data).to.have.lengthOf(2);
-            expect(rows.data[0].name).to.equal('Example search 1');
+            expect(rows.data[0].name).to.equal('Example search 3');
             expect(rows.data[1].name).to.equal('Example search 2');
 
             const rows2 = await db.getSavedSearches(fixtures.users.staffUser.id, { perPage: 2, currentPage: 2 });
             expect(rows2.data).to.have.lengthOf(1);
-            expect(rows2.data[0].name).to.equal('Example search 3');
+            expect(rows2.data[0].name).to.equal('Example search 1');
 
             const row = await db.getSavedSearch(firstSearch.id);
             expect(row.name).to.equal('Example search 1');

--- a/packages/server/src/db/index.js
+++ b/packages/server/src/db/index.js
@@ -1080,7 +1080,7 @@ async function createSavedSearch(searchItem) {
 async function getSavedSearches(userId, paginationParams) {
     const response = await knex('grants_saved_searches')
         .where('created_by', userId)
-        .orderBy('id')
+        .orderBy('updated_at', 'desc')
         .paginate(paginationParams);
 
     response.data = response.data.map((r) => ({


### PR DESCRIPTION
### Ticket #
## Description
- Ensures we always send the most recent saved search first in the backend.

## Screenshots / Demo Video

## Testing
http://ocalhost:8080/api/organizations/0/grants/grants_saved_searches

### Automated and Unit Tests
- [x] Added Unit tests

### Manual tests for Reviewer
- [x] Added steps to test feature/functionality manually

## Checklist
- [x] Provided ticket and description
- [ ] Provided screenshots/demo
- [x] Provided testing information
- [x] Provided adequate test coverage for all new code
- [x] Added PR reviewers