### PR TITLE
Ensure saved search persisted before refreshing data

### DIFF
--- a/packages/client/src/components/Modals/SearchPanel.vue
+++ b/packages/client/src/components/Modals/SearchPanel.vue
@@ -313,14 +313,14 @@ export default {
       let searchId;
       try {
         if (this.isEditMode) {
-          this.updateSavedSearch({
+          searchId = this.formData.searchId;
+          await this.updateSavedSearch({
             searchId: this.formData.searchId,
             searchInfo: {
               name: this.formData.searchTitle,
               criteria: this.formData.criteria,
             },
           });
-          searchId = this.formData.searchId;
           this.$emit('filters-applied');
         } else {
           const res = await this.createSavedSearch({


### PR DESCRIPTION
### Ticket #1829
## Description
The issue I was able to reproduce on staging looks like a regression of the issue fixed in #1850 - the `await` was removed when the error message was added. 

Unless that was causing some other issue and this needs to be done async for some reason? 

## Screenshots / Demo Video

## Testing
Ensure saved searches refresh when editing. 

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [x] Provided ticket and description
- [x] Provided screenshots/demo
- [x] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [x] Added PR reviewers