### PR TITLE
Include cookies in logout request to API endpoint

### DIFF
--- a/packages/client/src/arpa_reporter/store/index.js
+++ b/packages/client/src/arpa_reporter/store/index.js
@@ -174,8 +174,9 @@ export default new Vuex.Store({
         dispatch('updateUsersRoles'),
       ]);
     },
-    logout({ commit }) {
-      fetch(apiURL('/api/sessions/logout')).then(() => commit('setUser', null));
+    async logout({ commit }) {
+      await get(apiURL('/api/sessions/logout'));
+      commit('setUser', null);
     },
     setViewPeriodID({ commit }, period_id) {
       commit('setViewPeriodID', period_id);


### PR DESCRIPTION
### Ticket #1537
## Description

Sets the `credentials: include` option when calling the `/api/sessions/logout` endpoint from the ARPA tool.

Without setting this options, fetch doesn't send the session cookie and express cannot tell the browser to clear the cookie, so the user stays logged in.

## Screenshots / Demo Video

## Testing

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [ ] Provided ticket and description
- [ ] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers