### PR TITLE
feat: display error message when search title already exists

### DIFF
--- a/packages/client/src/components/Modals/SearchPanel.vue
+++ b/packages/client/src/components/Modals/SearchPanel.vue
@@ -304,27 +304,41 @@ export default {
     async saveSearch() {
       this.apply();
       let searchId;
-      if (this.isEditMode) {
-        await this.updateSavedSearch({
-          searchId: this.formData.searchId,
-          searchInfo: {
-            name: this.formData.searchTitle,
-            criteria: this.formData.criteria,
-          },
-        });
-        searchId = this.formData.searchId;
-        this.$emit('filters-applied');
-      } else {
-        const res = await this.createSavedSearch({
-          searchInfo: {
-            name: this.formData.searchTitle,
-            criteria: this.formData.criteria,
-          },
-        });
-        searchId = res.id;
+      try {
+        if (this.isEditMode) {
+          this.updateSavedSearch({
+            searchId: this.formData.searchId,
+            searchInfo: {
+              name: this.formData.searchTitle,
+              criteria: this.formData.criteria,
+            },
+          });
+          searchId = this.formData.searchId;
+          this.$emit('filters-applied');
+        } else {
+          const res = await this.createSavedSearch({
+            searchInfo: {
+              name: this.formData.searchTitle,
+              criteria: this.formData.criteria,
+            },
+          });
+          searchId = res.id;
+        }
+        await this.fetchSavedSearches();
+        this.changeSelectedSearchId(searchId);
+      } catch (e) {
+        this.notifyError(e.message);
       }
-      await this.fetchSavedSearches();
-      this.changeSelectedSearchId(searchId);
+    },
+    notifyError(message) {
+      this.$bvToast.toast(message,
+        {
+          title: 'Error Saving Search',
+          variant: 'danger',
+          solid: true,
+          autoHideDelay: 5000,
+          toaster: 'b-toaster-top-left',
+        });
     },
     showSideBar() {
       if (!this.$refs.searchPanelSideBar.isOpen) {

--- a/packages/server/__tests__/api/grantsSavedSearch.test.js
+++ b/packages/server/__tests__/api/grantsSavedSearch.test.js
@@ -126,6 +126,24 @@ describe('`/api/grants-saved-search` endpoint', () => {
                 });
                 expect(response.statusText).to.equal('Forbidden');
             });
+            it('cannot create a second saved search of the same name', async () => {
+                const response = await fetchApi(`/grants-saved-search`, agencies.admin.own, {
+                    ...fetchOptions.admin,
+                    method: 'post',
+                    body: JSON.stringify({ name: 'Search2', criteria: '' }),
+                });
+                expect(response.statusText).to.equal('OK');
+                const json = await response.json();
+                idsToDelete.push(json.id);
+
+                const response2 = await fetchApi(`/grants-saved-search`, agencies.admin.own, {
+                    ...fetchOptions.admin,
+                    method: 'post',
+                    body: JSON.stringify({ name: 'Search2', criteria: '' }),
+                });
+                expect(response2.statusText).to.equal('Bad Request');
+                expect(await response2.text()).to.contain('already exists');
+            });
         });
     });
     context('DELETE /grants-saved-search/:id (delete a saved search for an agency)', () => {

--- a/packages/server/src/routes/grantsSavedSearch.js
+++ b/packages/server/src/routes/grantsSavedSearch.js
@@ -30,6 +30,11 @@ router.post('/', requireUser, async (req, res) => {
 
         res.json(result);
     } catch (e) {
+        if (e.constraint && e.constraint.includes('grants_saved_searches_name_created_by_idx')) {
+            console.warn(e);
+            res.status(400).send(`Title '${req.body.name}' already exists`);
+            return;
+        }
         console.error(e);
         res.status(500).send('Unable to create saved search. Please reach out to grants-helpdesk@usdigitalresponse.org');
     }


### PR DESCRIPTION
### Ticket #1829 
## Description

Shows a toast with red text when a user makes a second search with the same title.

## Screenshots / Demo Video
[Screencast from 09-03-2023 06:15:08 PM.webm](https://github.com/usdigitalresponse/usdr-gost/assets/64168322/00ec1839-418c-413e-b24e-4b199cf525e4)

## Testing

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [ ] Provided ticket and description
- [ ] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers