### PR TITLE
fix: email notifications not sending the correct grants-set

### DIFF
--- a/packages/server/__tests__/db/db.test.js
+++ b/packages/server/__tests__/db/db.test.js
@@ -27,6 +27,87 @@ describe('db', () => {
     after(async () => {
         await db.knex.destroy();
     });
+    context('Validate Search Filters', () => {
+        it('throws an error when non-existent option is passed', async () => {
+            const badFilters = {
+                nonExistentFilter: 'non existent values',
+            };
+            const errors = db.validateSearchFilters(badFilters);
+            expect(errors.length).to.equal(1);
+            expect(errors[0]).to.equal('Received invalid filter nonExistentFilter, does not exist');
+        });
+        it('throws an error when List filter-type is not an array', async () => {
+            const badFilters = {
+                reviewStatuses: 'not an array',
+                eligibilityCodes: 99,
+                includeKeywords: { 'non existent values': 'not an array' },
+                excludeKeywords: [99],
+                fundingTypes: new Set('not an array'),
+                opportunityStatuses: ['invalid'],
+                opportunityCategories: 'not an array',
+            };
+            const errors = db.validateSearchFilters(badFilters);
+            expect(errors.length).to.equal(7);
+            expect(errors[0]).to.equal('Received invalid filter reviewStatuses, expected List');
+            expect(errors[1]).to.equal('Received invalid filter eligibilityCodes, expected List');
+            expect(errors[2]).to.equal('Received invalid filter includeKeywords, expected List');
+            expect(errors[3]).to.equal('Received invalid filter excludeKeywords, expected List of String');
+            expect(errors[4]).to.equal('Received invalid filter fundingTypes, expected List');
+            expect(errors[5]).to.equal('Received invalid filter opportunityStatuses, expected List of Enum, found value invalid that is not in posted,forecasted,closed');
+            expect(errors[6]).to.equal('Received invalid filter opportunityCategories, expected List');
+        });
+        it('throws an error when String filter-type is not a string or enum', async () => {
+            const badFilters = {
+                opportunityNumber: 99,
+                costSharing: 'not a yes or no',
+                agencyCode: 99,
+                bill: 99,
+            };
+            const errors = db.validateSearchFilters(badFilters);
+            expect(errors.length).to.equal(4);
+            expect(errors[0]).to.equal('Received invalid filter opportunityNumber, expected String, received 99');
+            expect(errors[1]).to.equal('Received invalid filter costSharing, expected Enum, found value not a yes or no that is not in Yes,No');
+            expect(errors[2]).to.equal('Received invalid filter agencyCode, expected String, received 99');
+            expect(errors[3]).to.equal('Received invalid filter bill, expected String, received 99');
+        });
+        it('throws an error when Number filter-type is not a number', async () => {
+            const badFilters = {
+                postedWithinDays: 'not a number',
+                assignedToAgencyId: 'not a number',
+            };
+            const errors = db.validateSearchFilters(badFilters);
+            expect(errors.length).to.equal(2);
+            expect(errors[0]).to.equal('Received invalid filter postedWithinDays, expected number, received not a number');
+            expect(errors[1]).to.equal('Received invalid filter assignedToAgencyId, expected number, received not a number');
+        });
+        it('throws an error when Date filter-type is not a date', async () => {
+            const badFilters = {
+                openDate: 'not a date',
+            };
+            const errors = db.validateSearchFilters(badFilters);
+            expect(errors.length).to.equal(1);
+            expect(errors[0]).to.equal('Received invalid filter openDate, expected YYYY-MM-DD, received not a date');
+        });
+        it('returns no errors when all filters are valid', async () => {
+            const goodFilters = {
+                reviewStatuses: ['Applied', 'Not Applying', 'Interested'],
+                eligibilityCodes: ['11', '07'],
+                includeKeywords: ['Grant', 'Wetlands Phrase'],
+                excludeKeywords: ['post Doctorate'],
+                opportunityNumber: null,
+                opportunityStatuses: [],
+                fundingTypes: ['CA', 'G', 'PC', 'O'],
+                opportunityCategories: ['Other', 'Discretionary', 'Mandatory', 'Continuation'],
+                costSharing: 'Yes',
+                agencyCode: 'HHS',
+                postedWithinDays: 30,
+                assignedToAgencyId: 1,
+                bill: 'Infrastructure Investment and Jobs Act',
+            };
+            const errors = db.validateSearchFilters(goodFilters);
+            expect(errors.length).to.equal(0);
+        });
+    });
     context('CRUD Saved Search', () => {
         it('creates a new saved search', async () => {
             const row = await db.createSavedSearch({

--- a/packages/server/__tests__/db/seeds/fixtures.js
+++ b/packages/server/__tests__/db/seeds/fixtures.js
@@ -308,7 +308,7 @@ const grantsSavedSearches = [
         name: 'Simple 2 result search based on included keywords',
         created_by: users.adminUser.id,
         criteria: JSON.stringify({
-            includeKeywords: ['Community Health Aide Program'],
+            includeKeywords: 'Community Health Aide Program',
         }),
         created_at: '2023-08-10 16:26:25.555863+00',
         updated_at: '2023-08-10 16:26:25.555863+00',

--- a/packages/server/__tests__/email/email.test.js
+++ b/packages/server/__tests__/email/email.test.js
@@ -392,7 +392,7 @@ describe('Email sender', () => {
                 name: 'TestSavedSearch',
                 tenantId: 0,
                 email: 'foo@bar.com',
-                criteria: '{"includeKeywords":["interestedGrant"]}',
+                criteria: '{"includeKeywords":"interestedGrant"}',
             };
             await email.getAndSendGrantForSavedSearch({ userSavedSearch, openDate: '2021-08-05' });
 

--- a/packages/server/seeds/dev/ref/grantsSavedSearches.js
+++ b/packages/server/seeds/dev/ref/grantsSavedSearches.js
@@ -3,7 +3,7 @@ const grantsSavedSearches = [
         name: 'Simple 2 result search based on included keywords',
         created_by: 2,
         criteria: JSON.stringify({
-            includeKeywords: ['Community Health Aide Program'],
+            includeKeywords: 'Community Health Aide Program',
         }),
         created_at: '2023-08-10 16:26:25.555863+00',
         updated_at: '2023-08-10 16:26:25.555863+00',

--- a/packages/server/seeds/dev/ref/users.js
+++ b/packages/server/seeds/dev/ref/users.js
@@ -27,7 +27,7 @@ module.exports = [
     {
         id: 2,
         email: 'mindy@usdigitalresponse.org', // fake email for testing
-        name: 'Mindy Huant',
+        name: 'Mindy Huang',
         agency_id: usdrAgency.id,
         role_id: roles[0].id,
         tenant_id: usdrTenant.id,

--- a/packages/server/src/db/index.js
+++ b/packages/server/src/db/index.js
@@ -571,7 +571,7 @@ function formatSearchCriteriaToQueryFilters(criteria) {
         delete parsedCriteria.eligibility;
     }
     filters = { ...filters, ...parsedCriteria };
-    validateSearchFilters(filters);
+
     return filters;
 }
 

--- a/packages/server/src/db/index.js
+++ b/packages/server/src/db/index.js
@@ -540,6 +540,41 @@ function grantsQuery(queryBuilder, filters, agencyId, orderingParams, pagination
     }
 }
 
+function formatSearchCriteriaToQueryFilters(criteria) {
+    const parsedCriteria = JSON.parse(criteria);
+    const postedWithinOptions = {
+        'All Time': 0, 'One Week': 7, '30 Days': 30, '60 Days': 60,
+    };
+    let filters = {};
+    if (parsedCriteria.includeKeywords) {
+        filters.includeKeywords = parsedCriteria.includeKeywords.split(',').map((s) => s.trim());
+        delete parsedCriteria.includeKeywords;
+    }
+    if (parsedCriteria.excludeKeywords) {
+        filters.excludeKeywords = parsedCriteria.excludeKeywords.split(',').map((s) => s.trim());
+        delete parsedCriteria.excludeKeywords;
+    }
+    if (parsedCriteria.fundingTypes) {
+        filters.fundingTypes = parsedCriteria.fundingTypes.map((ft) => ft.code);
+        delete parsedCriteria.fundingTypes;
+    }
+    if (parsedCriteria.agency) {
+        filters.agencyCode = filters.agency;
+        delete parsedCriteria.agency;
+    }
+    if (parsedCriteria.postedWithin) {
+        filters.postedWithinDays = postedWithinOptions[parsedCriteria.postedWithin] || 0;
+        delete parsedCriteria.postedWithin;
+    }
+    if (parsedCriteria.eligibility) {
+        filters.eligibilityCodes = parsedCriteria.eligibility.map((e) => e.code);
+        delete parsedCriteria.eligibility;
+    }
+    filters = { ...filters, ...parsedCriteria };
+    validateFilters(filters);
+    return filters;
+}
+
 function validateFilters(filters) {
     const filterOptionsByType = {
         reviewStatuses: { type: 'List', valueType: 'Enum', values: ['Applied', 'Not Applying', 'Interested'] },
@@ -1673,6 +1708,7 @@ module.exports = {
     deleteSavedSearch,
     updateSavedSearch,
     getAllUserSavedSearches,
+    formatSearchCriteriaToQueryFilters,
     getUsers,
     createUser,
     deleteUser,

--- a/packages/server/src/db/index.js
+++ b/packages/server/src/db/index.js
@@ -540,8 +540,85 @@ function grantsQuery(queryBuilder, filters, agencyId, orderingParams, pagination
     }
 }
 
+function validateFilters(filters) {
+    const filterOptionsByType = {
+        reviewStatuses: { type: 'List', valueType: 'Enum', values: ['Applied', 'Not Applying', 'Interested'] },
+        eligibilityCodes: { type: 'List', valueType: 'String' },
+        includeKeywords: { type: 'List', valueType: 'String' },
+        excludeKeywords: { type: 'List', valueType: 'String' },
+        opportunityNumber: { type: 'String', valueType: 'Any' },
+        fundingTypes: { type: 'List', valueType: 'Enum', values: ['CA', 'G', 'PC', 'O'] },
+        opportunityStatuses: { type: 'List', valueType: 'Enum', values: ['posted', 'forecasted', 'closed'] },
+        opportunityCategories: { type: 'List', valueType: 'Enum', values: ['Other', 'Discretionary', 'Mandatory', 'Continuation'] },
+        costSharing: { type: 'String', valueType: 'Enum', values: ['Yes', 'No'] },
+        agencyCode: { type: 'String', valueType: 'Any' },
+        postedWithinDays: { type: 'number', valueType: 'Any' },
+        assignedToAgencyId: { type: 'number', valueType: 'Any' },
+        bill: { type: 'String', valueType: 'Any' },
+        openDate: { type: 'Date', valueType: 'YYYY-MM-DD' },
+    };
+
+    const errors = [];
+    for (const [option, value] of Object.entries(filters)) {
+        if (!value || value.length === 0) {
+            // eslint-disable-next-line no-continue
+            continue;
+        }
+
+        if (!filterOptionsByType[option]) {
+            errors.push(`Received invalid filter ${option}, does not exist`);
+        } else if (filterOptionsByType[option].type === 'List') {
+            if (!Array.isArray(value)) {
+                errors.push(`Received invalid filter ${option}, expected List`);
+            } else if (filterOptionsByType[option].valueType && value.length > 0) {
+                if (filterOptionsByType[option].valueType === 'Enum') {
+                    for (const v of value) {
+                        if (!filterOptionsByType[option].values.includes(v)) {
+                            errors.push(`Received invalid filter ${option}, expected List of Enum, found value ${v} that is not in ${filterOptionsByType[option].values}`);
+                        }
+                    }
+                } else if (filterOptionsByType[option].valueType === 'String') {
+                    for (const v of value) {
+                        if (typeof v !== 'string') {
+                            errors.push(`Received invalid filter ${option}, expected List of String`);
+                        }
+                    }
+                }
+            }
+        } else if (filterOptionsByType[option].type === 'String') {
+            if (filterOptionsByType[option].valueType === 'Enum') {
+                if (!filterOptionsByType[option].values.includes(value)) {
+                    errors.push(`Received invalid filter ${option}, expected Enum, found value ${value} that is not in ${filterOptionsByType[option].values}`);
+                }
+            } else if (filterOptionsByType[option].valueType === 'Any') {
+                if (typeof value !== 'string') {
+                    errors.push(`Received invalid filter ${option}, expected String, received ${value}`);
+                }
+            }
+        } else if (filterOptionsByType[option].type === 'number') {
+            if (filterOptionsByType[option].valueType === 'Any') {
+                if (typeof value !== 'number') {
+                    errors.push(`Received invalid filter ${option}, expected number, received ${value}`);
+                }
+            } else {
+                errors.push(`Numbers with specific value types is not implemented`);
+            }
+        } else if (filterOptionsByType[option].type === 'Date') {
+            if (filterOptionsByType[option].valueType === 'YYYY-MM-DD') {
+                if (!moment(value, 'YYYY-MM-DD', true).isValid()) {
+                    errors.push(`Received invalid filter ${option}, expected YYYY-MM-DD, received ${value}`);
+                }
+            } else {
+                errors.push(`Dates without specific value-types/date-format is not implemented`);
+            }
+        }
+    }
+
+    return errors;
+}
+
 /*
-    filters: {
+   filters: {
         reviewStatuses: List[Enum['Applied', 'Not Applying', 'Interested']],
         eligibilityCodes: List[String],
         includeKeywords: List[String],
@@ -562,7 +639,13 @@ function grantsQuery(queryBuilder, filters, agencyId, orderingParams, pagination
     agencyId: number
 */
 async function getGrantsNew(filters, paginationParams, orderingParams, tenantId, agencyId) {
-    console.log(filters, paginationParams, orderingParams, tenantId, agencyId);
+    console.log(JSON.stringify([filters, paginationParams, orderingParams, tenantId, agencyId]));
+
+    const errors = validateFilters(filters);
+    if (errors.length > 0) {
+        throw new Error(`Invalid filters: ${errors.join(', ')}`);
+    }
+
     const data = await knex(TABLES.grants)
         .select([
             'grants.grant_id',

--- a/packages/server/src/db/index.js
+++ b/packages/server/src/db/index.js
@@ -571,11 +571,11 @@ function formatSearchCriteriaToQueryFilters(criteria) {
         delete parsedCriteria.eligibility;
     }
     filters = { ...filters, ...parsedCriteria };
-    validateFilters(filters);
+    validateSearchFilters(filters);
     return filters;
 }
 
-function validateFilters(filters) {
+function validateSearchFilters(filters) {
     const filterOptionsByType = {
         reviewStatuses: { type: 'List', valueType: 'Enum', values: ['Applied', 'Not Applying', 'Interested'] },
         eligibilityCodes: { type: 'List', valueType: 'String' },
@@ -676,7 +676,7 @@ function validateFilters(filters) {
 async function getGrantsNew(filters, paginationParams, orderingParams, tenantId, agencyId) {
     console.log(JSON.stringify([filters, paginationParams, orderingParams, tenantId, agencyId]));
 
-    const errors = validateFilters(filters);
+    const errors = validateSearchFilters(filters);
     if (errors.length > 0) {
         throw new Error(`Invalid filters: ${errors.join(', ')}`);
     }
@@ -1774,4 +1774,5 @@ module.exports = {
     sync,
     getAllRows,
     close,
+    validateSearchFilters,
 };

--- a/packages/server/src/lib/email.js
+++ b/packages/server/src/lib/email.js
@@ -258,7 +258,7 @@ async function sendGrantDigest({
 async function getAndSendGrantForSavedSearch({
     userSavedSearch, openDate,
 }) {
-    const criteriaObj = JSON.parse(userSavedSearch.criteria);
+    const criteriaObj = db.formatSearchCriteriaToQueryFilters(userSavedSearch.criteria);
 
     // NOTE: can't pass this as a separate parameter as it exceeds the complexity limit of 5
     criteriaObj.openDate = openDate;


### PR DESCRIPTION
### Ticket #1829
## Description
- The reason for wrong emails being sent is because the email service is passing in the raw `criteria` from the `grants_saved_search`. This PR ensures that: 
  1. The email-service is formatting the input-filters correctly prior to sending it to `getGrantsNew` function.
  2. The `getGrantsNew` function validates all input filters being passed in and sends back an appropriate error message. Note: the lack of a clear error message was the reason for a longer debug time for these issues.

## Screenshots / Demo Video

## Testing
To manually test:
Sample test URL:
http://localhost:8080/api/organizations/0/users/enter-your-local-user-id/sendDigestEmail?date=2021-08-05

### Automated and Unit Tests
- [x] Added Unit tests

### Manual tests for Reviewer
- [x] Added steps to test feature/functionality manually

## Checklist
- [x] Provided ticket and description
- [x] Provided screenshots/demo
- [x] Provided testing information
- [x] Provided adequate test coverage for all new code
- [x] Added PR reviewers