### PR TITLE
fix: resizes contents of grants table

### DIFF
--- a/packages/client/src/components/GrantsTableNext.vue
+++ b/packages/client/src/components/GrantsTableNext.vue
@@ -24,7 +24,7 @@
     </b-row>
     <b-row align-v="center">
       <b-col cols="12">
-        <b-table fixed id="grants-table" sticky-header="600px" hover :items="formattedGrants" responsive
+        <b-table fixed id="grants-table" sticky-header="500px" hover :items="formattedGrants" responsive
           :fields="fields.filter(field => !field.hideGrantItem)" selectable striped :sort-by.sync="orderBy"
           :sort-desc.sync="orderDesc" :no-local-sorting="true" :bordered="true" select-mode="single" :busy="loading"
           @row-selected="onRowSelected" show-empty emptyText="No matches found">

--- a/packages/client/src/components/GrantsTableNext.vue
+++ b/packages/client/src/components/GrantsTableNext.vue
@@ -24,7 +24,7 @@
     </b-row>
     <b-row align-v="center">
       <b-col cols="12">
-        <b-table fixed id="grants-table" sticky-header="500px" hover :items="formattedGrants" responsive
+        <b-table fixed id="grants-table" sticky-header="450px" hover :items="formattedGrants" responsive
           :fields="fields.filter(field => !field.hideGrantItem)" selectable striped :sort-by.sync="orderBy"
           :sort-desc.sync="orderDesc" :no-local-sorting="true" :bordered="true" select-mode="single" :busy="loading"
           @row-selected="onRowSelected" show-empty emptyText="No matches found">


### PR DESCRIPTION
### Ticket #1829 
## Description
- Reduces max-height of the grants-table by 150px. See: https://bootstrap-vue.org/docs/components/table#sticky-headers
- Goal here is to make sure the table renders with the pagination options on a 13" laptop

## Screenshots / Demo Video

### Before
<img width="1680" alt="image" src="https://github.com/usdigitalresponse/usdr-gost/assets/6497366/f3f0f653-816a-4252-85be-b22f78c8fdbe">

### After
<img width="1680" alt="image" src="https://github.com/usdigitalresponse/usdr-gost/assets/6497366/ff4b5ab1-af16-4955-851d-0c00ee468ea1">


## Testing

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [ ] Provided ticket and description
- [ ] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers