### PR TITLE
fix: exclude keyword not working with title and description

### DIFF
--- a/packages/server/__tests__/db/db.test.js
+++ b/packages/server/__tests__/db/db.test.js
@@ -650,6 +650,32 @@ describe('db', () => {
             );
             expect(result).to.have.property('data').with.lengthOf(1);
         });
+        it('gets grants that match any include keywords in title but are excluded based description', async () => {
+            let result = await db.getGrantsNew(
+                {
+                    includeKeywords: ['community', 'health'],
+                },
+                { currentPage: 1, perPage: 10, isLengthAware: true },
+                { orderBy: 'open_date', orderDesc: true },
+                fixtures.tenants.SBA.id,
+                fixtures.agencies.accountancy.id,
+            );
+            expect(result).to.have.property('data').with.lengthOf(1);
+            expect(result.data[0].title).to.contain('Community');
+            expect(result.data[0].description).to.contain('Covid');
+
+            result = await db.getGrantsNew(
+                {
+                    includeKeywords: ['community', 'health'],
+                    excludeKeywords: ['covid'],
+                },
+                { currentPage: 1, perPage: 10, isLengthAware: true },
+                { orderBy: 'open_date', orderDesc: true },
+                fixtures.tenants.SBA.id,
+                fixtures.agencies.accountancy.id,
+            );
+            expect(result).to.have.property('data').with.lengthOf(0);
+        });
         it('gets grants that match any include phrases', async () => {
             const result = await db.getGrantsNew(
                 { includeKeywords: ['earth sciences'] },

--- a/packages/server/src/db/index.js
+++ b/packages/server/src/db/index.js
@@ -400,40 +400,46 @@ function buildTsqExpression(includeKeywords, excludeKeywords) {
         excludeKeywords.forEach((ek) => { if (ek.indexOf(' ') > 0) { signedKeywords.exclude.push(`-"${ek}"`); } else { signedKeywords.exclude.push(`-${ek}`); } });
     }
 
-    const validExpressions = [];
-
     const includeExpression = signedKeywords.include.join(' or ');
-    if (includeExpression.length > 0) {
-        validExpressions.push(includeExpression);
-    }
     const excludeExpression = signedKeywords.exclude.join(' ');
-    if (excludeExpression.length > 0) {
-        validExpressions.push(excludeExpression);
-    }
 
-    const phrase = validExpressions.join(' ');
-
-    return phrase;
+    return { includeExpression, excludeExpression };
 }
 
 function buildKeywordQuery(queryBuilder, includeKeywords, excludeKeywords, orderingParams) {
-    const tsqExpression = buildTsqExpression(includeKeywords, excludeKeywords);
-    if (tsqExpression) {
-        queryBuilder.joinRaw(`cross join websearch_to_tsquery('english', ?) as tsqp`, tsqExpression);
+    const expression = buildTsqExpression(includeKeywords, excludeKeywords);
+    const includeExpression = expression?.includeExpression;
+    const excludeExpression = expression?.excludeExpression;
+    if (!includeExpression && !excludeExpression) {
+        return false;
+    }
+    if (includeExpression) {
+        queryBuilder.joinRaw(`cross join websearch_to_tsquery('english', ?) as tsqp`, includeExpression);
+    }
+    if (excludeExpression) {
+        queryBuilder.joinRaw(`cross join websearch_to_tsquery('english', ?) as ntsqp`, excludeExpression);
+    }
+    if (includeExpression) {
         queryBuilder.andWhere((q) => {
             q.where('tsqp', '@@', knex.raw('title_ts'))
                 .orWhere('tsqp', '@@', knex.raw('description_ts'));
             return q;
         });
-        if (orderingParams.orderBy !== undefined) {
-            queryBuilder.select(
-                knex.raw(`ts_rank(title_ts, tsqp) as rank_title`),
-                knex.raw(`ts_rank(grants.description_ts, tsqp) as rank_description`),
-            );
-            queryBuilder.groupBy('rank_title', 'rank_description');
-        }
     }
-    return Boolean(tsqExpression);
+    if (excludeExpression) {
+        queryBuilder.andWhere((q) => {
+            q.where('ntsqp', '@@', knex.raw('title_ts'))
+                .andWhere('ntsqp', '@@', knex.raw('description_ts'));
+        });
+    }
+    if (includeExpression && orderingParams.orderBy !== undefined) {
+        queryBuilder.select(
+            knex.raw(`ts_rank(title_ts, tsqp) as rank_title`),
+            knex.raw(`ts_rank(grants.description_ts, tsqp) as rank_description`),
+        );
+        queryBuilder.groupBy('rank_title', 'rank_description');
+    }
+    return Boolean(includeExpression);
 }
 
 function buildFiltersQuery(queryBuilder, filters, agencyId) {


### PR DESCRIPTION
### Ticket #2061 
## Description
Grants containing an include keyword without any exclude keywords in the title would be included in search results even if the exclude keyword appeared in the description and vice versa.

## Screenshots / Demo Video

## Testing

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [ ] Provided ticket and description
- [ ] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers