### PR TITLE
Fix: Provide missing argument to `createReportsGroupedByProject()`

### DIFF
--- a/packages/server/src/arpa_reporter/lib/audit-report.js
+++ b/packages/server/src/arpa_reporter/lib/audit-report.js
@@ -388,6 +388,7 @@ async function generate(requestHost, tenantId) {
             async () => createReportsGroupedByProject(
                 periodId,
                 tenantId,
+                REPORTING_DATE_FORMAT,
                 logger.child({ sheet: { name: 'Project Summaries V2' } }),
             ));
         const KPIDataGroupedByProject = await tracer.trace('createKpiDataGroupedByProject',


### PR DESCRIPTION
### Fixes an issue introduced in #2036 
## Description

This PR is a one-line change to ensure all arguments are provided to `createReportsGroupedByProject()` during ARPA audit report generation. The previous PR introduced this issue as a result of adding a new optional argument to `createReportsGroupedByProject()`, and passing that value during the call. However, I neglected to realize that the caller was relying on the previously-last argument's default, so this happened:
- Before #2036:
  - Function signature: 
    ```js
    async function createReportsGroupedByProject(periodId, tenantId, dateFormat = REPORTING_DATE_FORMAT) {
    ```
  - Call (relies on the default `REPORTING_DATE_FORMAT`): 
    ```js
    createReportsGroupedByProject(periodId, tenantId)
    ```
- After #2036:
  - Function signature (new optional argument):
    ```js
    async function createReportsGroupedByProject(periodId, tenantId, dateFormat = REPORTING_DATE_FORMAT, logger = log)
    ```
  - Call (neglects to account for `dateFormat`, so `logger` gets passed to that):
    ```js
    createReportsGroupedByProject(periodId, tenantId, logger)
    ```
- Solution in this PR:
  - Call (passes all arguments):
    ```js
    createReportsGroupedByProject(periodId, tenantId, REPORTING_DATE_FORMAT, logger)
    ```