### PR TITLE
chore: add service-down page for report generation

### DIFF
--- a/packages/client/src/arpa_reporter/views/Home.vue
+++ b/packages/client/src/arpa_reporter/views/Home.vue
@@ -3,13 +3,16 @@
     <div class="row">
       <AlertBox v-if="alert" :text="alert.text" :level="alert.level" v-on:dismiss="clearAlert" />
     </div>
+    <div class="row" v-if="isAdmin">
+      <AlertBox text="Service Interruption - Please reach out to grants-helpdesk@usdigitalresponse.org for audit report and treasury report generation." level="err" />
+    </div>
     <div class="row mt-5 mb-5" v-if="viewingOpenPeriod">
       <div class="col" v-if="this.$route.query.sync_treasury_download && isAdmin">
         <DownloadButton :href="downloadTreasuryReportURL()" class="btn btn-primary btn-block">Download Treasury Report</DownloadButton>
       </div>
 
       <div class="col" v-if="isAdmin">
-        <button class="btn btn-primary btn-block" @click="sendTreasuryReport" :disabled="sending">
+        <button disabled title="Please reach out to grants-helpdesk@usdigitalresponse.org for the treasury report." class="btn btn-primary btn-block" @click="sendTreasuryReport">
           <span v-if="sending">Sending...</span>
           <span v-else>Send Treasury Report by Email</span>
         </button>
@@ -20,7 +23,7 @@
       </div>
 
       <div class="col" v-if="isAdmin">
-        <button class="btn btn-info btn-block" @click="sendAuditReport" :disabled="sending">
+        <button disabled title="Please reach out to grants-helpdesk@usdigitalresponse.org for the audit report." class="btn btn-info btn-block" @click="sendAuditReport">
           <span v-if="sending">Sending...</span>
           <span v-else>Send Audit Report by Email</span>
         </button>

--- a/terraform/modules/gost_api/task.tf
+++ b/terraform/modules/gost_api/task.tf
@@ -157,8 +157,8 @@ resource "aws_ecs_task_definition" "default" {
 
   # Valid configurations here:
   # https://docs.aws.amazon.com/AmazonECS/latest/developerguide/AWS_Fargate.html#fargate-tasks-size
-  cpu    = 512
-  memory = 2048
+  cpu    = 256
+  memory = 512
 
   runtime_platform {
     operating_system_family = "LINUX"


### PR DESCRIPTION
### Ticket #
## Description
If tests from #1958 are not successful, we can use this as a PR to turn off audit report generation and mitigate risk for search  redesign launch.

## Screenshots / Demo Video
<img width="919" alt="image" src="https://github.com/usdigitalresponse/usdr-gost/assets/6497366/bf66061a-1b2a-42e9-aeba-f19aefdb24ac">

## Testing

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [ ] Provided ticket and description
- [ ] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers