### PR TITLE
BUG: Fix SSM deployment param path typo

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -210,6 +210,6 @@ jobs:
           withDecryption: "true"
           parameterPairs: |
             /gost/${{ needs.select_target_environment.outputs.selected }}/deploy-config/consume-grants/cluster-name = ECS_CLUSTER_NAME,
-            /gost/${{ needs.select_target_environment.outputs.selected }}/deploy-config/consume-grants/cluster-name = ECS_SERVICE_NAME
+            /gost/${{ needs.select_target_environment.outputs.selected }}/deploy-config/consume-grants/service-name = ECS_SERVICE_NAME
       - name: Update ECS service
         run: aws ecs update-service --cluster ${{ env.ECS_CLUSTER_NAME }} --service ${{ env.ECS_SERVICE_NAME }} --force-new-deployment > /dev/null


### PR DESCRIPTION
## Description

This PR fixes a mis-named SSM parameter path used for configuring ECS deployment targets. It should fix issues where deploying new Docker images to the `consume-grants` ECS service is failing ([for example](https://github.com/usdigitalresponse/usdr-gost/actions/runs/5648626496/job/15301382164)).

## Screenshots / Demo Video

## Testing

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [ ] Provided ticket and description
- [ ] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers