### PR TITLE
Fix: Shorten arpa_audit_report role name to avoid character limit

### DIFF
--- a/terraform/modules/sqs_consumer_task/compute.tf
+++ b/terraform/modules/sqs_consumer_task/compute.tf
@@ -163,7 +163,7 @@ resource "aws_ecs_task_definition" "consumer" {
 }
 
 resource "aws_iam_role" "execution" {
-  name_prefix          = "${var.namespace}-ECSExec-"
+  name_prefix          = "${var.namespace}-Exec-"
   permissions_boundary = var.permissions_boundary_arn
   assume_role_policy = jsonencode({
     Version = "2012-10-17"

--- a/terraform/modules/sqs_consumer_task/compute.tf
+++ b/terraform/modules/sqs_consumer_task/compute.tf
@@ -191,7 +191,7 @@ resource "aws_iam_role_policy" "execution" {
 }
 
 resource "aws_iam_role" "task" {
-  name_prefix          = "${var.namespace}-ECSTask-"
+  name_prefix          = "${var.namespace}-Task-"
   permissions_boundary = var.permissions_boundary_arn
   assume_role_policy = jsonencode({
     Version = "2012-10-17"


### PR DESCRIPTION
## Description

Fix – just like it says on the tin...