### PR TITLE
Parallelize Audit Report generation

### DIFF
--- a/packages/server/src/arpa_reporter/lib/audit-report.js
+++ b/packages/server/src/arpa_reporter/lib/audit-report.js
@@ -151,7 +151,7 @@ async function createReportsGroupedByProject(periodId) {
         const allReportingPeriods = Array.from(new Set(projectRecords.map((r) => r.upload.reporting_period_id)));
 
         // initialize the columns in the row
-        allReportingPeriods.forEach(async (reportingPeriodId) => {
+        allReportingPeriods.forEach((reportingPeriodId) => {
             const reportingPeriodEndDate = reportingPeriods.filter((reportingPeriod) => reportingPeriod.id === reportingPeriodId)[0].end_date;
             [
                 `${reportingPeriodEndDate} Total Aggregate Expenditures`,
@@ -164,7 +164,7 @@ async function createReportsGroupedByProject(periodId) {
         row['Capital Expenditure Amount'] = 0;
 
         // set values in each column
-        projectRecords.forEach(async (r) => {
+        projectRecords.forEach((r) => {
             // for project summaries v2 report
             const reportingPeriodEndDate = reportingPeriods.filter((reportingPeriod) => r.upload.reporting_period_id === reportingPeriod.id)[0].end_date;
             row[`${reportingPeriodEndDate} Total Aggregate Expenditures`] += (r.content.Total_Expenditures__c || 0);

--- a/packages/server/src/arpa_reporter/lib/audit-report.js
+++ b/packages/server/src/arpa_reporter/lib/audit-report.js
@@ -39,7 +39,7 @@ async function createObligationSheet(periodId, domain) {
             const uploads = await usedForTreasuryExport(period.id);
             const records = await recordsForReportingPeriod(period.id);
 
-            return Promise.all(uploads.map(async (upload) => {
+            return Promise.all(uploads.map((upload) => {
                 const emptyRow = {
                     'Reporting Period': period.name,
                     'Period End Date': new Date(period.end_date),


### PR DESCRIPTION
### Ticket #1132
## Description

In January, we ran into some performance bottlenecks in ARPA report generation.  At the time, the biggest issue was that XLSX parsing was both synchronous and the primary bottleneck, which could cause the server's main thread to lock up for the duration of report generation — preventing other requests from being served.

This issue was successfully mitigated by the introduction of `asyncBatch` with #834.  This improved on the situation by forcing the server to batch XLSX parsing jobs and "come up for air" between batches so that the server had the chance to handle additional requests before continuing report generation.

Following up on this initial mitigation, we introduced a filesystem cache layer for XLSX parsing (#942).

We are still seeing performance issues, but the situation is different than it was in January in a few interesting ways.
1. Instead of parsing XLSX files, reading from the filesystem cache now appears to be our biggest bottleneck.
2. Unlike XLSX parsing, reading from disk is _not_ main thread blocking, and _can_ benefit from parallelization

Building on the above with some [insights from Datadog testing](https://usdigitalresponse.slack.com/archives/C031R1Y49KL/p1693065541547659), it looks like our usages of asyncBatch may now be unnecessarily serializing some of the disk access calls which _could_ be parallelized.  For production reports with many uploads, this effect may be further exacerbated (but this remains to be verified)!

This change attempts to reclaim the benefits of parallelizing disk access by rewriting a few of our asyncBatch usages, allowing all disk reads to once again run in parallel.

## Screenshots / Demo Video

BEFORE

![image](https://github.com/usdigitalresponse/usdr-gost/assets/11449340/f158c0f8-9f30-4943-8161-f50b18e81d9b)

AFTER

![image](https://github.com/usdigitalresponse/usdr-gost/assets/11449340/95be3a1c-7662-407c-9c20-898613a96162)

## Testing

1. Boot up reporter locally
1. Visit http://localhost:8080/api/audit_report to generate an audit report synchronously
1. Verify that behaviour remains unchanged before and after the change

NOTE: _Before_ landing this change, I would really like to have some production tracing in place: both to validate this hypothesis and also to ensure that we can get a clear image of the before and after effect of this change.

### Automated and Unit Tests
- [x] Added Unit tests

### Manual tests for Reviewer
- [x] Added steps to test feature/functionality manually

## Checklist
- [x] Provided ticket and description
- [x] Provided screenshots/demo
- [x] Provided testing information
- [x] Provided adequate test coverage for all new code
- [x] Added PR reviewers