### PR TITLE
feat(arpa): skip parsing of formulae and html

### DIFF
--- a/packages/server/src/arpa_reporter/services/persist-upload.js
+++ b/packages/server/src/arpa_reporter/services/persist-upload.js
@@ -250,7 +250,7 @@ async function jsonForUpload(upload) {
                 const { size } = await fs.stat(jsonFSName(upload));
                 span.setTag('filesize-kb', Math.round(size / (2 ** 10)));
                 span.setTag('tenant-id', upload.tenant_id);
-                span.setTag('reporting-period-id', upload.reporting_perdiod_id);
+                span.setTag('reporting-period-id', upload.reporting_period_id);
                 return f;
             });
             return tracer.trace('Cryo.parse', () => Cryo.parse(file));

--- a/packages/server/src/arpa_reporter/services/persist-upload.js
+++ b/packages/server/src/arpa_reporter/services/persist-upload.js
@@ -248,9 +248,9 @@ async function jsonForUpload(upload) {
             const file = await tracer.trace('fs.readFile', async (span) => {
                 const f = await fs.readFile(jsonFSName(upload), { encoding: 'utf-8' });
                 const { size } = await fs.stat(jsonFSName(upload));
-                span.setTag('filesize-kB', Math.round(size / (2 ** 10)));
-                span.setTag('tenantId', upload.tenant_id);
-                span.setTag('reportingPeriodId', upload.reporting_perdiod_id);
+                span.setTag('filesize-kb', Math.round(size / (2 ** 10)));
+                span.setTag('tenant-id', upload.tenant_id);
+                span.setTag('reporting-period-id', upload.reporting_perdiod_id);
                 return f;
             });
             return tracer.trace('Cryo.parse', () => Cryo.parse(file));

--- a/packages/server/src/arpa_reporter/services/persist-upload.js
+++ b/packages/server/src/arpa_reporter/services/persist-upload.js
@@ -249,6 +249,8 @@ async function jsonForUpload(upload) {
                 const f = await fs.readFile(jsonFSName(upload), { encoding: 'utf-8' });
                 const { size } = await fs.stat(jsonFSName(upload));
                 span.setTag('filesize-kB', Math.round(size / (2 ** 10)));
+                span.setTag('tenantId', upload.tenant_id);
+                span.setTag('reportingPeriodId', upload.reporting_perdiod_id);
                 return f;
             });
             return tracer.trace('Cryo.parse', () => Cryo.parse(file));

--- a/packages/server/src/arpa_reporter/services/records.js
+++ b/packages/server/src/arpa_reporter/services/records.js
@@ -69,6 +69,8 @@ async function loadRecordsForUpload(upload) {
     const workbook = await workbookForUpload(upload, {
         cellDates: true,
         type: 'buffer',
+        cellHTML: false,
+        cellFormula: false,
         sheets: [CERTIFICATION_SHEET, COVER_SHEET, LOGIC_SHEET, ...Object.keys(DATA_SHEET_TYPES)],
     });
 


### PR DESCRIPTION
### Ticket #<Enter Number Here To Auto-Link>
## Description

We shouldn't actually need to preserve any formula or HTML formatting when loading an upload from disk.  We can skip this parsing to save processing time, memory and disk space (when caching uploads to JSON).

This change also adds two new tracing spans, breaking down `jsonForUpload` into disk reading and JSON parsing components.  It also adds a file size tag to the `fs.readFile` span.

## Screenshots / Demo Video

<img width="1009" alt="image" src="https://github.com/usdigitalresponse/usdr-gost/assets/11449340/1c5b09bd-1368-416b-96f7-c7e9ae64c67d">

When testing locally, cached JSON file sizes shrink by 2–300 kB with these options set.

https://app.datadoghq.com/apm/trace/755985303388168448?colorBy=service&env=sandbox&graphType=flamegraph&shouldShowLegend=true&sort=time&spanID=755985303388168448&spanViewType=metadata&timeHint=1693184401669.03

## Testing

1. Install and start up gost service locally and log in
2. Upload at least one [valid test file](https://drive.google.com/drive/folders/1B9ooTSJK5H2pCKHl5zgs4TjNeOSol1f7).
3. Generate an audit report by visiting http://localhost:8080/api/audit_report
4. Check the size of the generated JSON file (at `packages/server/data/uploads/tmp`)

### Automated and Unit Tests
- ~Added Unit tests~

### Manual tests for Reviewer
- [x] Added steps to test feature/functionality manually

## Checklist
- ~Provided ticket and description~
- [x] Provided screenshots/demo
- [x] Provided testing information
- ~Provided adequate test coverage for all new code~
- [x] Added PR reviewers