### PR TITLE
Post-demo updates to saved search and search panel integration

### DIFF
--- a/packages/client/src/components/GrantsTableNext.vue
+++ b/packages/client/src/components/GrantsTableNext.vue
@@ -2,15 +2,15 @@
   <section class="container-fluid" style="margin: 10px;" >
     <b-row class="my-3">
       <div class="ml-3">
-        <SavedSearchPanel />
+        <SavedSearchPanel @edit-filter="openSearchForEdit" @filters-applied="paginateGrants" />
       </div>
       <div class="ml-3">
-        <SearchPanel ref="searchPanel" @filters-applied="paginateGrants" />
+        <SearchPanel ref="searchPanel" :search-id="searchId" @filters-applied="paginateGrants" />
       </div>
     </b-row>
     <b-row>
       <b-col cols="11">
-        <SearchFilter :filterKeys="searchFilters" @filter-removed="paginateGrants" />
+        <SearchFilter :filterKeys="searchFilters" @filter-removed="paginateGrants" @edit-filter="openSearchForEdit" />
       </b-col>
       <b-col align-self="end">
         <b-button @click="exportCSV" :disabled="loading" variant="outline-primary border-0">
@@ -148,6 +148,7 @@ export default {
       opportunityStatusOptions: ['Forecasted', 'Posted', 'Closed / Archived'],
       opportunityCategoryOptions: ['Discretionary', 'Mandatory', 'Earmark', 'Continuation'],
       costSharingOptions: ['Yes', 'No'],
+      searchId: null,
     };
   },
   mounted() {
@@ -161,6 +162,7 @@ export default {
       agency: 'users/agency',
       selectedAgency: 'users/selectedAgency',
       activeFilters: 'grants/activeFilters',
+      selectedSearchId: 'grants/selectedSearchId',
     }),
     totalRows() {
       return this.grantsPagination ? this.grantsPagination.total : 0;
@@ -276,6 +278,16 @@ export default {
       } finally {
         this.loading = false;
       }
+    },
+    openSearchForEdit(searchId) {
+      if (searchId === null || searchId === undefined) {
+        debugger;
+        this.searchId = Number(this.selectedSearchId);
+      } else {
+        this.searchId = Number(searchId);
+      }
+
+      this.$root.$emit('bv::toggle::collapse', 'search-panel');
     },
     getAwardFloor(grant) {
       let body;

--- a/packages/client/src/components/SearchFilter.vue
+++ b/packages/client/src/components/SearchFilter.vue
@@ -3,7 +3,7 @@
     <div class="mb-3">
       <div class="ml-2">
         <b>Saved Search Name </b>
-        <a href="#" v-on:click="clearAll">Edit</a> | <a href="#" v-on:click="clearAll" v-if="$props.filterKeys.length > 0">Clear</a>
+        <a href="#" v-on:click="editFilter">Edit</a> | <a href="#" v-on:click="clearAll" v-if="$props.filterKeys.length > 0">Clear</a>
       </div>
       <span class="filter-item" v-for="(item, idx) in $props.filterKeys" :key="idx">
         <strong >{{ item.label }}: </strong>{{ formatValue(item.value)  }}
@@ -37,13 +37,12 @@ export default {
       }
       return value;
     },
+    editFilter() {
+      this.$emit('edit-filter');
+    },
     clearAll() {
       this.clearFilters();
       this.$emit('filter-removed');
-    },
-    clearFilter(key) {
-      this.removeFilter(key);
-      this.$emit('filter-removed', key);
     },
   },
 };

--- a/packages/client/src/helpers/filters.js
+++ b/packages/client/src/helpers/filters.js
@@ -1,0 +1,32 @@
+// fields with ⚠️ are not yet implemented in the api
+const FILTER_FIELD_NAME_MAP = {
+  costSharing: 'Cost Sharing',
+  opportunityStatuses: 'Opportunity Statuses',
+  opportunityCategories: 'Opportunity Categories',
+  reviewStatus: 'Review Status',
+  includeKeywords: 'Include Keywords ⚠️',
+  excludeKeywords: 'Exclude Keywords ⚠️',
+  opportunityNumber: 'Opportunity Number ⚠️',
+  postedWithin: 'Posted Within ⚠️',
+  fundingType: 'Funding Type ⚠️',
+  eligibility: 'Eligibility ⚠️',
+};
+
+export function formatFilterDisplay(criteria) {
+  const filters = [];
+  Object.entries(criteria).forEach(([key, value]) => {
+    if (value && FILTER_FIELD_NAME_MAP[key]) {
+      // if it's an array, make sure it's not empty
+      if (Array.isArray(value) && value.length === 0) {
+        return;
+      }
+      filters.push({
+        label: FILTER_FIELD_NAME_MAP[key],
+        key,
+        value,
+      });
+    }
+  });
+
+  return filters;
+}

--- a/packages/client/src/store/modules/grants.js
+++ b/packages/client/src/store/modules/grants.js
@@ -1,18 +1,6 @@
 const fetchApi = require('@/helpers/fetchApi');
 
-// fields with ⚠️ are not yet implemented in the api
-const FILTER_FIELD_NAME_MAP = {
-  costSharing: 'Cost Sharing',
-  opportunityStatuses: 'Opportunity Statuses',
-  opportunityCategories: 'Opportunity Categories',
-  reviewStatus: 'Review Status',
-  includeKeywords: 'Include Keywords ⚠️',
-  excludeKeywords: 'Exclude Keywords ⚠️',
-  opportunityNumber: 'Opportunity Number ⚠️',
-  postedWithin: 'Posted Within ⚠️',
-  fundingType: 'Funding Type ⚠️',
-  eligibility: 'Eligibility ⚠️',
-};
+const { formatFilterDisplay } = require('@/helpers/filters');
 
 function initialState() {
   return {
@@ -59,22 +47,7 @@ export default {
       interested: state.interestedCodes.filter((c) => c.status_code === 'Interested'),
     }),
     activeFilters(state) {
-      const filters = [];
-      Object.entries(state.searchFormFilters).forEach(([key, value]) => {
-        if (value && FILTER_FIELD_NAME_MAP[key]) {
-          // if it's an array, make sure it's not empty
-          if (Array.isArray(value) && value.length === 0) {
-            return;
-          }
-          filters.push({
-            label: FILTER_FIELD_NAME_MAP[key],
-            key,
-            value,
-          });
-        }
-      });
-
-      return filters;
+      return formatFilterDisplay(state.searchFormFilters);
     },
     searchFormFilters(state) {
       return state.searchFormFilters;
@@ -196,8 +169,8 @@ export default {
       fetchApi.get('/api/organizations/:organizationId/grants-saved-search')
         .then((data) => commit('SET_SAVED_SEARCHES', data));
     },
-    createSavedSearch(context, { searchInfo }) {
-      fetchApi.post('/api/organizations/:organizationId/grants-saved-search', searchInfo);
+    async createSavedSearch(context, { searchInfo }) {
+      return fetchApi.post('/api/organizations/:organizationId/grants-saved-search', searchInfo);
     },
     updateSavedSearch(context, { searchId, searchInfo }) {
       fetchApi.put(`/api/organizations/:organizationId/grants-saved-search/${searchId}`, searchInfo);


### PR DESCRIPTION
### Ticket #1406 
Closes #1406, others
## Description
Multiple updates post demo
- Search form fills in when clicking edit from saved search panel
- Search form also fills in when clicking edit from table, if in a saved search
- Search criteria applies when clicking on a row in the saved search view
- Labels for saved search are formatted a little bit
- Fixed save button text
- Placeholder hover effect on saved search panel

## Screenshots / Demo Video

https://github.com/usdigitalresponse/usdr-gost/assets/624510/b269436c-0034-4d2e-890b-bdd257eeffbd


## Testing
1. Create a saved search or two
2. Open Saved Searches. Clicking on a search should apply its criteria to the current view.
3. Open Saved Search. Clicking kebab menu-> edit should open the criteria in the search panel. 
4. With a search open, you should be able to edit/save.

## Known issues
- The Saved Searches view doesn't consistently refresh between saving, and you might have to reload the screen.
- The edit/clear controls over the filters/table don't show correctly. i.e. they shouldn't show at all if there is no active search, and they don't display the saved search name.
- The hover is ugly, sorry. I wasn't sure where the color n such was in the Figma, and I didn't fix the padding n such. Figured something was better than nothing; will address that later.

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [x] Added steps to test feature/functionality manually

## Checklist
- [x] Provided ticket and description
- [x] Provided screenshots/demo
- [x] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers