### PR TITLE
ARPA Audit Report tweaks: Round 3

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -236,6 +236,8 @@ module "arpa_audit_report" {
   stop_timeout_seconds  = 120
   consumer_task_command = ["node", "./src/scripts/arpaAuditReport.js"]
   consumer_container_environment = {
+    API_DOMAIN          = local.api_domain_name
+    AUDIT_REPORT_BUCKET = module.api.arpa_audit_reports_bucket_id
     DATA_DIR            = "/var/data"
     NODE_OPTIONS        = "--max_old_space_size=3584" # Reserve 512 MB for other task resources
     NOTIFICATIONS_EMAIL = "grants-notifications@${var.website_domain_name}"

--- a/terraform/modules/gost_api/outputs.tf
+++ b/terraform/modules/gost_api/outputs.tf
@@ -28,6 +28,10 @@ output "ecs_task_role_name" {
   value = join("", aws_iam_role.task.*.name)
 }
 
+output "arpa_audit_reports_bucket_id" {
+  value = module.arpa_audit_reports_bucket.bucket_id
+}
+
 output "arpa_audit_reports_bucket_arn" {
   value = module.arpa_audit_reports_bucket.bucket_arn
 }


### PR DESCRIPTION
## Description

Third round of changes for fixing ARPA audit reports. In this PR, we're ensuring two environment variables are defined in consumer tasks:
- `API_DOMAIN`: Used to create download links for emails
- `AUDIT_REPORT_BUCKET`: Used to store generated audit reports