### PR TITLE
Add and fix configuration to expire non-current s3 objects

### DIFF
--- a/terraform/modules/gost_api/storage.tf
+++ b/terraform/modules/gost_api/storage.tf
@@ -45,7 +45,7 @@ module "arpa_audit_reports_bucket" {
       abort_incomplete_multipart_upload_days = 1
       expiration                             = { days = 14 }
       transition                             = null
-      noncurrent_version_expiration          = { days = 7 }
+      noncurrent_version_expiration          = { noncurrent_days = 7 }
       noncurrent_version_transition          = null
     }
   ]

--- a/terraform/modules/gost_website/storage.tf
+++ b/terraform/modules/gost_website/storage.tf
@@ -96,6 +96,19 @@ module "origin_bucket" {
   source_policy_documents = [
     module.cloudfront_to_origin_bucket_access_policy.json,
   ]
+
+  lifecycle_configuration_rules = [
+    {
+      enabled                                = true
+      id                                     = "rule-1"
+      filter_and                             = null
+      abort_incomplete_multipart_upload_days = 1
+      expiration                             = null
+      transition                             = null
+      noncurrent_version_expiration          = { noncurrent_days = 7 }
+      noncurrent_version_transition          = null
+    }
+  ]
 }
 
 module "logs_bucket" {

--- a/terraform/modules/gost_website/storage.tf
+++ b/terraform/modules/gost_website/storage.tf
@@ -144,8 +144,8 @@ module "logs_bucket" {
       }
       noncurrent_version_transition = [
         {
-          noncurrent_days          = 30
-          storage_class = "GLACIER"
+          noncurrent_days = 30
+          storage_class   = "GLACIER"
         },
       ]
       noncurrent_version_expiration = {

--- a/terraform/modules/gost_website/storage.tf
+++ b/terraform/modules/gost_website/storage.tf
@@ -131,12 +131,12 @@ module "logs_bucket" {
       }
       noncurrent_version_transition = [
         {
-          days          = 30
+          noncurrent_days          = 30
           storage_class = "GLACIER"
         },
       ]
       noncurrent_version_expiration = {
-        days = 90
+        noncurrent_days = 90
       }
     }
   ]


### PR DESCRIPTION
Fixes issue #1808 
## Description

- Update the terraform for S3 buckets arpa_audit_reports_bucket and logs_bucket to use the correct noncurrent_days parameter rather than days.
- Add new lifecycle rules for the origin S3 bucket to expire noncurrent versions after 7 days, and not expire or transition objects otherwise.