### PR TITLE
fix: prevent empty search causing 500s

### DIFF
--- a/packages/server/__tests__/api/grants.test.js
+++ b/packages/server/__tests__/api/grants.test.js
@@ -760,6 +760,14 @@ HHS-2021-IHS-TPI-0001,Community Health Aide Program:  Tribal Planning &`;
                     }
                 }
             });
+            it('with empty includeKeywords', async () => {
+                const response = await fetchApi(`/grants/next?pagination[currentPage]=1&pagination[perPage]=50&ordering[orderBy]=rank&criteria[includeKeywords]=&criteria[opportunityStatuses]=posted`, agencies.own, fetchOptions.staff);
+                expect(response.statusText).to.equal('OK');
+            });
+            it('with empty excludeKeywords', async () => {
+                const response = await fetchApi(`/grants/next?pagination[currentPage]=1&pagination[perPage]=50&ordering[orderBy]=rank&criteria[excludeKeywords]=&criteria[opportunityStatuses]=posted`, agencies.own, fetchOptions.staff);
+                expect(response.statusText).to.equal('OK');
+            });
         });
     });
 });


### PR DESCRIPTION
### Ticket #1829 
## Description
Creating an empty search from the client can cause a 500 if we try to order by a non-existent column.

## Screenshots / Demo Video

## Testing

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [ ] Provided ticket and description
- [ ] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers