### PR TITLE
fix: correctly apply distinct and resolve ambiguous column

### DIFF
--- a/packages/server/src/db/index.js
+++ b/packages/server/src/db/index.js
@@ -577,9 +577,8 @@ async function getGrantsNew(filters, paginationParams, orderingParams, tenantId,
         .modify((qb) => grantsQuery(qb, filters, agencyId, orderingParams, paginationParams));
 
     const counts = await knex(TABLES.grants)
-        .distinct()
         .modify((qb) => grantsQuery(qb, filters, agencyId, { orderBy: undefined }, null))
-        .count('grant_id as total_grants');
+        .countDistinct('grants.grant_id as total_grants');
 
     const pagination = {
         total: counts[0].total_grants,


### PR DESCRIPTION
### Ticket #1829 
## Description

## Screenshots / Demo Video
```sql
SELECT     Count(DISTINCT "grants"."grant_id") AS "total_grants"
FROM       "grants"
CROSS JOIN To_tsquery('english', '(health) & !(fire)') AS tsq
WHERE      (
                      "tsq" @@ title_ts
           OR         "tsq" @@ description_ts)
AND        (
                      "eligibility_codes" ~ '00|01'
           AND        "grants"."opportunity_status" IN ('posted'))
```

## Testing

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [ ] Provided ticket and description
- [ ] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers