### PR TITLE
fix: #1894 - Fix Project Summary V2 By Filtering Less Records

### DIFF
--- a/packages/server/src/arpa_reporter/services/records.js
+++ b/packages/server/src/arpa_reporter/services/records.js
@@ -202,6 +202,7 @@ async function recordsForReportingPeriod(periodId, tenantId) {
     requiredArgument(periodId, 'must specify periodId in recordsForReportingPeriod');
 
     const uploads = await usedForTreasuryExport(periodId, tenantId);
+    // const groupedRecords = await Promise.all(uploads.map(recordsForUpload));
     const groupedRecords = await Promise.all(uploads.map((upload) => recordsForUpload(upload)));
     return groupedRecords.flat();
 }
@@ -249,7 +250,7 @@ async function recordsForProject(periodId, tenantId) {
     const projectRecords = allRecords
         .flat()
         // exclude non-project records
-        .filter((record) => Object.values(EC_SHEET_TYPES).includes(record.type));
+        .filter((record) => ([...Object.values(EC_SHEET_TYPES), 'awards50k', 'expenditures50k']).includes(record.type));
 
     return Object.values(projectRecords);
 }

--- a/packages/server/src/arpa_reporter/services/records.js
+++ b/packages/server/src/arpa_reporter/services/records.js
@@ -202,7 +202,6 @@ async function recordsForReportingPeriod(periodId, tenantId) {
     requiredArgument(periodId, 'must specify periodId in recordsForReportingPeriod');
 
     const uploads = await usedForTreasuryExport(periodId, tenantId);
-    // const groupedRecords = await Promise.all(uploads.map(recordsForUpload));
     const groupedRecords = await Promise.all(uploads.map((upload) => recordsForUpload(upload)));
     return groupedRecords.flat();
 }


### PR DESCRIPTION
### Ticket #1894
- Fix project summary v2 tab by including missing sheets. The missing sheets caused some 0's for awards and expenditures. By adding back the sheets, the data is filled in.

## Screenshots / Demo Video

## Testing
Ran a version of the audit report and checked the Project Summary V2 tab.

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [x] Added steps to test feature/functionality manually

## Checklist
- [x] Provided ticket and description
- [ ] Provided screenshots/demo
- [x] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers