### PR TITLE
Fix: reduce query complexity for getting total grants

### DIFF
--- a/packages/server/src/db/index.js
+++ b/packages/server/src/db/index.js
@@ -577,6 +577,7 @@ async function getGrantsNew(filters, paginationParams, orderingParams, tenantId,
         .modify((qb) => grantsQuery(qb, filters, agencyId, orderingParams, paginationParams));
 
     const counts = await knex(TABLES.grants)
+        .distinct()
         .modify((qb) => grantsQuery(qb, filters, agencyId, { orderBy: undefined }, null))
         .count('grant_id as total_grants');
 

--- a/packages/server/src/db/index.js
+++ b/packages/server/src/db/index.js
@@ -507,6 +507,47 @@ function buildFiltersQuery(queryBuilder, filters, agencyId) {
     );
 }
 
+function grantsQuery(queryBuilder, filters, agencyId, orderingParams, paginationParams) {
+    if (filters) {
+        if (filters.reviewStatuses?.length) {
+            queryBuilder.join(TABLES.grants_interested, `${TABLES.grants}.grant_id`, `${TABLES.grants_interested}.grant_id`)
+                .join(TABLES.interested_codes, `${TABLES.interested_codes}.id`, `${TABLES.grants_interested}.interested_code_id`);
+        }
+        if (parseInt(filters.assignedToAgencyId, 10) >= 0) {
+            queryBuilder.join(TABLES.assigned_grants_agency, `${TABLES.grants}.grant_id`, `${TABLES.assigned_grants_agency}.grant_id`);
+        }
+        buildKeywordQuery(queryBuilder, filters.includeKeywords, filters.excludeKeywords);
+        buildFiltersQuery(queryBuilder, filters, agencyId);
+    }
+    if (orderingParams.orderBy && orderingParams.orderBy !== 'undefined') {
+        if (orderingParams.orderBy.includes('interested_agencies')) {
+            // Only perform the join if it was not already performed above.
+            if (!filters.reviewStatuses?.length) {
+                queryBuilder.leftJoin(TABLES.grants_interested, `${TABLES.grants}.grant_id`, `${TABLES.grants_interested}.grant_id`);
+            }
+            const orderArgs = orderingParams.orderBy.split('|');
+            queryBuilder.orderBy(`${TABLES.grants_interested}.grant_id`, orderArgs[1]);
+            queryBuilder.orderBy(`${TABLES.grants}.grant_id`, orderArgs[1]);
+        } else if (orderingParams.orderBy.includes('viewed_by')) {
+            const orderArgs = orderingParams.orderBy.split('|');
+            queryBuilder.leftJoin(TABLES.grants_viewed, `${TABLES.grants}.grant_id`, `${TABLES.grants_viewed}.grant_id`);
+            queryBuilder.orderBy(`${TABLES.grants_viewed}.grant_id`, orderArgs[1]);
+            queryBuilder.orderBy(`${TABLES.grants}.grant_id`, orderArgs[1]);
+        } else {
+            const orderArgs = orderingParams.orderBy.split('|');
+            const orderDirection = ((orderingParams.orderDesc === 'true') ? 'desc' : 'asc');
+            if (orderArgs.length > 1) {
+                console.log(`Too many orderArgs: ${orderArgs}`);
+            }
+            queryBuilder.orderBy(orderArgs[0], orderDirection);
+        }
+    }
+    if (paginationParams) {
+        queryBuilder.limit(paginationParams.perPage);
+        queryBuilder.offset((paginationParams.currentPage - 1) * paginationParams.perPage);
+    }
+}
+
 /*
     filters: {
         reviewStatuses: List[Enum['Interested', 'Result', 'Rejected']],
@@ -530,46 +571,19 @@ function buildFiltersQuery(queryBuilder, filters, agencyId) {
 */
 async function getGrantsNew(filters, paginationParams, orderingParams, tenantId, agencyId) {
     console.log(filters, paginationParams, orderingParams, tenantId, agencyId);
-    const { data, pagination } = await knex(TABLES.grants)
+    const data = await knex(TABLES.grants)
         .select(`${TABLES.grants}.*`)
         .distinct()
-        .modify((queryBuilder) => {
-            if (filters) {
-                if (filters.reviewStatuses?.length) {
-                    queryBuilder.join(TABLES.grants_interested, `${TABLES.grants}.grant_id`, `${TABLES.grants_interested}.grant_id`)
-                        .join(TABLES.interested_codes, `${TABLES.interested_codes}.id`, `${TABLES.grants_interested}.interested_code_id`);
-                }
-                if (parseInt(filters.assignedToAgencyId, 10) >= 0) {
-                    queryBuilder.join(TABLES.assigned_grants_agency, `${TABLES.grants}.grant_id`, `${TABLES.assigned_grants_agency}.grant_id`);
-                }
-                buildKeywordQuery(queryBuilder, filters.includeKeywords, filters.excludeKeywords);
-                buildFiltersQuery(queryBuilder, filters, agencyId);
-            }
-            if (orderingParams.orderBy && orderingParams.orderBy !== 'undefined') {
-                if (orderingParams.orderBy.includes('interested_agencies')) {
-                    // Only perform the join if it was not already performed above.
-                    if (!filters.reviewStatuses?.length) {
-                        queryBuilder.leftJoin(TABLES.grants_interested, `${TABLES.grants}.grant_id`, `${TABLES.grants_interested}.grant_id`);
-                    }
-                    const orderArgs = orderingParams.orderBy.split('|');
-                    queryBuilder.orderBy(`${TABLES.grants_interested}.grant_id`, orderArgs[1]);
-                    queryBuilder.orderBy(`${TABLES.grants}.grant_id`, orderArgs[1]);
-                } else if (orderingParams.orderBy.includes('viewed_by')) {
-                    const orderArgs = orderingParams.orderBy.split('|');
-                    queryBuilder.leftJoin(TABLES.grants_viewed, `${TABLES.grants}.grant_id`, `${TABLES.grants_viewed}.grant_id`);
-                    queryBuilder.orderBy(`${TABLES.grants_viewed}.grant_id`, orderArgs[1]);
-                    queryBuilder.orderBy(`${TABLES.grants}.grant_id`, orderArgs[1]);
-                } else {
-                    const orderArgs = orderingParams.orderBy.split('|');
-                    const orderDirection = ((orderingParams.orderDesc === 'true') ? 'desc' : 'asc');
-                    if (orderArgs.length > 1) {
-                        console.log(`Too many orderArgs: ${orderArgs}`);
-                    }
-                    queryBuilder.orderBy(orderArgs[0], orderDirection);
-                }
-            }
-        })
-        .paginate(paginationParams);
+        .modify((qb) => grantsQuery(qb, filters, agencyId, orderingParams, paginationParams));
+
+    const counts = await knex(TABLES.grants)
+        .modify((qb) => grantsQuery(qb, filters, agencyId, { orderBy: undefined }, null))
+        .count('grant_id as total_grants');
+
+    const pagination = {
+        total: counts[0].total_grants,
+        lastPage: Math.ceil(parseInt(counts[0].total_grants, 10) / parseInt(paginationParams.perPage, 10)),
+    };
 
     const dataWithAgency = await enhanceGrantData(tenantId, data);
 

--- a/packages/server/src/routes/grants.js
+++ b/packages/server/src/routes/grants.js
@@ -111,6 +111,12 @@ router.get('/closestGrants/:perPage/:currentPage', requireUser, async (req, res)
     res.json(rows);
 });
 
+router.get('/exportCSVNext', requireUser, async (req, res) => {
+    console.log(req, res);
+    // Make a CSV file and upload it to S3
+    // Send email to user with a signed link to download the file
+});
+
 // For API tests, reduce the limit to 100 -- this is so we can test the logic around the limit
 // without the test having to insert 10k rows, which slows down the test.
 const MAX_CSV_EXPORT_ROWS = process.env.NODE_ENV !== 'test' ? 10000 : 100;


### PR DESCRIPTION
### Ticket #1829 
## Description

## Screenshots / Demo Video

```sql
/* Query for retrieving all the data. The thing to note here is that it has not changed for the given set of parameters. */
SELECT DISTINCT "grants".*
FROM            "grants"
CROSS JOIN      To_tsquery('english', '(health) & !(fire)') AS tsq
WHERE           (
                                "tsq" @@ title_ts
                OR              "tsq" @@ description_ts)
AND             (
                                "eligibility_codes" ~ '00|01'
                AND             "grants"."opportunity_status" IN ('posted'))
ORDER BY        "open_date" DESC limit 50


/* New query that retrieves the totals. Note: it now counts the number of distinct grant_ids rather than  all columns.*/
SELECT DISTINCT Count("grant_id") AS "total_grants"
FROM            "grants"
CROSS JOIN      To_tsquery('english', '(health) & !(fire)') AS tsq
WHERE           (
                                "tsq" @@ title_ts
                OR              "tsq" @@ description_ts)
AND             (
                                "eligibility_codes" ~ '00|01'
                AND             "grants"."opportunity_status" IN ('posted'))

 Unique  (cost=66.64..66.64 rows=1 width=8) (actual time=0.644..0.645 rows=1 loops=1)
   ->  Sort  (cost=66.64..66.64 rows=1 width=8) (actual time=0.643..0.644 rows=1 loops=1)
         Sort Key: (count(grants.grant_id))
         Sort Method: quicksort  Memory: 25kB
         ->  Aggregate  (cost=66.62..66.63 rows=1 width=8) (actual time=0.630..0.630 rows=1 loops=1)
               ->  Seq Scan on grants  (cost=0.00..66.56 rows=22 width=6) (actual time=0.044..0.621 rows=32 loops=1)
                     Filter: ((eligibility_codes ~ '00|01'::text) AND (opportunity_status = 'posted'::text) AND (('''health'' & !''fire'''::tsquery @@ title_ts) OR ('''health'' & !''fire'''::tsquery @@ description_ts)))
                     Rows Removed by Filter: 346
 Planning Time: 5.385 ms
 Execution Time: 0.686 ms
(10 rows)


/* old totals query which currently has performance issues in staging */
SELECT Count(*) AS "total"
FROM   (
                       SELECT DISTINCT "grants".*
                       FROM            "grants"
                       CROSS JOIN      To_tsquery('english', '(health) & !(fire)') AS tsq
                       WHERE           (
                                                       "tsq" @@ title_ts
                                       OR              "tsq" @@ description_ts)
                       AND             (
                                                       "eligibility_codes" ~ '00|01'
                                       AND             "grants"."opportunity_status" IN ('posted'))) AS "count__query__" limit 1

 Limit  (cost=68.76..68.77 rows=1 width=8) (actual time=18.252..18.253 rows=1 loops=1)
   ->  Aggregate  (cost=68.76..68.77 rows=1 width=8) (actual time=18.251..18.251 rows=1 loops=1)
         ->  Unique  (cost=67.05..68.48 rows=22 width=1777) (actual time=16.257..18.241 rows=32 loops=1)
               ->  Sort  (cost=67.05..67.11 rows=22 width=1777) (actual time=15.845..15.849 rows=32 loops=1)
                     Sort Key: grants.grant_id, grants.grant_number, grants.title, grants.status, grants.agency_code, grants.award_ceiling, grants.cost_sharing, grants.cfda_list, grants.open_date, grants.close_date, grants.reviewer_name, grants.opportunity_category, grants.search_terms, grants.notes, grants.created_at, grants.updated_at, grants.description, grants.eligibility_codes, grants.raw_body, grants.award_floor, grants.revision_id, grants.title_ts, grants.description_ts, grants.funding_instrument_codes, grants.bill
                     Sort Method: quicksort  Memory: 86kB
                     ->  Seq Scan on grants  (cost=0.00..66.56 rows=22 width=1777) (actual time=1.093..3.780 rows=32 loops=1)
                           Filter: ((eligibility_codes ~ '00|01'::text) AND (opportunity_status = 'posted'::text) AND (('''health'' & !''fire'''::tsquery @@ title_ts) OR ('''health'' & !''fire'''::tsquery @@ description_ts)))
                           Rows Removed by Filter: 346
 Planning Time: 60.872 ms
 Execution Time: 26.250 ms
(11 rows)
```

## Testing

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [ ] Provided ticket and description
- [ ] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers