### PR TITLE
fix: turn off new table by default in staging

### DIFF
--- a/terraform/staging.tfvars
+++ b/terraform/staging.tfvars
@@ -31,7 +31,7 @@ website_managed_waf_rules = {
   }
 }
 website_feature_flags = {
-  useNewTable = true
+  useNewTable = false
 }
 
 // ECS Cluster


### PR DESCRIPTION
### Ticket #1779 
## Description
- Turns off the new search experience by default in staging. This ensures the old search experience still works.

- Since the new search experience removes two tabs, turning on the feature-flag does not bring back the keywords and eligibility tabs.
- By keeping this flag turned off in staging, we can see the old tabs and still interact with the old flow.

## Screenshots / Demo Video

## Testing

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [ ] Provided ticket and description
- [ ] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers