### PR TITLE
Fix: Namespace issue in `module.arpa_audit_report`

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -222,8 +222,7 @@ data "aws_iam_policy_document" "arpa_audit_report_rw_reports_bucket" {
 
 module "arpa_audit_report" {
   source                   = "./modules/sqs_consumer_task"
-  namespace                = var.namespace
-  name                     = "arpa_audit_report"
+  namespace                = "${var.namespace}-arpa_audit_report"
   permissions_boundary_arn = local.permissions_boundary_arn
 
   # Networking

--- a/terraform/modules/sqs_consumer_task/variables.tf
+++ b/terraform/modules/sqs_consumer_task/variables.tf
@@ -3,11 +3,6 @@ variable "namespace" {
   type        = string
 }
 
-variable "name" {
-  description = "Name prefix for resource names and identifiers"
-  type        = string
-}
-
 variable "tags" {
   type    = map(string)
   default = {}


### PR DESCRIPTION
## Description

This PR fixes an issue in #1992 where resources were being named incorrectly. 