### PR TITLE
Gracefully disable `useRequest()` cache when no request is active

### DIFF
--- a/packages/server/src/arpa_reporter/services/records.js
+++ b/packages/server/src/arpa_reporter/services/records.js
@@ -171,6 +171,11 @@ async function loadRecordsForUpload(upload) {
 async function recordsForUpload(upload, req = useRequest()) {
     log(`recordsForUpload(${upload.id})`);
 
+    if (req === undefined) {
+        // Will not cache outside of a request
+        req = {};
+    }
+
     if (!req.recordsForUpload) {
         req.recordsForUpload = {};
     }


### PR DESCRIPTION
## Description

This PR allows the `recordsForUpload()` function in `packages/server/src/arpa_reporter/services/records.js` to gracefully fall back to a cache-less implementation when no request is active. Generally, the `useRequest()` function helps `recordsForUpload()` implement request-scoped memoization (specifically, for avoiding multiple reads of the same file in the same request), but it causes workflows that are not triggered by a request to fail when `recordsForUpload()` is called.

With these changes, when `recordsForUpload()` is called outside the scope of a request, it falls back to a function-local, empty object (which will be GC'd after the function returns). This is admittedly a bit of a hack, but I think it's worth the tradeoffs. If it turns out that, even in a task-based environment, memoization is definitely necessary, we'll have to come up with an alternative mechanism for scoping a memoization cache to a per-task-message lifecycle. 

## Screenshots / Demo Video

## Testing

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [ ] Provided ticket and description
- [ ] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers