### PR TITLE
ARPA Audit Report tweaks: Round 2

### DIFF
--- a/packages/server/src/arpa_reporter/lib/audit-report.js
+++ b/packages/server/src/arpa_reporter/lib/audit-report.js
@@ -530,7 +530,7 @@ async function processSQSMessageRequest(message) {
         if (!user) {
             throw new Error(`user not found: ${requestData.userId}`);
         }
-        generateAndSendEmail(ARPA_REPORTER_BASE_URL, user.email, user.tenant_id);
+        await generateAndSendEmail(ARPA_REPORTER_BASE_URL, user.email, user.tenant_id);
     } catch (e) {
         console.error('Failed to generate and send audit report', e);
         return false;

--- a/packages/server/src/arpa_reporter/services/records.js
+++ b/packages/server/src/arpa_reporter/services/records.js
@@ -178,7 +178,7 @@ async function recordsForUpload(upload, req = useRequest()) {
     }
 
     if (!req.recordsForUpload) {
-        log(`initializing req.recordsForUpload cache`);
+        log(`recordsForUpload(${upload.id}) initializing req.recordsForUpload cache`);
         req.recordsForUpload = {};
     }
     console.log(`Check: (req === undefined) is ${req === undefined}`);

--- a/packages/server/src/arpa_reporter/services/records.js
+++ b/packages/server/src/arpa_reporter/services/records.js
@@ -181,14 +181,12 @@ async function recordsForUpload(upload, req = useRequest()) {
         log(`recordsForUpload(${upload.id}) initializing req.recordsForUpload cache`);
         req.recordsForUpload = {};
     }
-    console.log(`Check: (req === undefined) is ${req === undefined}`);
-    console.log(`Check: (req === null) is ${req === null}`);
-    console.log(`Check: (req.recordsForUpload === null) is ${req.recordsForUpload === null}`);
-    console.log(`Check: (req.recordsForUpload === undefined) is ${req.recordsForUpload === undefined}`);
+
     if (req.recordsForUpload[upload.id]) {
         log(`recordsForUpload(${upload.id}): reading from cache`);
         return req.recordsForUpload[upload.id];
     }
+
     log(`recordsForUpload(${upload.id}): reading from disk`);
     const recordPromise = loadRecordsForUpload(upload);
 
@@ -224,9 +222,9 @@ async function mostRecentProjectRecords(periodId, tenantId) {
 
     const latestProjectRecords = allRecords
         .flat()
-    // exclude non-project records
+        // exclude non-project records
         .filter((record) => Object.values(EC_SHEET_TYPES).includes(record.type))
-    // collect the latest record for each project ID
+        // collect the latest record for each project ID
         .reduce(
             (accumulator, record) => {
                 accumulator[record.content.Project_Identification_Number__c] = record;
@@ -250,7 +248,7 @@ async function recordsForProject(periodId, tenantId) {
 
     const projectRecords = allRecords
         .flat()
-    // exclude non-project records
+        // exclude non-project records
         .filter((record) => Object.values(EC_SHEET_TYPES).includes(record.type));
 
     return Object.values(projectRecords);

--- a/packages/server/src/arpa_reporter/services/records.js
+++ b/packages/server/src/arpa_reporter/services/records.js
@@ -202,7 +202,7 @@ async function recordsForReportingPeriod(periodId, tenantId) {
     requiredArgument(periodId, 'must specify periodId in recordsForReportingPeriod');
 
     const uploads = await usedForTreasuryExport(periodId, tenantId);
-    const groupedRecords = await Promise.all(uploads.map(recordsForUpload));
+    const groupedRecords = await Promise.all(uploads.map((upload) => recordsForUpload(upload)));
     return groupedRecords.flat();
 }
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -240,7 +240,6 @@ module "arpa_audit_report" {
     NODE_OPTIONS        = "--max_old_space_size=3584" # Reserve 512 MB for other task resources
     NOTIFICATIONS_EMAIL = "grants-notifications@${var.website_domain_name}"
     WEBSITE_DOMAIN      = "https://${var.website_domain_name}"
-    VERBOSE             = "true"
   }
   consumer_task_efs_volume_mounts = [{
     name            = "data"


### PR DESCRIPTION
## Description

This PR is a continuation of work started in #2011 and contains the following modifications:
- Removes some of the extra-verbose debug log output that is no longer needed.
- Fixes a usage `recordsForUpload()` as a callback for `Array.map()` in `packages/server/src/arpa_reporter/services/records.js`
- Ensures that tasks wait for `generateAndSendEmail()` to finish before returning (missing `await`)
