### PR TITLE
Ensure Project IDs are treated as strings

### DIFF
--- a/packages/server/src/arpa_reporter/lib/audit-report.js
+++ b/packages/server/src/arpa_reporter/lib/audit-report.js
@@ -204,7 +204,9 @@ async function createProjectSummaries(periodId, domain, tenantId, logger = log) 
         uploadLogger.debug('filtered to usable EC records in upload');
 
         records.forEach((rec) => {
-            const projectId = rec.content.Project_Identification_Number__c;
+            // Sometimes project IDs are represented as a numeric value;
+            // always treat as string to avoid errant "duplicate" map keys
+            const projectId = rec.content.Project_Identification_Number__c.toString();
             const projectLogger = uploadLogger.child({ project: { id: projectId } });
             projectLogger.debug(rowsByProject.has(projectId)
                 ? 'replacing existing row for project with data from newer record'


### PR DESCRIPTION
### Relates to #2060
## Description

This PR fixes a bug introduced by #2060 by neglecting to enforce type-consistency for `Project ID` values in the `Project Summaries` spreadsheet for ARPA audit reports, which resulted in certain projects being represented more than once in that sheet.

**The problem**
Certain (possibly older?) uploads provide `Project ID` values as numbers, while others provide them as strings. Since we only want to include data from the _latest_ record pertaining to each individual project in the `Project Summaries` sheet, we need to ensure that `Project ID` values are unique. Prior to #2060, this was handled in an `Array.reduce()` operation that accumulated records into a plain JavaScript `Object` container, which implicitly treats all keys as strings. However, #2060 changed the way record data is used to populate rows; one of those modifications involves using a `Map` container to hold record-derived row data on a per-project basis. As the `Map` is keyed by the `Project_Identification_Number__c` value provided by records in the upload, and since `Map`s will treat a numeric key of `1234` as distinct from a string key of `"1234"`, the mix of types from the source records was causing up to 2 rows for the same project (one with a numeric `Project ID` and one with a string `Project ID`) to be included in the final audit report.

**Solution**
All `Project_Identification_Number__c` values provided by uploads' records are always converted to a string using the `.toString()` method, ensuring that the `Map` container is consistently keyed by string values, regardless of the data type from which the source value was derived.

Additionally, this PR normalizes the values outputted to the `Project Summaries` spreadsheet under the `Project ID` column to also be strings, per a [suggestion](https://usdigitalresponse.slack.com/archives/C031R1Y49KL/p1697068364195889?thread_ts=1696954478.549509&cid=C031R1Y49KL) from @jcomeau1.