### PR TITLE
fix: #2065 Results Table Horizontal Responsiveness Updates

### DIFF
--- a/packages/client/src/components/GrantsTableNext.vue
+++ b/packages/client/src/components/GrantsTableNext.vue
@@ -21,7 +21,7 @@
     </b-row>
     <b-row align-v="center">
       <b-col cols="12">
-        <b-table fixed id="grants-table" sticky-header="32rem" hover :items="formattedGrants" responsive
+        <b-table id="grants-table" sticky-header="32rem" hover :items="formattedGrants" responsive
           :fields="fields.filter(field => !field.hideGrantItem)" selectable striped :sort-by.sync="orderBy"
           :sort-desc.sync="orderDesc" :no-local-sorting="true" :bordered="true" select-mode="single" :busy="loading"
           @row-selected="onRowSelected" show-empty emptyText="No matches found">


### PR DESCRIPTION
Remove fixed attribute from grants table. 

### Ticket #2065
## Description
Table cell content was overlapping when the window got smaller.  Remove fixed attribute so the table width can fit the content. When the window is wide enough, the table will fill the viewport width. When the window is too narrow, horizontal scrolling will be needed. This matches how the table on grants.gov works.

## Screenshots / Demo Video

https://github.com/usdigitalresponse/usdr-gost/assets/146878468/c4d716f6-b2b6-479d-8c1c-8034aab567ae


## Testing
Tested grants view manually with a few saved searches.

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [ ] Provided ticket and description
- [ ] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers