### PR TITLE
Enable debug logs for audit report tasks

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -239,6 +239,8 @@ module "arpa_audit_report" {
     API_DOMAIN          = "https://${local.api_domain_name}"
     AUDIT_REPORT_BUCKET = module.api.arpa_audit_reports_bucket_id
     DATA_DIR            = "/var/data"
+    LOG_LEVEL           = "DEBUG"
+    LOG_SRC_ENABLED     = "false"
     NODE_OPTIONS        = "--max_old_space_size=3584" # Reserve 512 MB for other task resources
     NOTIFICATIONS_EMAIL = "grants-notifications@${var.website_domain_name}"
     WEBSITE_DOMAIN      = "https://${var.website_domain_name}"


### PR DESCRIPTION
Just like it says – this PR enables debug-level logs for audit report tasks by setting the `LOG_LEVEL=debug` in the task's environment variables.

`LOG_SRC_ENABLED=false` is also set for good measure.