### PR TITLE
feat(1303): add capital expenditure amount column to new project summary sheets

### DIFF
--- a/packages/server/src/arpa_reporter/lib/audit-report.js
+++ b/packages/server/src/arpa_reporter/lib/audit-report.js
@@ -128,6 +128,8 @@ async function getProjectSummaryGroupedByProjectRow(data) {
         ].forEach((columnName) => { row[columnName] = 0; });
     });
 
+    row['Capital Expenditure Amount'] = 0;
+
     // set values in each column
     records.forEach(async (r) => {
         const reportingPeriodEndDate = reportingPeriods.filter((reportingPeriod) => r.upload.reporting_period_id === reportingPeriod.id)[0].end_date;
@@ -135,6 +137,7 @@ async function getProjectSummaryGroupedByProjectRow(data) {
         row[`${reportingPeriodEndDate} Total Aggregate Obligations`] += (r.content.Total_Obligations__c || 0);
         row[`${reportingPeriodEndDate} Total Obligations for Awards Greater or Equal to $50k`] += (record.content.Award_Amount__c || 0);
         row[`${reportingPeriodEndDate} Total Expenditures for Awards Greater or Equal to $50k`] += (record.content.Expenditure_Amount__c || 0);
+        row['Capital Expenditure Amount'] += (r.content.Expenditure_Amount__c || 0);
     });
 
     return row;

--- a/packages/server/src/arpa_reporter/lib/audit-report.js
+++ b/packages/server/src/arpa_reporter/lib/audit-report.js
@@ -135,9 +135,9 @@ async function getProjectSummaryGroupedByProjectRow(data) {
         const reportingPeriodEndDate = reportingPeriods.filter((reportingPeriod) => r.upload.reporting_period_id === reportingPeriod.id)[0].end_date;
         row[`${reportingPeriodEndDate} Total Aggregate Expenditures`] += (r.content.Total_Expenditures__c || 0);
         row[`${reportingPeriodEndDate} Total Aggregate Obligations`] += (r.content.Total_Obligations__c || 0);
-        row[`${reportingPeriodEndDate} Total Obligations for Awards Greater or Equal to $50k`] += (record.content.Award_Amount__c || 0);
-        row[`${reportingPeriodEndDate} Total Expenditures for Awards Greater or Equal to $50k`] += (record.content.Expenditure_Amount__c || 0);
-        row['Capital Expenditure Amount'] += (r.content.Expenditure_Amount__c || 0);
+        row[`${reportingPeriodEndDate} Total Obligations for Awards Greater or Equal to $50k`] += (r.content.Award_Amount__c || 0);
+        row[`${reportingPeriodEndDate} Total Expenditures for Awards Greater or Equal to $50k`] += (r.content.Expenditure_Amount__c || 0);
+        row['Capital Expenditure Amount'] += (r.content.Total_Cost_Capital_Expenditure__c || 0);
     });
 
     return row;


### PR DESCRIPTION
### Ticket #1303
## Description
This PR adds a new column for `Capital Expenditure Amount` in the new project summary sheets, where records are grouped by project. To calculate the column we sum the records associated with the project by its `Total_Cost_Capital_Expenditure__c` value.

Additional changes involve adding the value from the records we're iterating and not the same record over and over for total obligations and total expenditures columns.

## Screenshots / Demo Video
![image](https://github.com/usdigitalresponse/usdr-gost/assets/14842270/ec343f18-fc67-4d38-8fa9-ffdc6fa76c44)

## Testing
1. Local DB has the following two records:
```
const records = [
  {
    type: 'ec5',
    subcategory: "5.19-Broadband: 'Last Mile' projects",
    upload: {
      filename: '2023-06-22-Michelle_Testing.xlsm',
      created_at: '2023-06-23T02:43:11.625Z',
      reporting_period_id: 43,
      user_id: 17,
      agency_id: 0,
      validated_at: '2023-06-23T02:43:12.277Z',
      validated_by: 17,
      ec_code: '5.19',
      tenant_id: 1,
      id: 'adf5acdb-e0c2-4554-a85c-1efc24dda9b1',
      notes: null,
      invalidated_at: null,
      invalidated_by: null,
      created_by: 'grant-admin@usdigitalresponse.org',
      agency_code: 'USDR'
    },
    content: {
      Name: 'Project Broadband',
      Project_Identification_Number__c: 'A010203',
      Completion_Status__c: 'Completed less than 50%',
      Adopted_Budget__c: 2000000,
      Total_Obligations__c: 1000000,
      Total_Expenditures__c: 1000000,
      Current_Period_Obligations__c: 1000000,
      Current_Period_Expenditures__c: 1000000,
      Project_Description__c: 'This is a description.',
      Proj_Actual_Construction_Start_Date__c: '2023-03-01T05:00:00.000Z',
      Initiation_of_Operations_Date__c: '2023-07-01T04:00:00.000Z',
      Is_project_designed_to_meet_100_mbps__c: 'Yes',
      Is_project_designed_to_exceed_100_mbps__c: 'Yes',
      Is_project_designed_provide_hh_service__c: 'Yes',
      Technology_Type_Planned__c: 'Fiber',
      Total_Miles_of_Fiber_Deployed_c: 30,
      Planned_Funded_Locations_Served__c: 30,
      Planned_Funded_Locations_25_3_Below__c: 0,
      Planned_Funded_Locations_Between_25_100__c: 0,
      Planned_Funded_Locations_Minimum_100_100__c: 30,
      Planned_Funded_Locations_Minimum_100_20__c: 30,
      Planned_Funded_Locations_Residential__c: 30,
      Planned_Funded_Locations_Total_Housing__c: 30,
      Planned_Funded_Locations_Business__c: 0,
      Planned_Funded_Locations_Community__c: 0,
      Planned_Funded_Locations_Explanation__c: 'Because.',
      Confirm_Service_Provider__c: 'Yes',
      Fabric_ID__c: 1234567890,
      FCC_Provider_ID__c: 123456
    }
  },
  {
    type: 'ec5',
    subcategory: "5.19-Broadband: 'Last Mile' projects",
    upload: {
      filename: '2023-06-22-Michelle_Testing 1.xlsm',
      created_at: '2023-06-25T01:48:56.129Z',
      reporting_period_id: 44,
      user_id: 17,
      agency_id: 0,
      validated_at: '2023-06-25T01:48:56.455Z',
      validated_by: 17,
      ec_code: '5.19',
      tenant_id: 1,
      id: '78dffeda-724a-42b0-b0b5-a893862092e3',
      notes: null,
      invalidated_at: null,
      invalidated_by: null,
      created_by: 'grant-admin@usdigitalresponse.org',
      agency_code: 'USDR'
    },
    content: {
      Name: 'Project Broadband',
      Project_Identification_Number__c: 'A010203',
      Completion_Status__c: 'Completed less than 50%',
      Adopted_Budget__c: 2000000,
      Total_Obligations__c: 1000000,
      Total_Expenditures__c: 1000000,
      Current_Period_Obligations__c: 1000000,
      Current_Period_Expenditures__c: 1000000,
      Project_Description__c: 'This is a description.',
      Proj_Actual_Construction_Start_Date__c: '2023-03-01T05:00:00.000Z',
      Initiation_of_Operations_Date__c: '2023-07-01T04:00:00.000Z',
      Is_project_designed_to_meet_100_mbps__c: 'Yes',
      Is_project_designed_to_exceed_100_mbps__c: 'Yes',
      Is_project_designed_provide_hh_service__c: 'Yes',
      Technology_Type_Planned__c: 'Fiber',
      Total_Miles_of_Fiber_Deployed_c: 30,
      Planned_Funded_Locations_Served__c: 30,
      Planned_Funded_Locations_25_3_Below__c: 0,
      Planned_Funded_Locations_Between_25_100__c: 0,
      Planned_Funded_Locations_Minimum_100_100__c: 30,
      Planned_Funded_Locations_Minimum_100_20__c: 30,
      Planned_Funded_Locations_Residential__c: 30,
      Planned_Funded_Locations_Total_Housing__c: 30,
      Planned_Funded_Locations_Business__c: 0,
      Planned_Funded_Locations_Community__c: 0,
      Planned_Funded_Locations_Explanation__c: 'Because.',
      Confirm_Service_Provider__c: 'Yes',
      Fabric_ID__c: 1234567890,
      FCC_Provider_ID__c: 123456
    }
  }
]
```
2. Selecting send audit report results in the excel sheet (see screenshot above) where there is 1 column for Capital Expenditure Amount. There is also no `WORKBOOK REPAIRED` messaging (like the one mentioned in this [PR](https://github.com/usdigitalresponse/usdr-gost/pull/1668)).

### Manual tests for Reviewer
- [x] Added steps to test feature/functionality manually

## Checklist
- [x] Provided ticket and description
- [x] Provided screenshots/demo
- [x] Provided testing information
~~- [ ] Provided adequate test coverage for all new code~~
- [x] Added PR reviewers