### PR TITLE
Fix: Set consistent arch for postgres to avoid Docker issue on Apple Silicon Macs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,6 +66,7 @@ services:
     container_name: gost-postgres
     hostname: postgres
     image: 'bitnami/postgresql:14.4.0'
+    platform: linux/amd64
     networks:
       - postgres
     environment:


### PR DESCRIPTION
Fix: Workaround for issue where Docker can't find the right image for an Apple Silicon Mac. Making this change will provide consistency for all contributors, ensuring everyone is working against the same emulated environment.