### PR TITLE
fix: ensure archive_date is captured always

### DIFF
--- a/packages/server/src/lib/grants-ingest.js
+++ b/packages/server/src/lib/grants-ingest.js
@@ -50,9 +50,9 @@ function mapSourceDataToGrant(source) {
     grant.open_date = milestones.post_date;
     grant.close_date = milestones.close && milestones.close.date
         ? milestones.close.date : '2100-01-01';
+    grant.archive_date = milestones.archive_date;
     const today = moment().startOf('day');
     if (milestones.archive_date && today.isSameOrAfter(moment(milestones.archive_date), 'date')) {
-        grant.archive_date = milestones.archive_date;
         grant.opportunity_status = 'archived';
     } else if (today.isSameOrAfter(moment(grant.close_date), 'date')) {
         grant.opportunity_status = 'closed';


### PR DESCRIPTION
### Ticket #1829
## Description
most grants have a pre-determined archive date and having this be behind a filter that enforces the date has to be <= today eliminates any ability of us to capture these dates

## Screenshots / Demo Video

## Testing

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [ ] Provided ticket and description
- [ ] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers