### PR TITLE
feat: adds index to opportunity_status field

### DIFF
--- a/packages/server/migrations/20230912195046_add-grants-opportunity-status-index.js
+++ b/packages/server/migrations/20230912195046_add-grants-opportunity-status-index.js
@@ -3,7 +3,7 @@
  * @returns { Promise<void> }
  */
 exports.up = function (knex) {
-    return knex.raw('CREATE INDEX IF NOT EXISTS idx_grants_opportunity_status ON grants USING hash (opportunity_status);');
+    return knex.raw(`CREATE INDEX IF NOT EXISTS idx_grants_opportunity_status ON grants USING btree (opportunity_status) WHERE (opportunity_status <> 'archived'::text)`);
 };
 
 /**

--- a/packages/server/migrations/20230912195046_add-grants-opportunity-status-index.js
+++ b/packages/server/migrations/20230912195046_add-grants-opportunity-status-index.js
@@ -1,0 +1,15 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function (knex) {
+    return knex.raw('CREATE INDEX IF NOT EXISTS idx_grants_opportunity_status ON grants USING hash (opportunity_status);');
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function (knex) {
+    return knex.raw('DROP INDEX IF EXISTS idx_grants_opportunity_status;');
+};

--- a/packages/server/migrations/20230912195046_add-grants-opportunity-status-index.js
+++ b/packages/server/migrations/20230912195046_add-grants-opportunity-status-index.js
@@ -11,5 +11,5 @@ exports.up = function (knex) {
  * @returns { Promise<void> }
  */
 exports.down = function (knex) {
-    return knex.raw('DROP INDEX IF EXISTS idx_grants_opportunity_status;');
+    return knex.raw('DROP INDEX IF EXISTS idx_grants_opportunity_status');
 };


### PR DESCRIPTION
### Ticket #1829 
## Description
- Adds a partial index for non-archived grants.

## Screenshots / Demo Video
```
usdr_grants=# SELECT indexdef FROM pg_indexes WHERE indexname = 'idx_grants_opportunity_status';
                                                                  indexdef                                                                   
---------------------------------------------------------------------------------------------------------------------------------------------
 CREATE INDEX idx_grants_opportunity_status ON public.grants USING btree (opportunity_status) WHERE (opportunity_status <> 'archived'::text)
(1 row)

usdr_grants=# reset work_mem;
RESET
usdr_grants=# explain analyze select distinct "grants".* from "grants" where ("grants"."opportunity_status" <> 'archived') order by "open_date" desc limit 50;
                                                                                                                                                                                     QUERY PLAN                                                                                                                                                                                     
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=15302.75..15306.13 rows=50 width=1361) (actual time=51.092..51.442 rows=50 loops=1)
   ->  Unique  (cost=15302.75..15911.87 rows=9024 width=1361) (actual time=51.091..51.435 rows=50 loops=1)
         ->  Sort  (cost=15302.75..15325.31 rows=9024 width=1361) (actual time=51.089..51.130 rows=50 loops=1)
               Sort Key: open_date DESC, grant_id, grant_number, title, status, agency_code, award_ceiling, cost_sharing, cfda_list, close_date, reviewer_name, opportunity_category, search_terms, notes, created_at, updated_at, description, eligibility_codes, raw_body, opportunity_status, award_floor, revision_id, title_ts, description_ts, funding_instrument_codes, bill
               Sort Method: external merge  Disk: 11432kB
               ->  Index Scan using idx_grants_opportunity_status on grants  (cost=0.29..9340.89 rows=9024 width=1361) (actual time=0.018..21.996 rows=9086 loops=1)
 Planning Time: 0.309 ms
 Execution Time: 54.092 ms
(8 rows)

usdr_grants=# 
```
## Testing
```
yarn db:rollback
```
<img width="537" alt="image" src="https://github.com/usdigitalresponse/usdr-gost/assets/6497366/cb86d372-a512-48f7-bc0c-25910d072f0d">

```
yarn db:migrate
```
<img width="1138" alt="image" src="https://github.com/usdigitalresponse/usdr-gost/assets/6497366/265f3196-8394-4d05-a67e-26b495762ca6">

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [ ] Provided ticket and description
- [ ] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers