### PR TITLE
fix: ensure save button disabled for new saved searches

### DIFF
--- a/packages/client/src/components/Modals/SearchPanel.vue
+++ b/packages/client/src/components/Modals/SearchPanel.vue
@@ -171,7 +171,7 @@ const defaultCriteria = {
   fundingTypes: null,
   agency: null,
   bill: null,
-  costSharing: false,
+  costSharing: null,
   opportunityCategories: [],
   reviewStatus: [],
   postedWithin: [],
@@ -230,7 +230,9 @@ export default {
     }),
     saveEnabled() {
       // save is enabled if any criteria is not null and a title is set
-      return Object.values(this.formData.criteria).some((value) => value !== null && !(Array.isArray(value) && value.length === 0)) && this.formData.searchTitle !== null;
+      return Object.values(this.formData.criteria).some((value) => value !== null
+      && !(Array.isArray(value) && value.length === 0))
+      && this.formData.searchTitle !== null;
     },
     isEditMode() {
       return this.searchId !== null && this.searchId !== undefined && this.searchId !== 0;


### PR DESCRIPTION
### Ticket #1829
## Description
To enable the save button we check that no values have been entered into the search form by checking looking at whether they are null or empty. The 'costSharing' field defaulted to false, which meant all searches start as save-able even before the radio button is clicked.

## Screenshots / Demo Video

![Screenshot from 2023-08-29 16-43-19](https://github.com/usdigitalresponse/usdr-gost/assets/64168322/b3311c17-043c-439b-944f-f1c604259639)

## Testing

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [ ] Provided ticket and description
- [x] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [x] Added PR reviewers