### PR TITLE
fix: ignore closed and archived grants by default

### DIFF
--- a/packages/client/src/components/GrantsTable.vue
+++ b/packages/client/src/components/GrantsTable.vue
@@ -143,7 +143,7 @@ export default {
       searchInput: null,
       debouncedSearchInput: null,
       reviewStatusFilters: [],
-      opportunityStatusFilters: [],
+      opportunityStatusFilters: ['Forecasted', 'Posted'],
       opportunityCategoryFilters: [],
       costSharingFilter: null,
       reviewStatusOptions: ['interested', 'result', 'rejected'],

--- a/packages/client/src/components/Modals/SearchPanel.vue
+++ b/packages/client/src/components/Modals/SearchPanel.vue
@@ -226,7 +226,7 @@ const defaultCriteria = {
   includeKeywords: null,
   excludeKeywords: null,
   opportunityNumber: null,
-  opportunityStatuses: ['forecasted', 'posted'],
+  opportunityStatuses: ['posted'],
   fundingTypes: null,
   agency: null,
   bill: null,
@@ -264,7 +264,6 @@ export default {
         { code: 'O', name: 'Other' },
       ],
       opportunityStatusOptions: [
-        { text: 'Forecasted', value: 'forecasted' },
         { text: 'Posted', value: 'posted' },
         { text: 'Closed / Archived', value: ['closed', 'archived'] },
       ],

--- a/packages/client/src/components/Modals/SearchPanel.vue
+++ b/packages/client/src/components/Modals/SearchPanel.vue
@@ -226,7 +226,7 @@ const defaultCriteria = {
   includeKeywords: null,
   excludeKeywords: null,
   opportunityNumber: null,
-  opportunityStatuses: [],
+  opportunityStatuses: ['forecasted', 'posted'],
   fundingTypes: null,
   agency: null,
   bill: null,
@@ -266,8 +266,7 @@ export default {
       opportunityStatusOptions: [
         { text: 'Forecasted', value: 'forecasted' },
         { text: 'Posted', value: 'posted' },
-        { text: 'Closed', value: 'closed' },
-        { text: 'Archived', value: 'archived' },
+        { text: 'Closed / Archived', value: ['closed', 'archived'] },
       ],
     };
   },

--- a/packages/client/src/store/modules/grants.js
+++ b/packages/client/src/store/modules/grants.js
@@ -62,6 +62,10 @@ function buildGrantsNextQuery({ filters, ordering, pagination }) {
   criteria.fundingTypes = criteria.fundingTypes?.map((f) => f.code);
   criteria.bill = criteria.bill === 'All Bills' ? null : criteria.bill;
 
+  if (!criteria.opportunityStatuses || criteria.opportunityStatuses.length === 0) {
+    // by default, only show posted and forecasted opportunities
+    criteria.opportunityStatuses = ['posted', 'forecasted'];
+  }
   const paginationQuery = Object.entries(pagination)
     // filter out undefined and nulls since api expects parameters not present as undefined
     // eslint-disable-next-line no-unused-vars

--- a/packages/client/src/store/modules/grants.js
+++ b/packages/client/src/store/modules/grants.js
@@ -63,8 +63,8 @@ function buildGrantsNextQuery({ filters, ordering, pagination }) {
   criteria.bill = criteria.bill === 'All Bills' ? null : criteria.bill;
 
   if (!criteria.opportunityStatuses || criteria.opportunityStatuses.length === 0) {
-    // by default, only show posted and forecasted opportunities
-    criteria.opportunityStatuses = ['posted', 'forecasted'];
+    // by default, only show posted opportunities
+    criteria.opportunityStatuses = ['posted'];
   }
   const paginationQuery = Object.entries(pagination)
     // filter out undefined and nulls since api expects parameters not present as undefined


### PR DESCRIPTION
### Ticket #1829
## Description
- Search panel defaults to selecting Posted and Forecasted
- Search panel consolidates Closed and Archived
- Old search defaults to Posted and Forecasted

## Screenshots / Demo Video
### Old search flow defaults to filtering by posted or forecasted
<img width="834" alt="image" src="https://github.com/usdigitalresponse/usdr-gost/assets/6497366/79e5d72e-03c3-47b1-acec-86404b683ff0">

### Can access all grants in old search flow by explicitly selecting all grant statuses
<img width="934" alt="image" src="https://github.com/usdigitalresponse/usdr-gost/assets/6497366/74ee6ee2-20b4-4f73-ae18-ac1ccd847524">

### New search flow defaults to loading only posted and forecasted grants
<img width="662" alt="image" src="https://github.com/usdigitalresponse/usdr-gost/assets/6497366/83a53b35-83c0-43a9-886a-bb93822d0fc4">

### New search panel
<img width="478" alt="image" src="https://github.com/usdigitalresponse/usdr-gost/assets/6497366/b1d79857-3c62-44dc-bca9-9fd9082ea317">

### New search loads all grants if explicitly selected
<img width="624" alt="image" src="https://github.com/usdigitalresponse/usdr-gost/assets/6497366/eeaace63-9745-462b-954d-053a46812f8c">

## Testing

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [ ] Provided ticket and description
- [ ] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers