### PR TITLE
2213 add top and bottom borders to table

### DIFF
--- a/packages/client/src/components/GrantsTableNext.vue
+++ b/packages/client/src/components/GrantsTableNext.vue
@@ -21,7 +21,7 @@
     </b-row>
     <b-row align-v="center">
       <b-col cols="12">
-        <b-table id="grants-table" sticky-header="70vh" hover no-border-collapse :items="formattedGrants"
+        <b-table id="grants-table" sticky-header="70vh" hover :items="formattedGrants"
           :fields="fields.filter(field => !field.hideGrantItem)" selectable striped :sort-by.sync="orderBy"
           :sort-desc.sync="orderDesc" :no-local-sorting="true" :bordered="true" select-mode="single" :busy="loading"
           @row-selected="onRowSelected" show-empty emptyText="No matches found">
@@ -434,7 +434,10 @@ export default {
   justify-content: left;
   align-items: center;
 }
+
+/* Fix for disappearing table borders when Vue collapses table borders */
 .b-table-sticky-header {
+  border-top: 1px solid #dee2e6;
   border-bottom: 1px solid #dee2e6;
 }
 </style>

--- a/packages/client/src/components/GrantsTableNext.vue
+++ b/packages/client/src/components/GrantsTableNext.vue
@@ -436,7 +436,7 @@ export default {
 }
 
 /* Fix for disappearing table borders when Vue collapses table borders */
-.b-table-sticky-header {
+.grants-table-container > .b-table-sticky-header {
   border-top: 1px solid #dee2e6;
   border-bottom: 1px solid #dee2e6;
 }

--- a/packages/client/src/components/GrantsTableNext.vue
+++ b/packages/client/src/components/GrantsTableNext.vue
@@ -436,7 +436,7 @@ export default {
 }
 
 /* Fix for disappearing table borders when Vue collapses table borders */
-.grants-table-container > .b-table-sticky-header {
+.grants-table-container .b-table-sticky-header {
   border-top: 1px solid #dee2e6;
   border-bottom: 1px solid #dee2e6;
 }

--- a/packages/client/src/components/GrantsTableNext.vue
+++ b/packages/client/src/components/GrantsTableNext.vue
@@ -21,7 +21,7 @@
     </b-row>
     <b-row align-v="center">
       <b-col cols="12">
-        <b-table id="grants-table" sticky-header="70vh" hover :items="formattedGrants"
+        <b-table id="grants-table" sticky-header="70vh" hover no-border-collapse :items="formattedGrants"
           :fields="fields.filter(field => !field.hideGrantItem)" selectable striped :sort-by.sync="orderBy"
           :sort-desc.sync="orderDesc" :no-local-sorting="true" :bordered="true" select-mode="single" :busy="loading"
           @row-selected="onRowSelected" show-empty emptyText="No matches found">
@@ -433,5 +433,8 @@ export default {
   display: flex;
   justify-content: left;
   align-items: center;
+}
+.b-table-sticky-header {
+  border-bottom: 1px solid #dee2e6;
 }
 </style>


### PR DESCRIPTION
### Ticket #2213
## Description
Workaround a problem with Vue's table border collapsing + sticky headers, where the borders can disappear.

## Screenshots / Demo Video

https://github.com/usdigitalresponse/usdr-gost/assets/146878468/e837f2e1-470e-41b0-a081-d7d1d5661608


## Testing
Tested scrolling Grants table with different data sets.

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ x] Added steps to test feature/functionality manually

## Checklist
- [ x] Provided ticket and description
- [ x] Provided screenshots/demo
- [x ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [x ] Added PR reviewers