### PR TITLE
Fix monitor name: "ARPA audit report job failed"

### DIFF
--- a/terraform/datadog_monitors.tf
+++ b/terraform/datadog_monitors.tf
@@ -46,7 +46,7 @@ resource "datadog_monitor" "consume_grants-event_failed" {
 resource "datadog_monitor" "arpa_audit_report-task_failed" {
   count = var.datadog_monitors_enabled ? 1 : 0
 
-  name = "${local.dd_monitor_name_prefix}: Grant modification events failed to process"
+  name = "${local.dd_monitor_name_prefix}: ARPA audit report job failed"
   type = "metric alert"
   message = join("\n", [
     "{{#is_alert}}",


### PR DESCRIPTION
## Description

One of our Datadog monitors is named incorrectly. Although it has been manually updated in Datadog, but since the monitor resource is managed by Terraform, it will eventually get overwritten. This PR resolves the issue by ensuring that the monitor is named correctly by Terraform.