### PR TITLE
Allow `persistJson()` to overwrite files

### DIFF
--- a/packages/server/src/arpa_reporter/services/persist-upload.js
+++ b/packages/server/src/arpa_reporter/services/persist-upload.js
@@ -216,7 +216,7 @@ async function persistJson(upload, workbook) {
             try {
                 const filename = jsonFSName(upload);
                 await fs.mkdir(path.dirname(filename), { recursive: true });
-                await fs.writeFile(filename, Cryo.stringify(workbook), { flag: 'wx' });
+                await fs.writeFile(filename, Cryo.stringify(workbook), { flag: 'w' });
             } catch (e) {
                 throw new ValidationError(`Cannot persist ${upload.filename} to filesystem: ${e}`);
             }


### PR DESCRIPTION
## Description

This PR addresses an [issue](https://app.datadoghq.com/logs?query=host%3Agost-prod-arpa_audit_report-20230929025001186300000006%20service%3Acloudwatch%20%40aws.awslogs.logGroup%3Agost-prod-arpa_audit_report-20230929025001186300000006%20&agg_q=status%2Cservice&cols=host%2Cservice&context_event=AYr3AeoBAACEuU9IUhmOdwAD&event=&index=%2A&messageDisplay=inline&refresh_mode=paused&sort_m=%2C&sort_t=%2C&storage=hot&stream_sort=time%2Cdesc&to_event=AgAAAYr3AwJ-Jb8czwAAAAAAAAAYAAAAAEFZcjNBd29XQUFCc1N5Ylk3S0RCY0FBQQAAACQAAAAAMDE4YWY3MGUtYWEwMC00Yzc5LWJkZmQtOGQ4ZGIyNzBlNjFh&top_n=10%2C10&top_o=top%2Ctop&viz=&x_missing=true%2Ctrue&from_ts=1696360908775&to_ts=1696361284223&live=false) where the `persistJson()` function in `packages/server/src/arpa_reporter/services/persist-upload.js` throws an error when attempting to save workbook JSON to the local disk cache. Although the `workbookForUpload()` function only calls `persistJson()` after first determining that the file in question does not exist, it's possible that a concurrent operation has created the file in the intervening time it took to build the workbook JSON (which is a slow operation).

In that case, we have three options:
1. The resulting `EEXIST` IO error causes audit report generation to fail (this is what happens currently).
2. Discard the just-built workbook JSON, perform another check for the existence of the cached file, and either return that if successful, or fail if it (still) doesn't exist.
3. Allow the existing cached file to be overwritten.
4. Don't overwrite the file, but use the JSON on-hand anyway.

I chose Option 3 in this case since, as fresh JSON data is already on-hand, it seems like we'd still want to use it, and although the in-memory JSON is likely identical to what's already on-disk (which would require even more time/resources to determine and short-circuit), it could also represent more up-to-date data that would freshen the cache.