### PR TITLE
ARPA audit report investigation: Round 2

### DIFF
--- a/packages/server/src/arpa_reporter/lib/audit-report.js
+++ b/packages/server/src/arpa_reporter/lib/audit-report.js
@@ -54,15 +54,32 @@ function getUploadLink(domain, id, filename) {
 }
 
 async function createObligationSheet(periodId, domain) {
+    log('called createObligationSheet()', { periodId, domain, fn: 'createObligationSheet' });
     // select active reporting periods and sort by date
     const reportingPeriods = await getPreviousReportingPeriods(periodId);
+    log('retrieved previous reporting periods', {
+        periodId, domain, reportingPeriods, fn: 'createObligationSheet',
+    });
 
     const rows = await Promise.all(
         reportingPeriods.map(async (period) => {
+            log('creating row for reporting period', { period, fn: 'createObligationSheet' });
             const uploads = await usedForTreasuryExport(period.id);
+            log('retrived uploads for period', { period, fn: 'createObligationSheet' });
             const records = await recordsForReportingPeriod(period.id);
+            log('retrieved records', { period, fn: 'createObligationSheet' });
 
+            log('mapping uploads', { period, fn: 'createObligationSheet' });
             return Promise.all(uploads.map((upload) => {
+                log('initializing empty row', {
+                    period: {
+                        start: period.start_date,
+                        end: period.end_date,
+                        id: period.id,
+                        name: period.name,
+                    },
+                    fn: 'createObligationSheet',
+                });
                 const emptyRow = {
                     'Reporting Period': period.name,
                     'Period End Date': new Date(period.end_date),
@@ -78,9 +95,30 @@ async function createObligationSheet(periodId, domain) {
                     [COLUMN.E_CPE]: 0,
                 };
 
+                log('populating rows from records in upload', {
+                    period: {
+                        start: period.start_date,
+                        end: period.end_date,
+                        id: period.id,
+                        name: period.name,
+                    },
+                    upload: { id: upload.id },
+                    fn: 'createObligationSheet',
+                });
                 const row = records
                     .filter((record) => record.upload.id === upload.id)
                     .reduce((newRow, record) => {
+                        log('determining record type for upload row', {
+                            period: {
+                                start: period.start_date,
+                                end: period.end_date,
+                                id: period.id,
+                                name: period.name,
+                            },
+                            upload: { id: upload.id },
+                            record: { type: record.type },
+                            fn: 'createObligationSheet',
+                        });
                         switch (record.type) {
                             case 'ec1':
                             case 'ec2':
@@ -110,23 +148,63 @@ async function createObligationSheet(periodId, domain) {
                         return newRow;
                     }, emptyRow);
 
+                log('returning populated row', {
+                    period, upload: { id: upload.id }, fn: 'createObligationSheet',
+                });
                 return row;
             }));
         }),
     );
 
+    log('returning flattened rows for sheet', { fn: 'createObligationSheet' });
     return rows.flat();
 }
 
 async function createProjectSummaries(periodId, domain) {
+    log('called createProjectSummaries()', { periodId, domain });
     const records = await mostRecentProjectRecords(periodId);
+    log('retrieved most recent project records', {
+        fn: 'createProjectSummaries', periodId, domain, record_count: records.length,
+    });
 
+    // TODO: inputs does not appear to be used
     const inputs = [];
     records.forEach((r) => inputs.push({ record: r, domain }));
+    log('populated inputs[] for each record', {
+        fn: 'createProjectSummaries', input_count: inputs.length,
+    });
 
+    log('mapping rows from records', { fn: 'createProjectSummaries' });
     const rows = records.map(async (record) => {
+        log('mapping row from record', {
+            fn: 'createProjectSummaries',
+            record: {
+                upload: {
+                    id: record.upload.id,
+                    reporting_period_id: record.upload.reporting_period_id,
+                },
+            },
+        });
         const reportingPeriod = await getReportingPeriod(record.upload.reporting_period_id);
+        log('retrieved reporting period for row mapped from record', {
+            fn: 'createProjectSummaries',
+            record: {
+                upload: {
+                    id: record.upload.id,
+                    reporting_period_id: record.upload.reporting_period_id,
+                },
+            },
+        });
 
+        log('returning row mapped from record', {
+            fn: 'createProjectSummaries',
+            record: {
+                upload: {
+                    id: record.upload.id,
+                    reporting_period_id: record.upload.reporting_period_id,
+                },
+            },
+        });
         return {
             'Project ID': record.content.Project_Identification_Number__c,
             Upload: getUploadLink(domain, record.upload.id, record.upload.filename),
@@ -141,6 +219,7 @@ async function createProjectSummaries(periodId, domain) {
         };
     });
 
+    log('returning Promise.all(rows)', { periodId, domain });
     return Promise.all(rows);
 }
 
@@ -155,14 +234,22 @@ function getRecordsByProject(records) {
 }
 
 async function createReportsGroupedByProject(periodId) {
+    log('called createProjectSummaries()', { periodId });
     const records = await recordsForProject(periodId);
+    log('retrieved records for project', { fn: 'createReportsGroupedByProject', count: records.length });
     const recordsByProject = getRecordsByProject(records);
+    log('organized records by project', { fn: 'createReportsGroupedByProject', count: recordsByProject.length });
     const reportingPeriods = await getAllReportingPeriods();
+    log('retrieved all reporting periods', { fn: 'createReportsGroupedByProject', count: reportingPeriods.length });
 
+    log('mapping each recordsByProject', { fn: 'createReportsGroupedByProject' });
     return Object.entries(recordsByProject).map(([projectId, projectRecords]) => {
         const record = projectRecords[0];
 
         // set values for columns that are common across all records of projectId
+        log('setting values for columns that are common across all records of projectId', {
+            fn: 'createReportsGroupedByProject', projectId,
+        });
         const row = {
             'Project ID': projectId,
             'Project Description': record.content.Project_Description__c,
@@ -171,9 +258,18 @@ async function createReportsGroupedByProject(periodId) {
         };
 
         // get all reporting periods related to the project
+        log('getting all reporting periods related to the project', {
+            fn: 'createReportsGroupedByProject', projectId,
+        });
         const allReportingPeriods = Array.from(new Set(projectRecords.map((r) => r.upload.reporting_period_id)));
+        log('populated allReportingPeriods from projectRecords', {
+            fn: 'createReportsGroupedByProject', projectId,
+        });
 
         // initialize the columns in the row
+        log('initializing the columns in the row', {
+            fn: 'createReportsGroupedByProject', projectId,
+        });
         allReportingPeriods.forEach((reportingPeriodId) => {
             const reportingPeriodEndDate = reportingPeriods.filter((reportingPeriod) => reportingPeriod.id === reportingPeriodId)[0].end_date;
             [
@@ -187,6 +283,9 @@ async function createReportsGroupedByProject(periodId) {
         row['Capital Expenditure Amount'] = 0;
 
         // set values in each column
+        log('setting values in each column', {
+            fn: 'createReportsGroupedByProject', projectId,
+        });
         projectRecords.forEach((r) => {
             // for project summaries v2 report
             const reportingPeriodEndDate = reportingPeriods.filter((reportingPeriod) => r.upload.reporting_period_id === reportingPeriod.id)[0].end_date;
@@ -197,15 +296,23 @@ async function createReportsGroupedByProject(periodId) {
             row['Capital Expenditure Amount'] += (r.content.Total_Cost_Capital_Expenditure__c || 0);
         });
 
+        log('returning populated row', {
+            fn: 'createReportsGroupedByProject', projectId,
+        });
         return row;
     });
 }
 
 async function createKpiDataGroupedByProject(periodId) {
+    log('called createKpiDataGroupedByProject()', { periodId });
     const records = await recordsForProject(periodId);
+    log('retrieved records for project', { fn: 'createKpiDataGroupedByProject', count: records.length });
     const recordsByProject = getRecordsByProject(records);
+    log('organized records by project', { fn: 'createKpiDataGroupedByProject', count: recordsByProject.length });
 
+    log('mapping each recordsByProject', { fn: 'createKpiDataGroupedByProject' });
     return Object.entries(recordsByProject).map(([projectId, projectRecords]) => {
+        log('initializing row for project', { fn: 'createKpiDataGroupedByProject', projectId, periodId });
         const row = {
             'Project ID': projectId,
             'Number of Subawards': 0,
@@ -213,6 +320,7 @@ async function createKpiDataGroupedByProject(periodId) {
             'Evidence Based Total Spend': 0,
         };
 
+        log('populating row values from each projectRecords', { fn: 'createKpiDataGroupedByProject', projectId, periodId });
         projectRecords.forEach((r) => {
             const currentPeriodExpenditure = r.content.Current_Period_Expenditures__c || 0;
             row['Number of Subawards'] += (r.type === 'awards50k');
@@ -220,6 +328,9 @@ async function createKpiDataGroupedByProject(periodId) {
             row['Evidence Based Total Spend'] += (r.content.Spending_Allocated_Toward_Evidence_Based_Interventions || 0);
         });
 
+        log('returning populated row', {
+            fn: 'createKpiDataGroupedByProject', projectId, periodId,
+        });
         return row;
     });
 }


### PR DESCRIPTION
## Description

This PR is a follow-up to #1976. The results from the test run following deployment of #1976 were minimal; the program crashed after printing the following (abbreviated) log, emitted from [this line](https://github.com/usdigitalresponse/usdr-gost/blob/main/packages/server/src/arpa_reporter/lib/audit-report.js#L238):

<details>
  <summary>Log output</summary>

```json
{
	"id": "AgAAAYrUFNlsTK3RoQAAAAAAAAAYAAAAAEFZclVGT2piQUFDczdJaU1xQlRXQVFBSwAAACQAAAAAMDE4YWQ0MTQtZjFhOC00ZWQ2LWE5ZDEtNzYxNDUzYzY1YTVl",
	"content": {
		"timestamp": "2023-09-27T00:40:50.796Z",
		"message": "generating sheets",
		"attributes": {
			"level": "debug",
			"usage": "ARPA investigation",
			"extra": {
				"periodId": 175,
				"domain": "https://grants.usdigitalresponse.org/arpa_reporter",
				"tenantId": 9
			},
			"processStats": {
				"memory": {
					"heapUsed": 54838104,
					"external": 13476700,
					"rss": 116903936,
					"heapTotal": 58114048,
					"arrayBuffers": 12193239
				},
				"cpu": {
					"system": 1675252,
					"user": 4619209
				}
			},
		}
	}
}
```

</details>

On its own this doesn't tell us much, but it does indicate that (perhaps obviously) report generation is failing during the part of the workflow responsible for generating individual sheets in the workbook. Therefore, this PR annotates each of these four functions with step-by-step log messages. Subsequent investigation should include checking not just the final log that was emitted during report generation, but also whether certain attributes remain constant over consecutive report-generation activities. In particular, I'm interested in knowing whether a particular function is responsible for running out of memory, or if it is more likely a result of all functions running in parallel.

At this point, signs indicate that one or more of the following will be warranted for remediation:
- Cap the number of parallel async executions within a consistent worker-pool (that is, one that is shared across all async coroutines for any report being generated).
- Identify opportunities to optimize code by limiting the number of redundant copies of data held in-memory. At a glance, it appears as though data structures (which may be quite large) are being copied into various data shapes that are most conducive to the processing step at-hand. I'm not familiar enough with the mechanics of how NodeJS copies data to say for sure that this is a problem, but it may be worth investigating further. Hopefully the logs' memory usage outputs will shed some light here.
- Rewrite sheet-generating processes to be more sequential. Given the hour-long window that we have to deliver a report, I think the amount of parallelization here (assuming that is contributing to the memory bloat) is not worth the time-savings.
- Continue to explore opportunities to divide-and-conquer this problem by preparing data ahead of time, ideally in a deferred job that triggers based on relevant data lifecycle events (e.g. when a new file is uploaded).

Note: The above are just some preliminary takeaways from code exploration; I'm hoping that the additional log data following deployment of these changes will serve to confirm or refute some of these assumptions.

## Screenshots / Demo Video

## Testing

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [ ] Provided ticket and description
- [ ] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers