### PR TITLE
fix: remove sorting grants, Viewed By and Interested Agencies #1396

### DIFF
--- a/packages/client/src/components/GrantsTable.vue
+++ b/packages/client/src/components/GrantsTable.vue
@@ -102,11 +102,9 @@ export default {
         },
         {
           key: 'viewed_by',
-          sortable: true,
         },
         {
           key: 'interested_agencies',
-          sortable: true,
         },
         {
           // opportunity_status

--- a/packages/client/src/components/GrantsTableNext.vue
+++ b/packages/client/src/components/GrantsTableNext.vue
@@ -110,11 +110,9 @@ export default {
         },
         {
           key: 'viewed_by',
-          sortable: true,
         },
         {
           key: 'interested_agencies',
-          sortable: true,
         },
         {
           // opportunity_status

--- a/packages/server/__tests__/api/grants.test.js
+++ b/packages/server/__tests__/api/grants.test.js
@@ -767,13 +767,13 @@ HHS-2021-IHS-TPI-0001,Community Health Aide Program:  Tribal Planning &`;
                 const response = await fetchApi(`/grants/next?pagination[currentPage]=1&pagination[perPage]=50&ordering[orderBy]=rank&criteria[excludeKeywords]=&criteria[opportunityStatuses]=posted`, agencies.own, fetchOptions.staff);
                 expect(response.statusText).to.equal('OK');
             });
-            it('orderBy viewed_by is ignored', async () => {
+            it('orderBy viewed_by is a 400 error', async () => {
                 const response = await fetchApi(`/grants/next?pagination[currentPage]=1&pagination[perPage]=50&ordering[orderBy]=viewed_by&criteria[opportunityStatuses]=posted`, agencies.own, fetchOptions.staff);
-                expect(response.statusText).to.equal('OK');
+                expect(response.status).to.equal(400);
             });
-            it('orderBy interested_agencies is ignored', async () => {
+            it('orderBy interested_agencies is a 400 error', async () => {
                 const response = await fetchApi(`/grants/next?pagination[currentPage]=1&pagination[perPage]=50&ordering[orderBy]=interested_agencies&criteria[opportunityStatuses]=posted`, agencies.own, fetchOptions.staff);
-                expect(response.statusText).to.equal('OK');
+                expect(response.status).to.equal(400);
             });
         });
     });

--- a/packages/server/__tests__/api/grants.test.js
+++ b/packages/server/__tests__/api/grants.test.js
@@ -768,6 +768,14 @@ HHS-2021-IHS-TPI-0001,Community Health Aide Program:  Tribal Planning &`;
                 const response = await fetchApi(`/grants/next?pagination[currentPage]=1&pagination[perPage]=50&ordering[orderBy]=rank&criteria[excludeKeywords]=&criteria[opportunityStatuses]=posted`, agencies.own, fetchOptions.staff);
                 expect(response.statusText).to.equal('OK');
             });
+            it('orderBy viewed_by is ignored', async () => {
+                const response = await fetchApi(`/grants/next?pagination[currentPage]=1&pagination[perPage]=50&ordering[orderBy]=viewed_by&criteria[opportunityStatuses]=posted`, agencies.own, fetchOptions.staff);
+                expect(response.statusText).to.equal('OK');
+            });
+            it('orderBy interested_agencies is ignored', async () => {
+                const response = await fetchApi(`/grants/next?pagination[currentPage]=1&pagination[perPage]=50&ordering[orderBy]=interested_agencies&criteria[opportunityStatuses]=posted`, agencies.own, fetchOptions.staff);
+                expect(response.statusText).to.equal('OK');
+            });
         });
     });
 });


### PR DESCRIPTION
### Ticket #1396 
## Description
Resolves the problem that sorting grants by 'Viewed By' and 'Interested Agencies' throws API errors.

On the frontend, the Viewed By and Interested Agencies columns are no longer sortable.

On the server, tightened up the input validation such that any values for `orderBy` other than `award_ceiling|open_date|close_date` are ignored completely.

## Screenshots / Demo Video
![CleanShot 2023-10-27 at 09 37 15@2x](https://github.com/usdigitalresponse/usdr-gost/assets/9027674/ea4f3934-f4cf-466f-b18c-a6aa7bbbff92)

## Testing
Navigate to My Grants and Browse Grants and confirm that sorting is unavailable for Viewed By and Interested Agencies columns.

### Automated and Unit Tests
- [x] Added Unit tests

### Manual tests for Reviewer
- [x] Added steps to test feature/functionality manually

## Checklist
- [x] Provided ticket and description
- [x] Provided screenshots/demo
- [x] Provided testing information
- [x] Provided adequate test coverage for all new code
- [x] Added PR reviewers