### PR TITLE
Fix swap of interested and rejected totals

### DIFF
--- a/packages/server/__tests__/db/db.test.js
+++ b/packages/server/__tests__/db/db.test.js
@@ -691,6 +691,22 @@ describe('db', () => {
         });
     });
 
+    context('getTotalInterestedGrantsByAgencies', () => {
+        it('returns total interested grants by agencies', async () => {
+            const agencyId = fixtures.users.staffUser.agency_id;
+            const result = await db.getTotalInterestedGrantsByAgencies(agencyId);
+            const agencyResult = result[0];
+            expect(agencyResult.agency_id).to.equal(fixtures.agencies.accountancy.id);
+            expect(agencyResult.interested).to.equal('1');
+            expect(agencyResult.rejections).to.equal('2');
+
+            expect(agencyResult.count).to.equal('4');
+            expect(agencyResult.total_grant_money).to.equal('1506500');
+            expect(agencyResult.total_interested_grant_money).to.equal('500000');
+            expect(agencyResult.total_rejected_grant_money).to.equal('506500');
+        });
+    });
+
     context('createUser', () => {
         it('sets default email unsubuscribe when new users are created', async () => {
             const response = await db.createUser(

--- a/packages/server/src/db/index.js
+++ b/packages/server/src/db/index.js
@@ -1043,8 +1043,8 @@ async function getTotalInterestedGrantsByAgencies(agencyId) {
             knex.raw(`SUM(CASE WHEN status_code = 'Rejected' THEN 1 ELSE 0 END) rejections`),
             knex.raw(`SUM(CASE WHEN status_code = 'Interested' THEN 1 ELSE 0 END) interested`),
             knex.raw('SUM(award_ceiling::numeric) total_grant_money'),
-            knex.raw(`SUM(CASE WHEN status_code = 'Rejected' THEN award_ceiling::numeric ELSE 0 END) total_interested_grant_money`),
-            knex.raw(`SUM(CASE WHEN status_code = 'Interested' THEN award_ceiling::numeric ELSE 0 END) total_rejected_grant_money`))
+            knex.raw(`SUM(CASE WHEN status_code = 'Interested' THEN award_ceiling::numeric ELSE 0 END) total_interested_grant_money`),
+            knex.raw(`SUM(CASE WHEN status_code = 'Rejected' THEN award_ceiling::numeric ELSE 0 END) total_rejected_grant_money`))
         .join(TABLES.agencies, `${TABLES.grants_interested}.agency_id`, `${TABLES.agencies}.id`)
         .join(TABLES.interested_codes, `${TABLES.grants_interested}.interested_code_id`, `${TABLES.interested_codes}.id`)
         .join(TABLES.grants, `${TABLES.grants_interested}.grant_id`, `${TABLES.grants}.grant_id`)


### PR DESCRIPTION
### Ticket #1829
## Description
It looks like the total interested & rejected values were swapped (and had been for some time?). 

I didn't look into this, but it looks like the total count is maybe off too? Shouldn't  it be the sum of interested & rejected? I don't know the data model well enough to say so I left it alone. 

## Screenshots / Demo Video
![image](https://github.com/usdigitalresponse/usdr-gost/assets/624510/9b7ccc3a-1453-40fe-9604-24314b4e0d07)

## Testing
Assign and reject various grants, go to Dashboard. Total $'s should add up correctly.

### Automated and Unit Tests
- [x] Added Unit tests

### Manual tests for Reviewer
- [x] Added steps to test feature/functionality manually

## Checklist
- [x] Provided ticket and description
- [x] Provided screenshots/demo
- [x] Provided testing information
- [x] Provided adequate test coverage for all new code
- [ ] Added PR reviewers