### PR TITLE
Sidebar backdrop for grants search and saved search

### DIFF
--- a/packages/client/src/components/Modals/SavedSearchPanel.vue
+++ b/packages/client/src/components/Modals/SavedSearchPanel.vue
@@ -9,6 +9,8 @@
       model="displaySavedSearchPanel"
       ref="savedSearchPanel"
       bg-variant="white"
+      @hidden="cancel"
+      backdrop
       right
       shadow
     >
@@ -156,6 +158,13 @@ export default {
         autoHideDelay: 2500,
         toaster: 'b-toaster-bottom-right',
       });
+    },
+    cancel() {
+      // something closed the sidebar outside of the state store actions
+      // so we need to reset the state
+      if (this.displaySavedSearchPanel) {
+        this.initViewResults();
+      }
     },
   },
 };

--- a/packages/client/src/components/Modals/SearchPanel.vue
+++ b/packages/client/src/components/Modals/SearchPanel.vue
@@ -10,6 +10,8 @@
         class="search-panel"
         bg-variant="white"
         @shown="onShown"
+        @hidden="cancel"
+        backdrop
         right
         shadow
       >
@@ -218,6 +220,9 @@ export default {
         this.$refs.searchPanelSideBar.hide();
       }
     },
+    isEditMode() {
+      this.initFormState();
+    },
   },
   mounted() {
     this.setup();
@@ -270,7 +275,11 @@ export default {
       this.initViewResults();
     },
     cancel() {
-      this.initViewResults();
+      // something closed the sidebar outside of the state store actions
+      // so we need to reset the state
+      if (this.displaySearchPanel) {
+        this.initViewResults();
+      }
     },
     initFormState() {
       if (this.isEditMode) {

--- a/packages/client/src/store/modules/grants.js
+++ b/packages/client/src/store/modules/grants.js
@@ -246,6 +246,7 @@ export default {
     },
     // table action state
     initNewSearch(context) {
+      context.commit('SET_EDITING_SEARCH_ID', null);
       context.commit('SET_TABLE_MODE', tableModes.CREATE);
     },
     initEditSearch(context, searchId) {


### PR DESCRIPTION
### Ticket #1829
## Description
Adds a backdrop to each sidebar, which adds a dark backdrop to the rest of the page, and most importantly, closes the sidebar when the user clicks outside. 

## Screenshots / Demo Video

https://github.com/usdigitalresponse/usdr-gost/assets/624510/db9af24e-ea36-4886-ad85-acde6f457902


## Testing
Open/close both side bars through different means

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [x] Provided ticket and description
- [x] Provided screenshots/demo
- [x] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [x] Added PR reviewers