### PR TITLE
fix: adds earmark as valid option

### DIFF
--- a/packages/server/__tests__/db/db.test.js
+++ b/packages/server/__tests__/db/db.test.js
@@ -62,13 +62,15 @@ describe('db', () => {
                 costSharing: 'not a yes or no',
                 agencyCode: 99,
                 bill: 99,
+                opportunityCategories: ['Earmark', 'foo'],
             };
             const errors = db.validateSearchFilters(badFilters);
-            expect(errors.length).to.equal(4);
+            expect(errors.length).to.equal(5);
             expect(errors[0]).to.equal('Received invalid filter opportunityNumber, expected String, received 99');
             expect(errors[1]).to.equal('Received invalid filter costSharing, expected Enum, found value not a yes or no that is not in Yes,No');
             expect(errors[2]).to.equal('Received invalid filter agencyCode, expected String, received 99');
             expect(errors[3]).to.equal('Received invalid filter bill, expected String, received 99');
+            expect(errors[4]).to.equal('Received invalid filter opportunityCategories, expected List of Enum, found value foo that is not in Other,Discretionary,Mandatory,Continuation,Earmark');
         });
         it('throws an error when Number filter-type is not a number', async () => {
             const badFilters = {

--- a/packages/server/src/db/index.js
+++ b/packages/server/src/db/index.js
@@ -584,7 +584,7 @@ function validateSearchFilters(filters) {
         opportunityNumber: { type: 'String', valueType: 'Any' },
         fundingTypes: { type: 'List', valueType: 'Enum', values: ['CA', 'G', 'PC', 'O'] },
         opportunityStatuses: { type: 'List', valueType: 'Enum', values: ['posted', 'forecasted', 'closed', 'archived'] },
-        opportunityCategories: { type: 'List', valueType: 'Enum', values: ['Other', 'Discretionary', 'Mandatory', 'Continuation'] },
+        opportunityCategories: { type: 'List', valueType: 'Enum', values: ['Other', 'Discretionary', 'Mandatory', 'Continuation', 'Earmark'] },
         costSharing: { type: 'String', valueType: 'Enum', values: ['Yes', 'No'] },
         agencyCode: { type: 'String', valueType: 'Any' },
         postedWithinDays: { type: 'number', valueType: 'Any' },


### PR DESCRIPTION
### Ticket #1829
## Description
- 'Earmark' category was returning 500 errors this will fix it.

## Screenshots / Demo Video
### Before
<img width="500" alt="image" src="https://github.com/usdigitalresponse/usdr-gost/assets/6497366/eeae55b7-d49e-4f97-b671-d7603c8f0250">

### After
<img width="522" alt="image" src="https://github.com/usdigitalresponse/usdr-gost/assets/6497366/79fa04a1-411c-4367-8616-79c9be1cc564">

## Testing

### Automated and Unit Tests
- [x] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [x] Provided ticket and description
- [x] Provided screenshots/demo
- [ ] Provided testing information
- [x] Provided adequate test coverage for all new code
- [x] Added PR reviewers