### PR TITLE
ARPA audit report tuning: Round 2

### DIFF
--- a/packages/server/__tests__/arpa_reporter/server/routes/audit_report.spec.js
+++ b/packages/server/__tests__/arpa_reporter/server/routes/audit_report.spec.js
@@ -3,6 +3,7 @@ const sinon = require('sinon');
 const { makeTestServer, getSessionCookie } = require('./route_test_helpers');
 const audit_report = require('../../../../src/arpa_reporter/lib/audit-report');
 const aws = require('../../../../src/lib/gost-aws');
+const { ARPA_REPORTER_BASE_URL } = require('../../../../src/arpa_reporter/environment');
 
 function headObjectFake(type, callback) {
     if (type === 'error') {
@@ -62,7 +63,7 @@ describe('/api/audit_report', () => {
             .get('/api/audit_report/0/99/example.xlsx');
 
         expect(response.status).to.equal(302);
-        expect(response.headers.location).to.equal('http://localhost:8080/arpa_reporter/login?redirect_to=/api/audit_report/0/99/example.xlsx&message=Please%20login%20to%20visit%20the%20link.');
+        expect(response.headers.location).to.equal(`${ARPA_REPORTER_BASE_URL}/login?redirect_to=/api/audit_report/0/99/example.xlsx&message=Please%20login%20to%20visit%20the%20link.`);
     });
     it('Signed URL - redirects when object is not found', async () => {
         const s3InstanceFake = sandbox.fake.returns('just s3');
@@ -77,7 +78,7 @@ describe('/api/audit_report', () => {
             .set('Cookie', tenantACookie);
 
         expect(response.status).to.equal(302);
-        expect(response.headers.location).to.equal(`http://localhost:8080/arpa_reporter?alert_text=The%20audit%20report%20you%20requested%20has%20expired.%20Please%20try%20again%20by%20clicking%20the%20'Send%20Audit%20Report%20By%20Email'.&alert_level=err`);
+        expect(response.headers.location).to.equal(`${ARPA_REPORTER_BASE_URL}?alert_text=The%20audit%20report%20you%20requested%20has%20expired.%20Please%20try%20again%20by%20clicking%20the%20'Send%20Audit%20Report%20By%20Email'.&alert_level=err`);
     });
     it('Signed URL - redirects to login page when user is accessing wrong tenant', async () => {
         const s3InstanceFake = sandbox.fake.returns('just s3');
@@ -92,7 +93,7 @@ describe('/api/audit_report', () => {
             .set('Cookie', tenantACookie);
 
         expect(response.status).to.equal(302);
-        expect(response.headers.location).to.equal(`http://localhost:8080/arpa_reporter/login?redirect_to=/api/audit_report/1/99/example.xlsx&message=Please%20login%20to%20visit%20the%20link.`);
+        expect(response.headers.location).to.equal(`${ARPA_REPORTER_BASE_URL}/login?redirect_to=/api/audit_report/1/99/example.xlsx&message=Please%20login%20to%20visit%20the%20link.`);
     });
     it('Signed URL - returns redirect with message when there is an issue generating URL', async () => {
         const s3InstanceFake = sandbox.fake.returns('just s3');
@@ -109,7 +110,7 @@ describe('/api/audit_report', () => {
             .set('Cookie', tenantACookie);
 
         expect(response.status).to.equal(302);
-        expect(response.headers.location).to.equal(`http://localhost:8080/arpa_reporter?alert_text=Something%20went%20wrong.%20Please%20reach%20out%20to%20grants-helpdesk@usdigitalresponse.org.&alert_level=err`);
+        expect(response.headers.location).to.equal(`${ARPA_REPORTER_BASE_URL}?alert_text=Something%20went%20wrong.%20Please%20reach%20out%20to%20grants-helpdesk@usdigitalresponse.org.&alert_level=err`);
     });
     it('Signed URL - Success response', async () => {
         const s3InstanceFake = sandbox.fake.returns('just s3');

--- a/packages/server/__tests__/arpa_reporter/server/routes/exports.spec.js
+++ b/packages/server/__tests__/arpa_reporter/server/routes/exports.spec.js
@@ -4,6 +4,7 @@ const sinon = require('sinon');
 const { makeTestServer, getSessionCookie } = require('./route_test_helpers');
 const arpa = require('../../../../src/arpa_reporter/services/generate-arpa-report');
 const aws = require('../../../../src/lib/gost-aws');
+const { ARPA_REPORTER_BASE_URL } = require('../../../../src/arpa_reporter/environment');
 
 function headObjectFake(type, callback) {
     if (type === 'error') {
@@ -101,7 +102,7 @@ describe('/api/exports', () => {
             .get('/api/exports/0/99/example.xlsx');
 
         expect(response.status).to.equal(302);
-        expect(response.headers.location).to.equal('http://localhost:8080/arpa_reporter/login?redirect_to=/api/exports/0/99/example.xlsx&message=Please%20login%20to%20visit%20the%20link.');
+        expect(response.headers.location).to.equal(`${ARPA_REPORTER_BASE_URL}/login?redirect_to=/api/exports/0/99/example.xlsx&message=Please%20login%20to%20visit%20the%20link.`);
     });
     it('Signed URL - redirects when object is not found', async () => {
         const s3InstanceFake = sandbox.fake.returns('just s3');
@@ -116,7 +117,7 @@ describe('/api/exports', () => {
             .set('Cookie', tenantACookie);
 
         expect(response.status).to.equal(302);
-        expect(response.headers.location).to.equal(`http://localhost:8080/arpa_reporter?alert_text=The%20treasury%20report%20you%20requested%20has%20expired.%20Please%20try%20again%20by%20clicking%20the%20'Send%20Treasury%20Report%20By%20Email'.&alert_level=err`);
+        expect(response.headers.location).to.equal(`${ARPA_REPORTER_BASE_URL}?alert_text=The%20treasury%20report%20you%20requested%20has%20expired.%20Please%20try%20again%20by%20clicking%20the%20'Send%20Treasury%20Report%20By%20Email'.&alert_level=err`);
     });
     it('Signed URL - redirects to login page when user is accessing wrong tenant', async () => {
         const s3InstanceFake = sandbox.fake.returns('just s3');
@@ -131,7 +132,7 @@ describe('/api/exports', () => {
             .set('Cookie', tenantACookie);
 
         expect(response.status).to.equal(302);
-        expect(response.headers.location).to.equal(`http://localhost:8080/arpa_reporter/login?redirect_to=/api/exports/1/99/example.xlsx&message=Please%20login%20to%20visit%20the%20link.`);
+        expect(response.headers.location).to.equal(`${ARPA_REPORTER_BASE_URL}/login?redirect_to=/api/exports/1/99/example.xlsx&message=Please%20login%20to%20visit%20the%20link.`);
     });
     it('Signed URL - returns redirect with message when there is an issue generating URL', async () => {
         const s3InstanceFake = sandbox.fake.returns('just s3');
@@ -148,7 +149,7 @@ describe('/api/exports', () => {
             .set('Cookie', tenantACookie);
 
         expect(response.status).to.equal(302);
-        expect(response.headers.location).to.equal(`http://localhost:8080/arpa_reporter?alert_text=Something%20went%20wrong.%20Please%20reach%20out%20to%20grants-helpdesk@usdigitalresponse.org.&alert_level=err`);
+        expect(response.headers.location).to.equal(`${ARPA_REPORTER_BASE_URL}?alert_text=Something%20went%20wrong.%20Please%20reach%20out%20to%20grants-helpdesk@usdigitalresponse.org.&alert_level=err`);
     });
     it('Signed URL - Success response', async () => {
         const s3InstanceFake = sandbox.fake.returns('just s3');

--- a/packages/server/__tests__/email/email.test.js
+++ b/packages/server/__tests__/email/email.test.js
@@ -78,9 +78,6 @@ describe('Email module', () => {
         });
 
         it('Fails when NOTIFICATIONS_EMAIL is missing', async () => {
-            // 'send' will throw no error, but will log an error to the console.
-            // However, without returning the result of the promise in 'send',
-            // we can't capture it here
             delete process.env.NOTIFICATIONS_EMAIL;
             let err = { message: 'No error' };
 
@@ -89,7 +86,10 @@ describe('Email module', () => {
             } catch (e) {
                 err = e;
             }
-            expect(err.message).to.equal('No error');
+            // expect(err.message).to.equal('No error');
+            expect(err.message).to.be.a('string').and.satisfy(
+                (msg) => msg.startsWith('exception while calling ses.SendEmail'),
+            );
         });
         xit('Works when AWS credentials are valid but expect email to be unverified', async () => {
             const expects = 'Email address is not verified.';

--- a/packages/server/__tests__/email/email.test.js
+++ b/packages/server/__tests__/email/email.test.js
@@ -18,6 +18,7 @@ const {
     AWS_ACCESS_KEY_ID,
     AWS_SECRET_ACCESS_KEY,
     AWS_DEFAULT_REGION,
+    AWS_REGION,
     NOTIFICATIONS_EMAIL,
 
     NODEMAILER_HOST,
@@ -38,6 +39,7 @@ describe('Email module', () => {
         process.env.AWS_ACCESS_KEY_ID = AWS_ACCESS_KEY_ID;
         process.env.AWS_SECRET_ACCESS_KEY = AWS_SECRET_ACCESS_KEY;
         process.env.AWS_DEFAULT_REGION = AWS_DEFAULT_REGION;
+        process.env.AWS_REGION = AWS_REGION;
         process.env.NOTIFICATIONS_EMAIL = NOTIFICATIONS_EMAIL;
         process.env.NODEMAILER_HOST = NODEMAILER_HOST;
         process.env.NODEMAILER_PORT = NODEMAILER_PORT;
@@ -55,6 +57,7 @@ describe('Email module', () => {
     function clearSESEnvironmentVariables() {
         delete process.env.AWS_ACCESS_KEY_ID;
         delete process.env.AWS_SECRET_ACCESS_KEY;
+        delete process.env.AWS_REGION;
         delete process.env.AWS_DEFAULT_REGION;
         delete process.env.NOTIFICATIONS_EMAIL;
     }
@@ -81,6 +84,7 @@ describe('Email module', () => {
             process.env.AWS_ACCESS_KEY_ID = 'testing';
             process.env.AWS_SECRET_ACCESS_KEY = 'testing';
             process.env.AWS_DEFAULT_REGION = 'us-west-2';
+            process.env.AWS_REGION = 'us-west-2';
             process.env.NOTIFICATIONS_EMAIL = 'fake@example.org';
         });
 
@@ -95,7 +99,7 @@ describe('Email module', () => {
             }
             // expect(err.message).to.equal('No error');
             expect(err.message).to.be.a('string').and.satisfy(
-                (msg) => msg.startsWith('exception while calling ses.SendEmail'),
+                (msg) => msg.startsWith('NOTIFICATIONS_EMAIL is not set'),
             );
         });
         xit('Works when AWS credentials are valid but expect email to be unverified', async () => {

--- a/packages/server/__tests__/email/email.test.js
+++ b/packages/server/__tests__/email/email.test.js
@@ -17,6 +17,7 @@ const {
 
     AWS_ACCESS_KEY_ID,
     AWS_SECRET_ACCESS_KEY,
+    AWS_DEFAULT_REGION,
     NOTIFICATIONS_EMAIL,
 
     NODEMAILER_HOST,
@@ -36,6 +37,7 @@ describe('Email module', () => {
         process.env.TEST_EMAIL_RECIPIENT = TEST_EMAIL_RECIPIENT;
         process.env.AWS_ACCESS_KEY_ID = AWS_ACCESS_KEY_ID;
         process.env.AWS_SECRET_ACCESS_KEY = AWS_SECRET_ACCESS_KEY;
+        process.env.AWS_DEFAULT_REGION = AWS_DEFAULT_REGION;
         process.env.NOTIFICATIONS_EMAIL = NOTIFICATIONS_EMAIL;
         process.env.NODEMAILER_HOST = NODEMAILER_HOST;
         process.env.NODEMAILER_PORT = NODEMAILER_PORT;
@@ -53,6 +55,7 @@ describe('Email module', () => {
     function clearSESEnvironmentVariables() {
         delete process.env.AWS_ACCESS_KEY_ID;
         delete process.env.AWS_SECRET_ACCESS_KEY;
+        delete process.env.AWS_DEFAULT_REGION;
         delete process.env.NOTIFICATIONS_EMAIL;
     }
 
@@ -75,6 +78,10 @@ describe('Email module', () => {
     context('AWS SES', () => {
         beforeEach(() => {
             clearNodemailerEnvironmentVariables();
+            process.env.AWS_ACCESS_KEY_ID = 'testing';
+            process.env.AWS_SECRET_ACCESS_KEY = 'testing';
+            process.env.AWS_DEFAULT_REGION = 'us-west-2';
+            process.env.NOTIFICATIONS_EMAIL = 'fake@example.org';
         });
 
         it('Fails when NOTIFICATIONS_EMAIL is missing', async () => {

--- a/packages/server/__tests__/email/email.test.js
+++ b/packages/server/__tests__/email/email.test.js
@@ -102,18 +102,6 @@ describe('Email module', () => {
                 (msg) => msg.startsWith('NOTIFICATIONS_EMAIL is not set'),
             );
         });
-        xit('Works when AWS credentials are valid but expect email to be unverified', async () => {
-            const expects = 'Email address is not verified.';
-            let err;
-            let result;
-            try {
-                result = await emailService.getTransport().sendEmail(testEmail);
-            } catch (e) {
-                err = e;
-            }
-            expect(err.message).to.contain(expects);
-            expect(typeof result.MessageId).to.equal('string');
-        });
     });
     context('Nodemailer', () => {
         beforeEach(() => {

--- a/packages/server/__tests__/email/email.test.js
+++ b/packages/server/__tests__/email/email.test.js
@@ -111,6 +111,9 @@ describe('Email module', () => {
         });
         it('Fails when NODEMAILER_PORT is missing', async () => {
             delete process.env.NODEMAILER_PORT;
+            if (!process.env.NODEMAILER_HOST) {
+                process.env.NODEMAILER_HOST = 'example.org';
+            }
             const expects = 'Missing environment variable NODEMAILER_PORT!';
             let err = { message: 'No error' };
 
@@ -123,6 +126,9 @@ describe('Email module', () => {
         });
         it('Fails when NODEMAILER_EMAIL is missing', async () => {
             delete process.env.NODEMAILER_EMAIL;
+            if (!process.env.NODEMAILER_HOST) {
+                process.env.NODEMAILER_HOST = 'example.org';
+            }
             const expects = 'Missing environment variable NODEMAILER_EMAIL!';
             let err = { message: 'No error' };
 
@@ -135,6 +141,9 @@ describe('Email module', () => {
         });
         it('Fails when NODEMAILER_EMAIL_PW is missing', async () => {
             delete process.env.NODEMAILER_EMAIL_PW;
+            if (!process.env.NODEMAILER_HOST) {
+                process.env.NODEMAILER_HOST = 'example.org';
+            }
             const expects = 'Missing environment variable NODEMAILER_EMAIL_PW!';
             let err = { message: 'No error' };
 

--- a/packages/server/__tests__/lib/grants-ingest.test.js
+++ b/packages/server/__tests__/lib/grants-ingest.test.js
@@ -12,9 +12,12 @@ describe('processMessages', async () => {
 
     const serlializeGrantEvent = (newData = {}, prevData = {}) => {
         const eventData = { detail: { versions: { new: newData, previous: prevData } } };
-        if (newData !== {} && prevData !== {}) {
+        const newDataJSON = JSON.stringify(newData);
+        const prevDataJSON = JSON.stringify(prevData);
+        const emptyObjectJSON = JSON.stringify({});
+        if (newDataJSON !== emptyObjectJSON && prevDataJSON !== emptyObjectJSON) {
             eventData.detail.type = 'update';
-        } else if (newData !== {}) {
+        } else if (newDataJSON !== emptyObjectJSON) {
             eventData.detail.type = 'create';
         } else {
             eventData.detail.type = 'delete';

--- a/packages/server/src/arpa_reporter/services/records.js
+++ b/packages/server/src/arpa_reporter/services/records.js
@@ -258,6 +258,7 @@ module.exports = {
     recordsForReportingPeriod,
     recordsForUpload,
     mostRecentProjectRecords,
+    EC_SHEET_TYPES,
     DATA_SHEET_TYPES,
     TYPE_TO_SHEET_NAME,
     readVersionRecord,

--- a/packages/server/src/lib/gost-aws.js
+++ b/packages/server/src/lib/gost-aws.js
@@ -86,8 +86,8 @@ async function sendEmail(message) {
     };
     const command = new SendEmailCommand(params);
     try {
-        await transport.send(command)
-            .then((data) => console.log('Success sending SES email:', JSON.stringify(data)));
+        const data = await transport.send(command);
+        console.log('Success sending SES email:', JSON.stringify(data));
     } catch (err) {
         console.error('Error sending SES email:', err, err.stack);
         throw err;

--- a/packages/server/src/lib/gost-aws.js
+++ b/packages/server/src/lib/gost-aws.js
@@ -58,7 +58,7 @@ function getSESClient() {
     return new SESClient(sesOptions);
 }
 
-function sendEmail(message) {
+async function sendEmail(message) {
     if (process.env.SUPPRESS_EMAIL) return;
 
     const transport = getSESClient();
@@ -85,9 +85,13 @@ function sendEmail(message) {
         },
     };
     const command = new SendEmailCommand(params);
-    transport.send(command)
-        .then((data) => console.log('Success sending SES email:', JSON.stringify(data)))
-        .catch((err) => console.error('Error sending SES email:', err, err.stack));
+    try {
+        await transport.send(command)
+            .then((data) => console.log('Success sending SES email:', JSON.stringify(data)));
+    } catch (err) {
+        console.error('Error sending SES email:', err, err.stack);
+        throw err;
+    }
 }
 
 /*

--- a/packages/server/src/lib/gost-aws.js
+++ b/packages/server/src/lib/gost-aws.js
@@ -60,6 +60,7 @@ function getSESClient() {
 
 async function sendEmail(message) {
     if (process.env.SUPPRESS_EMAIL) return;
+    if (!process.env.NOTIFICATIONS_EMAIL) throw new Error('NOTIFICATIONS_EMAIL is not set');
 
     const transport = getSESClient();
     const params = {


### PR DESCRIPTION
## Description

This PR provides further performance/reliability optimizations (and a few other tweaks) for the ARPA audit report. 

Summary of changes:
- Refactor the `createProjectSummaries()` function to only use a single Postgres query in order to build the report.
  - Although the number of queries emitted over building this spreadsheet were not contributing to performance issues on the Postgres side, the number of queries executed in-parallel were maxing out the available number of (local) connections maintained by Knex. 
  - The previous query patterns were to execute several deeply-nested queries:
    - To find the current reporting period
    - To find all previous (non-current) reporting periods
    - For each identified reporting period, at least one query to find all uploads associated with the reporting period
  - The unbounded (especially when concurrent) querying behavior was causing certain generate-and-send processes to fail in Production. Now, only a single query is issued when generating this spreadsheet.
  - **Note:** the number of rows potentially fetched by this query is (still) unbounded. While not currently an issue, we can expect this number to grow per-tenant over time. Further work is warranted to pre-compute the results of this query at the point when a new file contributing to the audit report is uploaded.
  - This query is similar to that which is produced by the `usedForTreasuryExport()` helper function, although it contains a few optimizations for limiting both the number of returned rows and for limiting the virtual table size for inner-join operations.
  - In addition to reducing the number of Postgres queries, the new query pattern yields additional memory optimizations for the `Project Summaries` sheet generation process. 
    - Although other recent PRs have introduced concurrency limits to control sudden memory usage spikes, the total amount of memory required by the `createProjectSummaries()` was still dependent on being able to load all records from all uploads in all reporting periods.
    - With these changes, we only load records for a single upload at a time, and the only record-derived data retained across the sheet-building process are the values used in the final rows. Therefore, the amount of memory required at any given moment during the function call is more-closely aligned to the aggregate row data and/or the number of records in a single upload. This is still unbounded (and the size of a single upload and/or the total amount of project data in a`Project Summaries` sheet may very well still cause problems down the line), but this buys us some runway by avoiding the need to hold multiple uploaded spreadsheets in memory at once.
- Update the behavior of sending SES emails through the AWS transport to throw errors instead of just logging them. This is necessary to ensure that workflows which cannot be considered successful (such as the ARPA report-generation process) unless an email is sent. The previous "fire-and-forget" async behavior caused the generate-and-send process to "finish" before the `sendEmail()` call had returned.
- Updated various unit tests with hard-coded `localhost` expectations in the ARPA suite to instead use the configured `ARPA_REPORTER_BASE_URL` value.

**Next steps**
1. Once these changes have been tested and confirmed as working successfully, we should be able to re-enable the ability for partners to request ARPA audit report emails.
2. The optimizations in this PR should be applicable to other sheet-generating functions in the ARPA audit report workflow. We should prioritize which of those warrant similar optimization efforts and follow up accordingly.
3. As mentioned above, a better long-term solution for limiting resource requirements (and relatedly, keeping email-sending times within the 1-hour limit) lies in a strategy that maintains precomputed, running aggregates values for these spreadsheets. We should investigate and discuss whether it's worth exploring those sooner than we might be able to deliver a modular reporting tool.

## Testing

- Follow the testing path outlined in the QA script for uploading files and requesting an ARPA audit report.

### Automated and Unit Tests
- [x] Added Unit tests

### Manual tests for Reviewer
- [x] Added steps to test feature/functionality manually

## Checklist
- [x] Provided ticket and description
- [] Provided screenshots/demo
- [x] Provided testing information
- [x] Provided adequate test coverage for all new code 
- [x] Added PR reviewers