### PR TITLE
fix: disable components while loading search results

### DIFF
--- a/packages/client/src/components/GrantsTableNext.vue
+++ b/packages/client/src/components/GrantsTableNext.vue
@@ -2,15 +2,15 @@
   <section class="container-fluid grants-table-container">
     <b-row class="my-3" v-if="showSearchControls">
       <div class="ml-3">
-        <SavedSearchPanel />
+        <SavedSearchPanel :isDisabled="loading" />
       </div>
       <div class="ml-2">
-        <SearchPanel ref="searchPanel" :search-id="Number(editingSearchId)" @filters-applied="paginateGrants" />
+        <SearchPanel :isDisabled="loading" ref="searchPanel" :search-id="Number(editingSearchId)" @filters-applied="paginateGrants" />
       </div>
     </b-row>
     <b-row  class="grants-table-title-control">
       <b-col v-if="showSearchControls" >
-        <SearchFilter :filterKeys="searchFilters" @filter-removed="clearSearch" />
+        <SearchFilter :isDisabled="loading" :filterKeys="searchFilters" @filter-removed="clearSearch" />
       </b-col>
       <b-col align-self="end" v-if="!showSearchControls">
         <h4 class="mb-0">{{ searchTitle }}</h4>

--- a/packages/client/src/components/Modals/SavedSearchPanel.vue
+++ b/packages/client/src/components/Modals/SavedSearchPanel.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="saved-search-panel">
-    <b-button @click="initManageSearches" variant="primary" size="sm">
+    <b-button @click="initManageSearches" variant="primary" size="sm" :disabled="isDisabled">
       My Saved Searches
     </b-button>
     <b-sidebar
@@ -89,6 +89,7 @@ import { formatFilterDisplay } from '@/helpers/filters';
 export default {
   props: {
     showModal: Boolean,
+    isDisabled: Boolean,
   },
   directives: {
     'v-b-toggle': VBToggle,

--- a/packages/client/src/components/Modals/SearchPanel.vue
+++ b/packages/client/src/components/Modals/SearchPanel.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="search-panel">
-      <b-button @click="initNewSearch" variant="outline-primary" size="sm">
+      <b-button @click="initNewSearch" variant="outline-primary" size="sm" :disabled="isDisabled">
         New Search
       </b-button>
 
@@ -241,6 +241,7 @@ export default {
     SearchType: String,
     showModal: Boolean,
     searchId: Number,
+    isDisabled: Boolean,
   },
   directives: {
     'v-b-toggle': VBToggle,

--- a/packages/client/src/components/SearchFilter.vue
+++ b/packages/client/src/components/SearchFilter.vue
@@ -43,13 +43,13 @@ export default {
       return value;
     },
     editFilter() {
-      if (!this.isDisabled) {
+      if (this.isDisabled) {
         return;
       }
       this.initEditSearch(this.selectedSearch.id);
     },
     clearAll() {
-      if (!this.isDisabled) {
+      if (this.isDisabled) {
         return;
       }
       this.clearSelectedSearch();

--- a/packages/client/src/components/SearchFilter.vue
+++ b/packages/client/src/components/SearchFilter.vue
@@ -4,7 +4,8 @@
       <div class="align-self-end">
         <h4 class="mb-0">{{ selectedSearch === null ? "All Grants" : searchName }} </h4>
         <span v-if="selectedSearch !== null">
-          <a href="#" v-on:click.prevent="editFilter">Edit</a> | <a href="#" v-on:click.prevent="clearAll" >Clear</a>
+          <a href="#" :class="{ inactiveLink: isDisabled }" v-on:click.prevent="editFilter">Edit</a> |
+          <a href="#" :class="{ inactiveLink: isDisabled }" v-on:click.prevent="clearAll" >Clear</a>
         </span>
       </div>
       <span class="filter-item" v-for="(item, idx) in $props.filterKeys" :key="idx">
@@ -18,6 +19,7 @@ import { mapActions, mapGetters } from 'vuex';
 
 export default {
   props: {
+    isDisabled: Boolean,
     filterKeys: {
       type: Array,
       required: true,
@@ -41,9 +43,15 @@ export default {
       return value;
     },
     editFilter() {
+      if (!this.isDisabled) {
+        return;
+      }
       this.initEditSearch(this.selectedSearch.id);
     },
     clearAll() {
+      if (!this.isDisabled) {
+        return;
+      }
       this.clearSelectedSearch();
       this.$emit('filter-removed');
     },
@@ -63,3 +71,9 @@ export default {
 };
 
 </script>
+<style>
+.inactiveLink {
+  pointer-events: none;
+  color: grey;
+}
+</style>


### PR DESCRIPTION
### Ticket #1829 
## Description
Prevents clicking on buttons and links that would change a search already in progress.

## Screenshots / Demo Video
[Screencast from 10-06-2023 12:25:30 PM.webm](https://github.com/usdigitalresponse/usdr-gost/assets/64168322/02bb3b9e-9665-416c-9747-e4b189c20407)

## Testing

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [ ] Provided ticket and description
- [ ] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers