### PR TITLE
fix: update 'master' to '_staging'

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,7 +102,7 @@ Follow these steps to start contributing:
 
    ```bash
    $ git fetch origin
-   $ git rebase origin/master
+   $ git rebase origin/_staging
    ```
 
    Push the changes to your account using:


### PR DESCRIPTION
Update 'master' to '_staging' in Contributing documentation