### PR TITLE
ARPA Audit Report tweaks: Round 1

### DIFF
--- a/packages/server/__tests__/arpa_reporter/server/lib/audit-report.spec.js
+++ b/packages/server/__tests__/arpa_reporter/server/lib/audit-report.spec.js
@@ -1,3 +1,8 @@
+const chai = require('chai');
+const chaiAsPromised = require('chai-as-promised');
+
+chai.use(chaiAsPromised);
+
 const { expect } = require('chai');
 const sinon = require('sinon');
 const email = require('../../../../src/lib/email');
@@ -93,7 +98,7 @@ describe('audit report generation', () => {
         await expect(withTenantId(
             tenantId,
             () => audit_report.generateAndSendEmail('usdigitalresponse.org', 'foo@example.com'),
-        )).to.be.rejectedWith(Error);
+        )).to.be.rejected;
 
         console.log('Asserting generate function');
         expect(generateFake.calledOnce).to.equal(true);

--- a/packages/server/__tests__/arpa_reporter/server/lib/audit-report.spec.js
+++ b/packages/server/__tests__/arpa_reporter/server/lib/audit-report.spec.js
@@ -90,7 +90,10 @@ describe('audit report generation', () => {
         sandbox.replace(aws, 'getS3Client', s3Fake);
 
         const tenantId = 0;
-        await withTenantId(tenantId, () => audit_report.generateAndSendEmail('usdigitalresponse.org', 'foo@example.com'));
+        await expect(withTenantId(
+            tenantId,
+            () => audit_report.generateAndSendEmail('usdigitalresponse.org', 'foo@example.com'),
+        )).to.be.rejectedWith(Error);
 
         console.log('Asserting generate function');
         expect(generateFake.calledOnce).to.equal(true);

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -89,6 +89,7 @@
     "api": "^4.2.1",
     "aws-sdk-mock": "5.8.0",
     "chai": "^4.3.4",
+    "chai-as-promised": "^7.1.1",
     "chalk": "^5.0.1",
     "cookie-signature": "^1.2.0",
     "eslint": "^7.12.1",

--- a/packages/server/src/arpa_reporter/lib/audit-report.js
+++ b/packages/server/src/arpa_reporter/lib/audit-report.js
@@ -506,12 +506,12 @@ async function generateAndSendEmail(requestHost, recipientEmail, tenantId = useT
 
     try {
         console.log(uploadParams);
-        console.log(uploadParams);
         log('uploading report', { bucket: uploadParams.Bucket, key: uploadParams.Key });
         await s3.send(new PutObjectCommand(uploadParams));
         await module.exports.sendEmailWithLink(reportKey, recipientEmail);
     } catch (err) {
         console.log(`Failed to upload/email audit report ${err}`);
+        throw err;
     }
     log('generateAndSendEmail() complete', null, null, true);
 }

--- a/packages/server/src/arpa_reporter/services/records.js
+++ b/packages/server/src/arpa_reporter/services/records.js
@@ -173,10 +173,12 @@ async function recordsForUpload(upload, req = useRequest()) {
 
     if (req === undefined) {
         // Will not cache outside of a request
+        log(`recordsForUpload(${upload.id}) will not cache for subsequent calls`);
         req = {};
     }
 
     if (!req.recordsForUpload) {
+        log(`initializing req.recordsForUpload cache`);
         req.recordsForUpload = {};
     }
     if (req.recordsForUpload[upload.id]) {

--- a/packages/server/src/arpa_reporter/services/records.js
+++ b/packages/server/src/arpa_reporter/services/records.js
@@ -181,6 +181,10 @@ async function recordsForUpload(upload, req = useRequest()) {
         log(`initializing req.recordsForUpload cache`);
         req.recordsForUpload = {};
     }
+    console.log(`Check: (req === undefined) is ${req === undefined}`);
+    console.log(`Check: (req === null) is ${req === null}`);
+    console.log(`Check: (req.recordsForUpload === null) is ${req.recordsForUpload === null}`);
+    console.log(`Check: (req.recordsForUpload === undefined) is ${req.recordsForUpload === undefined}`);
     if (req.recordsForUpload[upload.id]) {
         log(`recordsForUpload(${upload.id}): reading from cache`);
         return req.recordsForUpload[upload.id];

--- a/packages/server/src/scripts/arpaAuditReport.js
+++ b/packages/server/src/scripts/arpaAuditReport.js
@@ -28,11 +28,14 @@ async function main() {
             // eslint-disable-next-line no-await-in-loop
             const processingSuccessful = await processSQSMessageRequest(message);
             if (processingSuccessful === true) {
+                console.log('Deleting successfully-processed SQS message');
                 // eslint-disable-next-line no-await-in-loop
                 await sqs.send(new DeleteMessageCommand({
                     QueueUrl: queueUrl,
                     ReceiptHandle: message.ReceiptHandle,
                 }));
+            } else {
+                console.log('SQS message was not processed successfully; will not delete');
             }
         } else {
             console.log('Empty messages batch received from SQS');

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -240,6 +240,7 @@ module "arpa_audit_report" {
     NODE_OPTIONS        = "--max_old_space_size=3584" # Reserve 512 MB for other task resources
     NOTIFICATIONS_EMAIL = "grants-notifications@${var.website_domain_name}"
     WEBSITE_DOMAIN      = "https://${var.website_domain_name}"
+    VERBOSE             = "true"
   }
   consumer_task_efs_volume_mounts = [{
     name            = "data"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5602,6 +5602,13 @@ cfb@~1.2.1:
     adler-32 "~1.3.0"
     crc-32 "~1.2.0"
 
+chai-as-promised@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/chai-as-promised/-/chai-as-promised-7.1.1.tgz#08645d825deb8696ee61725dbf590c012eb00ca0"
+  integrity sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==
+  dependencies:
+    check-error "^1.0.2"
+
 chai@^4.3.4:
   version "4.3.10"
   resolved "https://registry.yarnpkg.com/chai/-/chai-4.3.10.tgz#d784cec635e3b7e2ffb66446a63b4e33bd390384"
@@ -5663,7 +5670,7 @@ chardet@^0.7.0:
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
   integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
 
-check-error@^1.0.3:
+check-error@^1.0.2, check-error@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.3.tgz#a6502e4312a7ee969f646e83bb3ddd56281bd694"
   integrity sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==


### PR DESCRIPTION
## Description

This PR contains a few minor changes related to ARPA audit report tasks:
- Additional logging to help debug outstanding task failures
- Set `VERBOSE=true` env var in audit report tasks for enabling additional log output
- Modify `generateAndSendEmail()` so that errors resulting from uploading to S3 and/or sending emails can be caught be callers. The previous behavior was for `generateAndSendEmail()` to catch and log these errors, but that prevents callers from being able to understand whether the operation was successful.
