### PR TITLE
fix: emails being sent to all users

### DIFF
--- a/packages/server/__tests__/db/db.test.js
+++ b/packages/server/__tests__/db/db.test.js
@@ -92,6 +92,19 @@ describe('db', () => {
                 expect(() => { JSON.parse(row.criteria); }).not.to.throw();
             }
         });
+        it('get all user saved searches for a specific user', async () => {
+            await db.createSavedSearch({
+                name: 'Example search',
+                userId: fixtures.users.subStaffUser.id,
+                criteria: BASIC_SEARCH_CRITERIA,
+            });
+
+            const data = await db.getAllUserSavedSearches(fixtures.users.subStaffUser.id);
+            expect(data.length).to.equal(1);
+            for (const row of data) {
+                expect(() => { JSON.parse(row.criteria); }).not.to.throw();
+            }
+        });
     });
 
     context('getGrantsInterested', () => {

--- a/packages/server/src/db/index.js
+++ b/packages/server/src/db/index.js
@@ -1519,14 +1519,21 @@ async function getAllUserSavedSearches(userId) {
         `${TABLES.email_subscriptions}.notification_type as notification_type`,
         `${TABLES.users}.tenant_id as tenant_id`,
         `${TABLES.users}.email as email`,
-    ).from(`${TABLES.grants_saved_searches}`).join(TABLES.users, `${TABLES.grants_saved_searches}.created_by`, '=', `${TABLES.users}.id`)
-        .leftJoin(TABLES.email_subscriptions, (builder) => {
-            builder
-                .on(`${TABLES.grants_saved_searches}.created_by`, '=', `${TABLES.email_subscriptions}.user_id`)
-                .andOn(`${TABLES.email_subscriptions}.notification_type`, '=', knex.raw('?', [emailConstants.notificationType.grantDigest]));
-        })
-        .where(`${TABLES.email_subscriptions}.status`, `${emailConstants.emailSubscriptionStatus.subscribed}`)
-        .orWhereNull(`${TABLES.email_subscriptions}.status`);
+    )
+        .from(`${TABLES.grants_saved_searches}`)
+        .join(TABLES.users, `${TABLES.grants_saved_searches}.created_by`, '=', `${TABLES.users}.id`)
+        .leftJoin(
+            TABLES.email_subscriptions, (builder) => {
+                builder
+                    .on(`${TABLES.grants_saved_searches}.created_by`, '=', `${TABLES.email_subscriptions}.user_id`)
+                    .andOn(`${TABLES.email_subscriptions}.notification_type`, '=', knex.raw('?', [emailConstants.notificationType.grantDigest]));
+            },
+        )
+        .where((q) => {
+            q
+                .where(`${TABLES.email_subscriptions}.status`, `${emailConstants.emailSubscriptionStatus.subscribed}`)
+                .orWhereNull(`${TABLES.email_subscriptions}.status`);
+        });
     if (userId) {
         query.andWhere(`${TABLES.grants_saved_searches}.created_by`, '=', userId);
     }


### PR DESCRIPTION
### Ticket #1829 
## Description
- Fixes a parentheses issue within the `where` clause. This was causing the query to return all users even if only one user was passed into the function.

## Screenshots / Demo Video
### Before
```sql
SELECT "grants_saved_searches"."id"              AS "id",
       "grants_saved_searches"."created_by"      AS "created_by",
       "grants_saved_searches"."criteria"        AS "criteria",
       "grants_saved_searches"."name"            AS "name",
       "email_subscriptions"."status"            AS "status",
       "email_subscriptions"."notification_type" AS "notification_type",
       "users"."tenant_id"                       AS "tenant_id",
       "users"."email"                           AS "email"
FROM   "grants_saved_searches"
       INNER JOIN "users"
               ON "grants_saved_searches"."created_by" = "users"."id"
       LEFT JOIN "email_subscriptions"
              ON "grants_saved_searches"."created_by" =
                 "email_subscriptions"."user_id"
                 AND "email_subscriptions"."notification_type" = 'GRANT_DIGEST'
WHERE  "email_subscriptions"."status" = 'SUBSCRIBED'
        OR "email_subscriptions"."status" IS NULL
           AND "grants_saved_searches"."created_by" = 4;
```

### After
```sql
SELECT "grants_saved_searches"."id"              AS "id",
       "grants_saved_searches"."created_by"      AS "created_by",
       "grants_saved_searches"."criteria"        AS "criteria",
       "grants_saved_searches"."name"            AS "name",
       "email_subscriptions"."status"            AS "status",
       "email_subscriptions"."notification_type" AS "notification_type",
       "users"."tenant_id"                       AS "tenant_id",
       "users"."email"                           AS "email"
FROM   "grants_saved_searches"
       INNER JOIN "users"
               ON "grants_saved_searches"."created_by" = "users"."id"
       LEFT JOIN "email_subscriptions"
              ON "grants_saved_searches"."created_by" =
                 "email_subscriptions"."user_id"
                 AND "email_subscriptions"."notification_type" = 'GRANT_DIGEST'
WHERE  ("email_subscriptions"."status" = 'SUBSCRIBED'
        OR "email_subscriptions"."status" IS NULL)
           AND "grants_saved_searches"."created_by" = 4;
```

## Testing

### Automated and Unit Tests
- [x] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [x] Provided ticket and description
- [x] Provided screenshots/demo
- [x] Provided testing information
- [x] Provided adequate test coverage for all new code
- [ ] Added PR reviewers