### PR TITLE
Fix another typo that snuck into audit report generation

### DIFF
--- a/packages/server/src/arpa_reporter/lib/audit-report.js
+++ b/packages/server/src/arpa_reporter/lib/audit-report.js
@@ -255,9 +255,7 @@ async function generate(requestHost) {
             return newWorkbook;
         });
 
-        const outputWorkBook = tracer.trace('XLSX.write', () => {
-            XLSX.write(workbook, { bookType: 'xlsx', type: 'buffer' });
-        });
+        const outputWorkBook = tracer.trace('XLSX.write', () => XLSX.write(workbook, { bookType: 'xlsx', type: 'buffer' }));
 
         return {
             periodId,


### PR DESCRIPTION
Quick typo fix that I overlooked in #1732!

This function was missing a return statement.