### PR TITLE
Remove redundant apiUrl helper call

### DIFF
--- a/packages/client/src/arpa_reporter/store/index.js
+++ b/packages/client/src/arpa_reporter/store/index.js
@@ -175,7 +175,7 @@ export default new Vuex.Store({
       ]);
     },
     async logout({ commit }) {
-      await get(apiURL('/api/sessions/logout'));
+      await get('/api/sessions/logout');
       commit('setUser', null);
     },
     setViewPeriodID({ commit }, period_id) {


### PR DESCRIPTION
In #1838 I accidentally introduced a redundant call to `apiURL`.  I missed the detail that the `get` helper actually already injects the apiURL host for us!