### PR TITLE
fix: inconsistent checkbox state for opp status

### DIFF
--- a/packages/client/src/components/Modals/SearchPanel.vue
+++ b/packages/client/src/components/Modals/SearchPanel.vue
@@ -265,7 +265,9 @@ export default {
       ],
       opportunityStatusOptions: [
         { text: 'Posted', value: 'posted' },
-        { text: 'Closed / Archived', value: ['closed', 'archived'] },
+        // b-form-checkbox-group doesn't handle multiple values well 'archived' is added
+        // whenever 'closed' is checked, but as post processing step. See apply()
+        { text: 'Closed / Archived', value: 'closed' },
       ],
     };
   },
@@ -341,6 +343,11 @@ export default {
     },
     apply() {
       const formDataCopy = { ...this.formData.criteria };
+      // b-form-checkbox-group doesn't handle multiple values well. To include 'achived' whenever
+      // we click 'closed', we add 'archived' when it comes off of the form. See also initFormState()
+      if (formDataCopy?.opportunityStatuses.find((e) => e === 'closed')) {
+        formDataCopy.opportunityStatuses.push('archived');
+      }
       this.applyFilters(formDataCopy);
       this.initViewResults();
     },
@@ -357,6 +364,9 @@ export default {
         this.formData.searchId = search.id;
         this.formData.searchTitle = search.name;
         const criteria = JSON.parse(search.criteria);
+        // b-form-checkbox-group doesn't handle multiple values well. 'archive' will be stored
+        // when we display 'closed' as checked. We remove it here for consistency. See also apply()
+        criteria.opportunityStatuses = criteria.opportunityStatuses.filter((item) => item !== 'archived');
         this.formData.criteria = { ...criteria };
       } else {
         this.formData.searchId = null;


### PR DESCRIPTION
### Ticket #2034 
## Description

The b-form-checkbox-group doesn't always reflect the correct selection state when an option value is specified as an array instead of a string. This change adds the 'archived' when 'closed' is selected, and maintains that separately for the saved searches vs. the checkbox component.

## Screenshots / Demo Video
[Screencast from 10-07-2023 06:40:10 PM.webm](https://github.com/usdigitalresponse/usdr-gost/assets/64168322/8489b288-9585-4c3e-bf24-336f62808ebe)

## Testing

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [ ] Provided ticket and description
- [ ] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers