### PR TITLE
Allow API tasks to send messages to the `arpa_audit_report` SQS queue

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -284,6 +284,20 @@ module "arpa_audit_report" {
   postgres_db_name         = module.postgres.default_db_name
 }
 
+data "aws_iam_policy_document" "publish_to_arpa_audit_report_queue" {
+  statement {
+    sid       = "AllowPublishToQueue"
+    actions   = ["sqs:SendMessage"]
+    resources = [module.arpa_audit_report.sqs_queue_arn]
+  }
+}
+
+resource "aws_iam_role_policy" "api_task-publish_to_arpa_audit_report_queue" {
+  name_prefix = "send-arpa-audit-report-requests"
+  role        = module.api.ecs_task_role_name
+  policy      = data.aws_iam_policy_document.publish_to_arpa_audit_report_queue.json
+}
+
 module "postgres" {
   enabled                  = var.postgres_enabled
   source                   = "./modules/gost_postgres"

--- a/terraform/modules/gost_api/outputs.tf
+++ b/terraform/modules/gost_api/outputs.tf
@@ -24,6 +24,10 @@ output "ecs_service_arn" {
   value = join("", aws_ecs_service.default.*.id)
 }
 
+output "ecs_task_role_name" {
+  value = join("", aws_iam_role.task.name)
+}
+
 output "arpa_audit_reports_bucket_arn" {
   value = module.arpa_audit_reports_bucket.bucket_arn
 }

--- a/terraform/modules/gost_api/outputs.tf
+++ b/terraform/modules/gost_api/outputs.tf
@@ -25,7 +25,7 @@ output "ecs_service_arn" {
 }
 
 output "ecs_task_role_name" {
-  value = join("", aws_iam_role.task.name)
+  value = join("", aws_iam_role.task.*.name)
 }
 
 output "arpa_audit_reports_bucket_arn" {


### PR DESCRIPTION
### Follow-up for #1992 

## Description

This PR adds a missing permission to the ECS task role defined in the `api` Terraform module, which allows publishing of SQS messages to the queue defined by the `arpa_audit_report` module. Although the `arpa_audit_report` module configures the SQS queue policy to accept messages from API tasks, we still need to give the task's role permission to publish SQS messages. Although it seems redundant (IMO) it makes sense to think of the SQS resource policy as an ingress rule (i.e. defines the allowed principals from which messages may originate) and the task role policy as an egress rule (i.e. defines what the task is allowed to do).

In other words:
- Problem:
  - Bob is allowed to have friends over after school. _Bob is the SQS queue._
  - Alice doesn't have permission to go to a friend's house. _Alice is the API task._
- Solution: Give Alice permission to go to Bob's house after school.

In addition to implementing the fix, this PR also update's the `sqs_consumer_task` module's README with a note clarifying the need to add permissions on the producer side, as well as a corresponding code example.

## Screenshots / Demo Video

## Testing

See #1992 **Testing** instructions. Unfortunately, IAM policy enforcement is a "pro-only"/non-community-edition feature of LocalStack, which means this needs to be tested against an actual AWS environment.

### Automated and Unit Tests
- [x] Added Unit tests

### Manual tests for Reviewer
- [x] Added steps to test feature/functionality manually

## Checklist
- [x] Provided ticket and description
- [ ] Provided screenshots/demo
- [x] Provided testing information
- [x] Provided adequate test coverage for all new code
- [x] Added PR reviewers