### PR TITLE
fix: #1676 - Cache usedForTreasuryExport Queries

### DIFF
--- a/packages/server/src/arpa_reporter/lib/audit-report.js
+++ b/packages/server/src/arpa_reporter/lib/audit-report.js
@@ -9,7 +9,7 @@ const { ec } = require('./format');
 const { getPreviousReportingPeriods, getReportingPeriod, getAllReportingPeriods } = require('../db/reporting-periods');
 const { getCurrentReportingPeriodID } = require('../db/settings');
 const { recordsForProject, recordsForReportingPeriod, mostRecentProjectRecords } = require('../services/records');
-const { usedForTreasuryExport } = require('../db/uploads');
+const { usedForTreasuryExport, setUsedForTreasuryExportCache, clearUsedForTreasuryExportCache } = require('../db/uploads');
 const { ARPA_REPORTER_BASE_URL } = require('../environment');
 const email = require('../../lib/email');
 const { useTenantId } = require('../use-request');
@@ -206,10 +206,9 @@ async function createProjectSummariesGroupedByProject(periodId) {
 
 async function generate(requestHost) {
     const periodId = await getCurrentReportingPeriodID();
-    console.log(`generate(${periodId})`);
 
     const domain = ARPA_REPORTER_BASE_URL ?? requestHost;
-
+    await setUsedForTreasuryExportCache();
     // generate sheets
     const [
         obligations,
@@ -220,6 +219,7 @@ async function generate(requestHost) {
         createProjectSummaries(periodId, domain),
         createProjectSummariesGroupedByProject(periodId),
     ]);
+    clearUsedForTreasuryExportCache();
 
     // compose workbook
     const sheet1 = XLSX.utils.json_to_sheet(obligations, { dateNF: 'MM/DD/YYYY' });


### PR DESCRIPTION
Added the cache for usedForTreasuryExport. The cache queries all the reporting periods at once

### Ticket #1676
## Description

## Screenshots / Demo Video

## Testing

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [ ] Provided ticket and description
- [ ] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers