### PR TITLE
fix: removes view all grants button from digest

### DIFF
--- a/packages/server/src/lib/email.js
+++ b/packages/server/src/lib/email.js
@@ -203,10 +203,8 @@ async function buildDigestBody(matchedGrants) {
 
     let additionalBody = grantDetails.join(contentSpacerStr);
 
-    if (matchedGrants.length > 30) {
-        const additionalButtonTemplate = fileSystem.readFileSync(path.join(__dirname, '../static/email_templates/_additional_grants_button.html'));
-        additionalBody += mustache.render(additionalButtonTemplate.toString(), { additional_grants_url: `${process.env.WEBSITE_DOMAIN}/#/grants` });
-    }
+    const additionalButtonTemplate = fileSystem.readFileSync(path.join(__dirname, '../static/email_templates/_additional_grants_button.html'));
+    additionalBody += mustache.render(additionalButtonTemplate.toString(), { additional_grants_url: `${process.env.WEBSITE_DOMAIN}/#/grants` });
 
     const formattedBody = mustache.render(formattedBodyTemplate.toString(), {
         body_title: 'New grants have been posted',

--- a/packages/server/src/lib/email.js
+++ b/packages/server/src/lib/email.js
@@ -131,7 +131,7 @@ function getGrantDetail(grant, emailNotificationType) {
             cost_sharing: grant.cost_sharing,
             link_url: `https://www.grants.gov/web/grants/view-opportunity.html?oppId=${grant.grant_id}`,
             grants_url: `${process.env.WEBSITE_DOMAIN}/#/${emailNotificationType === notificationType.grantDigest ? 'grants' : 'my-grants'}`,
-            view_grant_label: emailNotificationType === notificationType.grantDigest ? 'View New Grants' : 'View My Grants',
+            view_grant_label: emailNotificationType === notificationType.grantDigest ? undefined : 'View My Grants',
         },
     );
     return grantDetail;

--- a/packages/server/src/static/email_templates/_grant_detail.html
+++ b/packages/server/src/static/email_templates/_grant_detail.html
@@ -68,6 +68,7 @@
                                                 </p>
                                             </td>
                                         </tr>
+                                        {{#view_grant_label}}
                                         <tr style="border-collapse:collapse">
                                             <td align="center"
                                                 style="Margin:0;padding-left:10px;padding-right:10px;padding-top:15px;padding-bottom:25px">
@@ -85,6 +86,7 @@
                                                 <!--<![endif]-->
                                             </td>
                                         </tr>
+                                        {{/view_grant_label}}
                                     </table>
                                 </td>
                             </tr>


### PR DESCRIPTION
### Ticket #1829
## Description
- Removes the per-grant "View All grants" button

## Screenshots / Demo Video
### Before
![image](https://github.com/usdigitalresponse/usdr-gost/assets/6497366/bb288d67-b0dc-4b4c-bfb7-434973473dbc)

### After
![image](https://github.com/usdigitalresponse/usdr-gost/assets/6497366/c668301b-0c08-4f71-a31d-001428e037f7)

## Testing

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [ ] Provided ticket and description
- [ ] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers