### PR TITLE
Enhancement: Declare explicit Datadog container dependencies

### DIFF
--- a/terraform/modules/gost_api/task.tf
+++ b/terraform/modules/gost_api/task.tf
@@ -24,6 +24,11 @@ module "api_container_definition" {
   essential                = true
   readonly_root_filesystem = "false"
 
+  container_depends_on = [{
+    containerName = "datadog"
+    condition     = "START"
+  }]
+
   linux_parameters = {
     capabilities = {
       add  = []

--- a/terraform/modules/gost_consume_grants/compute.tf
+++ b/terraform/modules/gost_consume_grants/compute.tf
@@ -26,7 +26,7 @@ resource "aws_ecs_service" "default" {
   ]
 }
 
-module "consumer_task_definition" {
+module "consumer_container_definition" {
   source  = "cloudposse/ecs-container-definition/aws"
   version = "0.60.0"
 
@@ -121,7 +121,7 @@ resource "aws_ecs_task_definition" "consume_grants" {
   }
 
   container_definitions = jsonencode([
-    module.consumer_task_definition.json_map_object,
+    module.consumer_container_definition.json_map_object,
     module.datadog_container_definition.json_map_object,
   ])
 

--- a/terraform/modules/gost_consume_grants/compute.tf
+++ b/terraform/modules/gost_consume_grants/compute.tf
@@ -37,6 +37,11 @@ module "consumer_task_definition" {
   stop_timeout             = local.stop_timeout_seconds
   command                  = ["node", "./src/scripts/consumeGrantModifications.js"]
 
+  container_depends_on = [{
+    containerName = "datadog"
+    condition     = "START"
+  }]
+
   linux_parameters = {
     capabilities = {
       add  = []

--- a/terraform/modules/sqs_consumer_task/compute.tf
+++ b/terraform/modules/sqs_consumer_task/compute.tf
@@ -37,6 +37,11 @@ module "consumer_task_definition" {
   stop_timeout             = var.stop_timeout_seconds
   command                  = var.consumer_task_command
 
+  container_depends_on = [{
+    containerName = "datadog"
+    condition     = "START"
+  }]
+
   linux_parameters = {
     capabilities = {
       add  = []

--- a/terraform/modules/sqs_consumer_task/compute.tf
+++ b/terraform/modules/sqs_consumer_task/compute.tf
@@ -26,7 +26,7 @@ resource "aws_ecs_service" "default" {
   ]
 }
 
-module "consumer_task_definition" {
+module "consumer_container_definition" {
   source  = "cloudposse/ecs-container-definition/aws"
   version = "0.60.0"
 
@@ -121,7 +121,7 @@ resource "aws_ecs_task_definition" "consumer" {
   }
 
   container_definitions = jsonencode([
-    module.consumer_task_definition.json_map_object,
+    module.consumer_container_definition.json_map_object,
     module.datadog_container_definition.json_map_object,
   ])
 


### PR DESCRIPTION
## Description

This PR modifies a few container definitions to explicitly declare [dependencies](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_ContainerDependency.html) on datadog containers, implementing a [suggestion](https://github.com/usdigitalresponse/usdr-gost/pull/1771#discussion_r1299267868) from @jakekreider in #1771. The ultimate change is to ensure that the datadog container has started before other containers that rely on the Datadog agent are allowed to start – this helps ensure that the agent can be reached by processes that need to send traces and metrics to it.

Summary of changes:
- `terraform/modules/sqs_consumer_task`: 
  - Add a main task container dependency so that ECS waits for the datadog container to reach `START` status before the main container starts.
  - Change the resource name of the main task container definition module (`api_task_definition` -> `api_container_definition`), which is more consistent with other container definitions and more reflective of what the module does.
- `terraform/modules/gost_api`:
  - Add an API task container dependency so that ECS waits for the datadog container to reach `START` status before the API container starts.
- `terraform/modules/gost_consume_grants`
  - Add a main consumer container dependency so that ECS waits for the datadog container to reach `START` status before the main container starts.
  - Change the resource name of the main task container definition module (`consumer_task_definition` -> `consumer_container_definition`), which is more consistent with other container definitions and more reflective of what the module does.

## Screenshots / Demo Video

## Testing

Should be fine to verify that the terraform plan outputted from CI reflects the new dependencies. Once deployed to Staging, we can verify the dependency is properly established and that task startups are (still) working as-expected.

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [X] Added steps to test feature/functionality manually

## Checklist
- [x] Provided ticket and description
- [x] Provided screenshots/demo
- [x] Provided testing information
- [x] Provided adequate test coverage for all new code
- [x] Added PR reviewers