### PR TITLE
Saved search UI bug fixes

### DIFF
--- a/packages/client/src/components/Modals/SavedSearchPanel.vue
+++ b/packages/client/src/components/Modals/SavedSearchPanel.vue
@@ -34,7 +34,7 @@
                 <b-icon icon="three-dots-vertical" class="text-dark" font-scale="1"></b-icon>
               </template>
               <b-dropdown-item :searchId="search.id" @click.stop="editSavedSearch">Edit</b-dropdown-item>
-              <b-dropdown-item @click="deleteSavedSearch" :searchId="search.id">Delete</b-dropdown-item>
+              <b-dropdown-item @click.stop="deleteSavedSearch" :searchId="search.id">Delete</b-dropdown-item>
             </b-dropdown>
           </b-col>
         </b-row>
@@ -127,10 +127,11 @@ export default {
     newSavedSearch() {
       this.initNewSearch();
     },
-    deleteSavedSearch(e) {
+    async deleteSavedSearch(e) {
       const searchId = `${e.target.getAttribute('searchid')}`;
-      this.deleteSavedSearchAPI({ searchId });
+      await this.deleteSavedSearchAPI({ searchId });
       this.fetchSavedSearches();
+      this.notifyDeleted();
     },
     appylySavedSearch(searchId) {
       const searchData = this.savedSearches.data.find((search) => search.id === searchId);
@@ -141,6 +142,14 @@ export default {
     formatCriteria(criteria) {
       const criteriaObj = JSON.parse(criteria);
       return formatFilterDisplay(criteriaObj);
+    },
+    notifyDeleted() {
+      this.$bvToast.toast('Search deleted', {
+        title: 'Success',
+        variant: 'success',
+        solid: true,
+        autoHideDelay: 2500,
+      });
     },
   },
 };

--- a/packages/client/src/components/Modals/SearchPanel.vue
+++ b/packages/client/src/components/Modals/SearchPanel.vue
@@ -294,7 +294,7 @@ export default {
       this.apply();
       let searchId;
       if (this.isEditMode) {
-        this.updateSavedSearch({
+        await this.updateSavedSearch({
           searchId: this.formData.searchId,
           searchInfo: {
             name: this.formData.searchTitle,

--- a/packages/client/src/components/SearchFilter.vue
+++ b/packages/client/src/components/SearchFilter.vue
@@ -4,7 +4,7 @@
       <div class="align-self-end">
         <h4 class="mb-0">{{ selectedSearch === null ? "All Grants" : searchName }} </h4>
         <span v-if="selectedSearch !== null">
-          <a href="#" v-on:click.prevent="editFilter">Edit</a> | <a href="#" v-on:click.prevent="clearAll" v-if="$props.filterKeys.length > 0">Clear</a>
+          <a href="#" v-on:click.prevent="editFilter">Edit</a> | <a href="#" v-on:click.prevent="clearAll" >Clear</a>
         </span>
       </div>
       <span class="filter-item" v-for="(item, idx) in $props.filterKeys" :key="idx">

--- a/packages/client/src/store/modules/grants.js
+++ b/packages/client/src/store/modules/grants.js
@@ -210,11 +210,11 @@ export default {
     async createSavedSearch(context, { searchInfo }) {
       return fetchApi.post('/api/organizations/:organizationId/grants-saved-search', searchInfo);
     },
-    updateSavedSearch(context, { searchId, searchInfo }) {
-      fetchApi.put(`/api/organizations/:organizationId/grants-saved-search/${searchId}`, searchInfo);
+    async updateSavedSearch(context, { searchId, searchInfo }) {
+      await fetchApi.put(`/api/organizations/:organizationId/grants-saved-search/${searchId}`, searchInfo);
     },
-    deleteSavedSearch(context, { searchId }) {
-      fetchApi.deleteRequest(`/api/organizations/:organizationId/grants-saved-search/${searchId}`);
+    async deleteSavedSearch(context, { searchId }) {
+      await fetchApi.deleteRequest(`/api/organizations/:organizationId/grants-saved-search/${searchId}`);
     },
     changeSelectedSearchId({ commit }, searchId) {
       commit('SET_SELECTED_SEARCH_ID', searchId);

--- a/packages/server/src/routes/grantsSavedSearch.js
+++ b/packages/server/src/routes/grantsSavedSearch.js
@@ -68,7 +68,7 @@ router.delete('/:searchId', requireUser, async (req, res) => {
     }
 
     if (deleteSuccess) {
-        res.status(200).send('OK');
+        res.status(200).json({ status: 'OK' });
     } else {
         res.status(404).send('Could not find the saved search');
     }


### PR DESCRIPTION
### Ticket #1829
## Description
- Ensure update operation is complete before fetching saved searches
- Stop click event on delete from propagating to parent row
- Return JSON from delete endpoint
- Ensure delete operation completed before fetching searches
- Add simple toast notification when deleting a search
- Always show "Clear" button if filters displayed

## Screenshots / Demo Video
Delete toast

https://github.com/usdigitalresponse/usdr-gost/assets/624510/c0277caf-b695-4505-ab3c-15a230c926db



## Testing
See bug tests and/or [Search QA for Demo](https://docs.google.com/document/d/1FXj7E8aA9pAMyWE6SSpupD-leMXznrBhOa7B_12HnjM/edit#heading=h.s7nbrmr29osw)

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [x] Provided ticket and description
- [x] Provided screenshots/demo
- [x] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [x] Added PR reviewers