### PR TITLE
FIX: PR 1763

### DIFF
--- a/terraform/modules/gost_api/variables.tf
+++ b/terraform/modules/gost_api/variables.tf
@@ -59,7 +59,6 @@ variable "rds_db_connect_resources" {
 variable "postgres_username" {
   description = "Username for authenticated connecting to the Postgres db."
   type        = string
-  sensitive   = true
 }
 
 variable "postgres_password" {

--- a/terraform/modules/gost_consume_grants/compute.tf
+++ b/terraform/modules/gost_consume_grants/compute.tf
@@ -57,14 +57,11 @@ module "consumer_task_definition" {
       GRANTS_INGEST_EVENTS_QUEUE_URL = module.sqs_queue.queue_url
       NODE_OPTIONS                   = "--max_old_space_size=200"
       PGSSLROOTCERT                  = "rds-combined-ca-bundle.pem"
+      POSTGRES_URL                   = local.postgres_connection_string
     },
     local.datadog_env_vars,
     var.consumer_container_environment,
   )
-
-  map_secrets = {
-    POSTGRES_URL = local.postgres_connection_string
-  }
 
   docker_labels = local.datadog_docker_labels
 

--- a/terraform/modules/gost_consume_grants/variables.tf
+++ b/terraform/modules/gost_consume_grants/variables.tf
@@ -47,7 +47,6 @@ variable "rds_db_connect_resources" {
 variable "postgres_username" {
   description = "Username for authenticated connecting to the Postgres db."
   type        = string
-  sensitive   = true
 }
 
 variable "postgres_endpoint" {

--- a/terraform/modules/gost_postgres/outputs.tf
+++ b/terraform/modules/gost_postgres/outputs.tf
@@ -13,7 +13,6 @@ output "rds_db_connect_resources_list" {
 output "master_username" {
   description = "Cluster master username."
   value       = module.db.cluster_master_username
-  sensitive   = true
 }
 
 output "master_password" {


### PR DESCRIPTION
### Ticket #1763 
## Description

This PR provides a fix for the issue that is causing the deployment for #1763's [commit to `_staging`](https://github.com/usdigitalresponse/usdr-gost/commit/f5892afb3d4f1339af604098ded8012e6dd801b6) to [fail when running `terraform apply`](https://github.com/usdigitalresponse/usdr-gost/actions/runs/5804332306/job/15733742321). 

**Problem:** In #1763, the `POSTGRES_URL` environment variable definition in the `gost_consume_grants` module was moved from the main container definition's `map_environment` setting to `map_secrets`. This was intended to be a shortcut to getting Terraform plan output to stop masking changes to nonsensitive environment variables, but was ultimately short-sighted, as the `map_secrets` map is intended to reference secret resources (SSM parameters or Secrets Manager secrets) rather than raw strings.

As I mentioned in #1763, the `var.postgres_username` input variable's is currently marked as a sensitive value (hence the problems with opaque Terraform plan output), but it really shouldn't be – it's unnecessary for a few reasons:
1. Knowing the username alone doesn't really compromise Postgres.
2. We don't use basic auth for Postgres (anymore). We use IAM auth, which makes the username even less valuable to a malicious actor.
3. Perhaps most of all: the Postgres username, `postgres`, is already hard-coded as a plaintext value in the `gost_postgres` module (see the previous 2 reasons for why this isn't an issue).

**Solution:** Remove the `sensitive = true` setting from all `postgres_username` input variables and move the `POSTGRES_URL` env var definition back to the `map_environment` setting of the task definition. The result should be that deployments can succeed, and Terraform will no longer mask strings on the basis of containing the Postgres username.

## Screenshots / Demo Video

## Testing

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [ ] Provided ticket and description
- [ ] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers