### PR TITLE
2134 admin access users outside allowed agencies

### DIFF
--- a/packages/client/src/store/modules/users.js
+++ b/packages/client/src/store/modules/users.js
@@ -66,8 +66,17 @@ export default {
       const data = await fetchApi.patch(`/api/organizations/:organizationId/users/${id}`, { name });
       commit('SET_LOGGED_IN_USER', data.user);
     },
-    async deleteUser({ dispatch }, userId) {
-      await fetchApi.deleteRequest(`/api/organizations/:organizationId/users/${userId}`);
+    async deleteUser({ dispatch, commit }, userId) {
+      try {
+        await fetchApi.deleteRequest(
+          `/api/organizations/:organizationId/users/${userId}`,
+        );
+      } catch (error) {
+        commit('alerts/addAlert', {
+          text: `Error deleting user: ${error.message}`,
+          level: 'err',
+        }, { root: true });
+      }
       await dispatch('fetchUsers');
     },
     async updateEmailSubscriptionPreferences({ dispatch }, { userId, preferences }) {

--- a/packages/server/__tests__/api/users.test.js
+++ b/packages/server/__tests__/api/users.test.js
@@ -25,6 +25,12 @@ describe('`/api/users` endpoint', () => {
                 cookie: undefined,
             },
         },
+        subagencyAdmin: {
+            headers: {
+                'Content-Type': 'application/json',
+                cookie: undefined,
+            },
+        },
         staff: {
             headers: {
                 'Content-Type': 'application/json',
@@ -40,6 +46,7 @@ describe('`/api/users` endpoint', () => {
         fetchOptions.admin.headers.cookie = await getSessionCookie('mindy@usdigitalresponse.org');
         fetchOptions.nonUSDRAdmin.headers.cookie = await getSessionCookie('joecomeau01@gmail.com');
         fetchOptions.staff.headers.cookie = await getSessionCookie('mindy+testsub@usdigitalresponse.org');
+        fetchOptions.subagencyAdmin.headers.cookie = await getSessionCookie('nat.hillard.usdr@gmail.com');
 
         testServer = await makeTestServer();
         fetchApi = testServer.fetchApi;
@@ -78,11 +85,20 @@ describe('`/api/users` endpoint', () => {
                 });
                 expect(response.statusText).to.equal('OK');
             });
-            it('is forbidden for an agency outside this user\'s hierarchy', async () => {
+            it('is forbidden for an agency outside this user\'s tenant', async () => {
                 const response = await fetchApi(`/users`, agencies.offLimits, {
                     ...fetchOptions.admin,
                     method: 'post',
                     body: JSON.stringify({ ...user, email: `3${user.email}` }),
+                });
+                expect(response.statusText).to.equal('Forbidden');
+            });
+            it('is forbidden for an agency that is a parent to this user\'s agency', async () => {
+                const parentAgency = agencies.own;
+                const response = await fetchApi(`/users`, parentAgency, {
+                    ...fetchOptions.subagencyAdmin,
+                    method: 'post',
+                    body: JSON.stringify({ ...user, agency: parentAgency, email: `4${user.email}` }),
                 });
                 expect(response.statusText).to.equal('Forbidden');
             });
@@ -142,7 +158,7 @@ describe('`/api/users` endpoint', () => {
                 const response = await fetchApi(`/users`, agencies.own, fetchOptions.admin);
                 expect(response.statusText).to.equal('OK');
                 const json = await response.json();
-                expect(json.length).to.equal(11);
+                expect(json.length).to.equal(12);
             });
             it('lists users for an agency outside this user\'s hierarchy but in the same tenant', async () => {
                 const response = await fetchApi(`/users`, agencies.offLimits, fetchOptions.admin);
@@ -185,12 +201,38 @@ describe('`/api/users` endpoint', () => {
                 expect(response.statusText).to.equal('Bad Request');
             });
         });
+        context('by a user with admin role', () => {
+            it('updates a user in this user\'s tenant and a subagency', async () => {
+                const response = await fetchApi(`/users/16`, agencies.staffOwn, {
+                    ...fetchOptions.admin,
+                    method: 'patch',
+                    body: JSON.stringify({ name: 'Test Name' }),
+                });
+                expect(response.statusText).to.equal('OK');
+            });
+            it('is forbidden for a user in this user\'s tenant and a parent agency', async () => {
+                const parentAgency = agencies.own;
+                const response = await fetchApi(`/users/2`, parentAgency, {
+                    ...fetchOptions.subagencyAdmin,
+                    method: 'patch',
+                    body: JSON.stringify({ name: 'Test Name' }),
+                });
+                expect(response.statusText).to.equal('Forbidden');
+            });
+        });
     });
 
     context('DELETE /api/users/:id', () => {
         context('by a user with admin role', () => {
-            it('deletes a user in this user\'s tenant', async () => {
+            it('deletes a user in this user\'s tenant and agency', async () => {
                 const response = await fetchApi(`/users/4`, agencies.own, {
+                    ...fetchOptions.admin,
+                    method: 'delete',
+                });
+                expect(response.statusText).to.equal('OK');
+            });
+            it('deletes a user in this user\'s tenant and a subagency', async () => {
+                const response = await fetchApi(`/users/16`, agencies.staffOwn, {
                     ...fetchOptions.admin,
                     method: 'delete',
                 });
@@ -199,6 +241,14 @@ describe('`/api/users` endpoint', () => {
             it('is forbidden for a user in an agency outside this user\'s tenant', async () => {
                 const response = await fetchApi(`/users/8`, agencies.offLimits, {
                     ...fetchOptions.admin,
+                    method: 'delete',
+                });
+                expect(response.statusText).to.equal('Forbidden');
+            });
+            it('is forbidden for a user in this user\'s tenant and a parent agency', async () => {
+                const parentAgency = agencies.own;
+                const response = await fetchApi(`/users/2`, parentAgency, {
+                    ...fetchOptions.subagencyAdmin,
                     method: 'delete',
                 });
                 expect(response.statusText).to.equal('Forbidden');

--- a/packages/server/seeds/dev/ref/users.js
+++ b/packages/server/seeds/dev/ref/users.js
@@ -136,4 +136,12 @@ module.exports = [
         role_id: roles[0].id,
         tenant_id: usdrTenant.id,
     },
+    {
+        id: 16,
+        email: 'admin1@usdigitalresponse.org',
+        name: 'USDR tenant sub agency admin',
+        agency_id: usdrSubAgency.id,
+        role_id: roles[1].id,
+        tenant_id: usdrTenant.id,
+    },
 ];

--- a/packages/server/src/lib/access-helpers.js
+++ b/packages/server/src/lib/access-helpers.js
@@ -17,6 +17,25 @@ function isUSDRSuperAdmin(user) {
 }
 
 /**
+ * Determine if the user's agency or subagencies includes the given agency.
+ *
+ * @param {Object} user
+ * @param {Number} agencyId
+ * @returns {Boolean} true if the agency is a subagency or same agency of the user
+ * */
+function isAuthorizedForAgency(user, agencyId) {
+    const subagency = user.agency.subagencies.find(
+        (agency) => agency.id === agencyId,
+    );
+
+    if (subagency) {
+        return true;
+    }
+
+    return false;
+}
+
+/**
  * Determine if a user is authorized for an agency.
  *
  * @param {Object} user
@@ -25,11 +44,6 @@ function isUSDRSuperAdmin(user) {
  * */
 async function isUserAuthorized(user, ...agencyIds) {
     return inTenant(user.tenant_id, agencyIds);
-}
-
-async function isAuthorized(userId, agencyId) {
-    const user = await getUser(userId);
-    return isUserAuthorized(user, agencyId);
 }
 
 async function getAdminAuthInfo(req) {
@@ -111,5 +125,5 @@ async function requireUSDRSuperAdminUser(req, res, next) {
 }
 
 module.exports = {
-    requireAdminUser, requireUser, isAuthorized, isUserAuthorized, isUSDRSuperAdmin, requireUSDRSuperAdminUser, getAdminAuthInfo,
+    requireAdminUser, requireUser, isAuthorizedForAgency, isUserAuthorized, isUSDRSuperAdmin, requireUSDRSuperAdminUser, getAdminAuthInfo,
 };

--- a/packages/server/src/routes/keywords.js
+++ b/packages/server/src/routes/keywords.js
@@ -1,7 +1,7 @@
 const express = require('express');
 
 const router = express.Router({ mergeParams: true });
-const { requireUser, isAuthorized } = require('../lib/access-helpers');
+const { requireUser, isAuthorizedForAgency } = require('../lib/access-helpers');
 const db = require('../db');
 
 router.post('/', requireUser, async (req, res) => {
@@ -21,7 +21,7 @@ router.delete('/:keywordId', requireUser, async (req, res) => {
     const { agency_id } = await db.getKeyword(req.params.keywordId);
 
     // Is this admin user authorized for that agency?
-    const authorized = await isAuthorized(req.signedCookies.userId, agency_id);
+    const authorized = isAuthorizedForAgency(req.session.user, agency_id);
     if (!authorized) {
         res.sendStatus(403);
         return;

--- a/packages/server/src/routes/users.js
+++ b/packages/server/src/routes/users.js
@@ -149,7 +149,7 @@ router.delete('/:userId', requireAdminUser, async (req, res) => {
     // Is this admin user able to delete a user in their agency
     const authorized = isAuthorizedForAgency(req.session.user, userToDelete.agency_id);
     if (!authorized) {
-        res.sendStatus(403);
+        res.status(403).send('Cannot delete a user from a parent agency or agency outside of the tenant');
         return;
     }
 

--- a/packages/server/src/routes/users.js
+++ b/packages/server/src/routes/users.js
@@ -10,8 +10,7 @@ const { ensureAsyncContext } = require('../arpa_reporter/lib/ensure-async-contex
 const {
     requireAdminUser,
     requireUser,
-    isAuthorized,
-    isUserAuthorized,
+    isAuthorizedForAgency,
     isUSDRSuperAdmin,
     requireUSDRSuperAdminUser,
 } = require('../lib/access-helpers');
@@ -33,9 +32,9 @@ router.post('/', requireAdminUser, async (req, res, next) => {
     }
 
     try {
-        const allowed = await isUserAuthorized(user, agencyId);
+        const allowed = isAuthorizedForAgency(user, agencyId);
         if (!allowed) {
-            res.status(403).send('Cannot assign user to agency outside of the tenant');
+            res.status(403).send('Cannot assign user to a parent agency or agency outside of the tenant');
             return;
         }
         const newUser = {
@@ -62,8 +61,16 @@ router.post('/', requireAdminUser, async (req, res, next) => {
 
 router.patch('/:userId', requireUser, async (req, res) => {
     const id = parseInt(req.params.userId, 10);
-    const allowedFields = new Set(['name']);
+    const { user } = req.session;
 
+    const userToEdit = user.id === id ? user : await db.getUser(id);
+    const allowed = isAuthorizedForAgency(user, userToEdit.agency_id);
+    if (!allowed) {
+        res.sendStatus(403);
+        return;
+    }
+
+    const allowedFields = new Set(['name']);
     for (const key of Object.keys(req.body)) {
         if (!allowedFields.has(key)) {
             res.status(400).json({ message: `Request body contains unsupported field: ${key}` });
@@ -140,7 +147,7 @@ router.delete('/:userId', requireAdminUser, async (req, res) => {
     const userToDelete = await db.getUser(req.params.userId);
 
     // Is this admin user able to delete a user in their agency
-    const authorized = await isAuthorized(req.signedCookies.userId, userToDelete.agency_id);
+    const authorized = isAuthorizedForAgency(req.session.user, userToDelete.agency_id);
     if (!authorized) {
         res.sendStatus(403);
         return;


### PR DESCRIPTION
### Ticket #2134
## Description
This PR adds a check to `/users` POST, PATCH, and DELETE to ensure the requesting user has access to the agency. 

This is done by checking that the agency is equal to the user's agency or is a sub-agency of the user's agency, preventing action against an agency above the user's agency in the hierarchy.

On the client, when a delete request fails, the error message is displayed.

Can be tested by deleting or adding a user in/from the parent agency of the logged in user.

## Screenshots / Demo Video
![Screenshot from 2023-11-01 19-23-58](https://github.com/usdigitalresponse/usdr-gost/assets/22715037/0913b305-034c-416e-b2f8-df44ce373c76)


## Testing

### Automated and Unit Tests
- [x] Added Unit tests

### Manual tests for Reviewer
- [x] Added steps to test feature/functionality manually

## Checklist
- [x] Provided ticket and description
- [x] Provided screenshots/demo
- [x] Provided testing information
- [x] Provided adequate test coverage for all new code
- [x] Added PR reviewers