### PR TITLE
fix: change Keywords heading from h3 to h2

### DIFF
--- a/packages/client/src/views/Keywords.vue
+++ b/packages/client/src/views/Keywords.vue
@@ -1,7 +1,7 @@
 <template>
 <section class="container-fluid">
     <b-row>
-        <b-col><h3>Keywords</h3></b-col>
+        <b-col><h2>Keywords</h2></b-col>
         <b-col class="d-flex justify-content-end">
             <div>
                 <b-button variant="success" name="include-button" @click="openAddKeywordModal">Add</b-button>


### PR DESCRIPTION
### Ticket #<Enter Number Here To Auto-Link>
## Description
Fix: Change Keywords heading in GOST frontend from `h3` to `h2`, to be consistent with other table headings.

## Screenshots / Demo Video
| Before             |  After |
:-------------------------:|:-------------------------:
<img width="1668" alt="Screen Shot 2023-08-11 at 2 00 49 PM" src="https://github.com/usdigitalresponse/usdr-gost/assets/2928395/08554547-45c2-4365-a77c-2b00cf531bf0"> | <img width="1667" alt="Screen Shot 2023-08-11 at 2 00 19 PM" src="https://github.com/usdigitalresponse/usdr-gost/assets/2928395/bad4474d-9116-4e96-9a8c-1f33bd5b18f5">



## Testing

### Automated and Unit Tests
- [N/A] Added Unit tests

### Manual tests for Reviewer
- [N/A] Added steps to test feature/functionality manually

## Checklist
- [x] Provided ticket and description
- [x] Provided screenshots/demo
- [N/A] Provided testing information
- [N/A] Provided adequate test coverage for all new code
- [x] Added PR reviewers