### PR TITLE
Enable Datadog profiling in ECS

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -38,6 +38,7 @@ locals {
   private_subnet_ids       = split(",", data.aws_ssm_parameter.private_subnet_ids.value)
   permissions_boundary_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/${var.permissions_boundary_policy_name}"
   api_domain_name          = coalesce(var.api_domain_name, "api.${var.website_domain_name}")
+  unified_service_tags     = { service = "gost", env = var.env, version = var.version_identifier }
 }
 
 data "aws_ssm_parameter" "public_dns_zone_id" {
@@ -125,7 +126,8 @@ module "api" {
   autoscaling_desired_count_maximum = var.api_maximum_task_count
   enable_grants_scraper             = var.api_enable_grants_scraper
   enable_grants_digest              = var.api_enable_grants_digest
-  unified_service_tags              = { service = "gost", env = var.env, version = var.version_identifier }
+  unified_service_tags              = local.unified_service_tags
+  datadog_environment_variables     = var.api_datadog_environment_variables
 
   # DNS
   domain_name         = local.api_domain_name
@@ -160,9 +162,10 @@ module "consume_grants" {
   security_group_ids = [module.api_to_postgres_security_group.id]
 
   # Task configuration
-  ecs_cluster_name     = join("", aws_ecs_cluster.default.*.name)
-  docker_tag           = var.api_container_image_tag
-  unified_service_tags = { service = "gost", env = var.env, version = var.version_identifier }
+  ecs_cluster_name              = join("", aws_ecs_cluster.default.*.name)
+  docker_tag                    = var.api_container_image_tag
+  unified_service_tags          = local.unified_service_tags
+  datadog_environment_variables = var.consume_grants_datadog_environment_variables
 
   # Messaging
   grants_ingest_event_bus_name = var.consume_grants_source_event_bus_name

--- a/terraform/modules/gost_api/task.tf
+++ b/terraform/modules/gost_api/task.tf
@@ -2,10 +2,13 @@ locals {
   api_container_image = "${var.docker_repository}:${var.docker_tag}"
   api_container_port  = 3000
 
-  datadog_env_vars = {
-    for k in compact([for k, v in var.unified_service_tags : (v != null ? k : "")]) :
-    "DD_${upper(k)}" => var.unified_service_tags[k]
-  }
+  datadog_env_vars = merge(
+    {
+      for k in compact([for k, v in var.unified_service_tags : (v != null ? k : "")]) :
+      "DD_${upper(k)}" => var.unified_service_tags[k]
+    },
+    { for k, v in var.datadog_environment_variables : upper(k) => v },
+  )
   datadog_docker_labels = {
     for k in compact([for k, v in var.unified_service_tags : (v != null ? k : "")]) :
     "com.datadoghq.tags.${lower(k)}" => var.unified_service_tags[k]

--- a/terraform/modules/gost_api/variables.tf
+++ b/terraform/modules/gost_api/variables.tf
@@ -178,6 +178,12 @@ variable "unified_service_tags" {
   })
 }
 
+variable "datadog_environment_variables" {
+  description = "Datadog-related environment variables to apply to both API and Datadog container runtime environments. See also: var.unified_service_tags."
+  type        = map(string)
+  default     = {}
+}
+
 variable "autoscaling_desired_count_minimum" {
   description = "Minimum desired auto-scaling group capacity"
   type        = number

--- a/terraform/modules/gost_consume_grants/compute.tf
+++ b/terraform/modules/gost_consume_grants/compute.tf
@@ -57,11 +57,14 @@ module "consumer_task_definition" {
       GRANTS_INGEST_EVENTS_QUEUE_URL = module.sqs_queue.queue_url
       NODE_OPTIONS                   = "--max_old_space_size=200"
       PGSSLROOTCERT                  = "rds-combined-ca-bundle.pem"
-      POSTGRES_URL                   = local.postgres_connection_string
     },
     local.datadog_env_vars,
     var.consumer_container_environment,
   )
+
+  map_secrets = {
+    POSTGRES_URL = local.postgres_connection_string
+  }
 
   docker_labels = local.datadog_docker_labels
 

--- a/terraform/modules/gost_consume_grants/datadog.tf
+++ b/terraform/modules/gost_consume_grants/datadog.tf
@@ -4,9 +4,10 @@ locals {
     for k in compact([for k, v in var.unified_service_tags : (v != null ? k : "")]) :
     k => var.unified_service_tags[k]
   }
-  datadog_env_vars = {
-    for k, v in local.unified_service_tags : "DD_${upper(k)}" => v
-  }
+  datadog_env_vars = merge(
+    { for k, v in local.unified_service_tags : "DD_${upper(k)}" => v },
+    { for k, v in var.datadog_environment_variables : upper(k) => v },
+  )
   datadog_docker_labels = {
     for k, v in local.unified_service_tags : "com.datadoghq.tags.${lower(k)}" => v
   }

--- a/terraform/modules/gost_consume_grants/variables.tf
+++ b/terraform/modules/gost_consume_grants/variables.tf
@@ -102,6 +102,12 @@ variable "unified_service_tags" {
   })
 }
 
+variable "datadog_environment_variables" {
+  description = "Datadog-related environment variables to apply to both consumer and Datadog container runtime environments. See also: var.unified_service_tags."
+  type        = map(string)
+  default     = {}
+}
+
 variable "sqs_dlq_enabled" {
   description = "Whether to create a dead-letter queue for the main SQS queue."
   type        = bool

--- a/terraform/prod.tfvars
+++ b/terraform/prod.tfvars
@@ -21,6 +21,9 @@ api_maximum_task_count         = 5
 api_enable_grants_scraper      = true
 api_enable_grants_digest       = true
 api_log_retention_in_days      = 30
+api_datadog_environment_variables = {
+  DD_PROFILING_ENABLED = true,
+}
 
 // Postgres
 postgres_enabled                   = true
@@ -30,3 +33,6 @@ postgres_apply_changes_immediately = false
 
 // Grant events consumer
 consume_grants_source_event_bus_name = "default"
+consume_grants_datadog_environment_variables = {
+  DD_PROFILING_ENABLED = true,
+}

--- a/terraform/production.tfvars
+++ b/terraform/production.tfvars
@@ -41,9 +41,6 @@ api_minumum_task_count         = 2
 api_maximum_task_count         = 5
 api_enable_grants_scraper      = true
 api_log_retention_in_days      = 30
-api_datadog_environment_variables = {
-  DD_PROFILING_ENABLED = true,
-}
 
 // Postgres
 postgres_enabled                   = true

--- a/terraform/production.tfvars
+++ b/terraform/production.tfvars
@@ -41,6 +41,9 @@ api_minumum_task_count         = 2
 api_maximum_task_count         = 5
 api_enable_grants_scraper      = true
 api_log_retention_in_days      = 30
+api_datadog_environment_variables = {
+  DD_PROFILING_ENABLED = true,
+}
 
 // Postgres
 postgres_enabled                   = true
@@ -50,3 +53,6 @@ postgres_apply_changes_immediately = false
 
 // Grant events consumer
 consume_grants_source_event_bus_name = "default"
+consume_grants_datadog_environment_variables = {
+  DD_PROFILING_ENABLED = true,
+}

--- a/terraform/production.tfvars
+++ b/terraform/production.tfvars
@@ -53,6 +53,3 @@ postgres_apply_changes_immediately = false
 
 // Grant events consumer
 consume_grants_source_event_bus_name = "default"
-consume_grants_datadog_environment_variables = {
-  DD_PROFILING_ENABLED = true,
-}

--- a/terraform/staging.tfvars
+++ b/terraform/staging.tfvars
@@ -43,6 +43,9 @@ api_maximum_task_count         = 5
 api_enable_grants_scraper      = false
 api_enable_grants_digest       = false
 api_log_retention_in_days      = 14
+api_datadog_environment_variables = {
+  DD_PROFILING_ENABLED = true,
+}
 
 // Postgres
 postgres_enabled                   = true
@@ -53,3 +56,6 @@ postgres_query_logging_enabled     = true
 
 // Grant events consumer
 consume_grants_source_event_bus_name = "default"
+consume_grants_datadog_environment_variables = {
+  DD_PROFILING_ENABLED = true,
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -92,6 +92,11 @@ variable "api_container_environment" {
   default = {}
 }
 
+variable "api_datadog_environment_variables" {
+  type    = map(string)
+  default = {}
+}
+
 variable "api_default_desired_task_count" {
   type = number
 }
@@ -136,4 +141,9 @@ variable "postgres_query_logging_enabled" {
 # Consume Grants
 variable "consume_grants_source_event_bus_name" {
   type = string
+}
+
+variable "consume_grants_datadog_environment_variables" {
+  type    = map(string)
+  default = {}
 }


### PR DESCRIPTION
## Description

This PR is a companion to @ajhyndman's #1756, which updated the `dd-trace` library to a version that has more debugging features.

This change sets a `DD_PROFILING_ENABLED` environment variable to `"true"` in Staging and Production environments, which is a requirement for [enabling the Node.js profiler](https://docs.datadoghq.com/profiler/enabling/nodejs/?tab=environmentvariables).

_Mostly_ unrelated, but this PR also moves the `POSTGRES_URL` env var in the `consume_grants` container definition out of plaintext and into a mapped secret env var. This is 99% unnecessary, but since the `postgres_username` input variable in terraform is marked as sensitive, including it in the plaintext env var mapping causes terraform plan output to hide all env var modifications, which isn't particularly helpful. The alternative would be to simply remove the `sensitive=true` annotation from the variable definition (the postgres username is just the standard `postgres`, which is hard-coded in the `gost_postgres` module), but given that this inclusion is already pushing the scope of the PR, moving the URL to `map_secrets` seemed slightly more sensible.

## Screenshots / Demo Video

## Testing

This change only applies to AWS environments, so the earliest point it can be verified is Staging. However, the terraform plan that will be automatically added as a comment on this PR should demonstrate the expected `DD_PROFILING_ENABLED="true"` behavior in container environments.

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [X] Added steps to test feature/functionality manually

## Checklist
- [ ] Provided ticket and description
- [ ] Provided screenshots/demo
- [x] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [x] Added PR reviewers