### PR TITLE
Revert "chore(deps): bump cloudposse/waf/aws from 0.3.0 to 0.4.0 in /terraform/modules/gost_website"

### DIFF
--- a/terraform/modules/gost_website/waf.tf
+++ b/terraform/modules/gost_website/waf.tf
@@ -18,7 +18,7 @@ locals {
 
 module "waf" {
   source         = "cloudposse/waf/aws"
-  version        = "0.4.0"
+  version        = "0.3.0"
   scope          = "CLOUDFRONT"
   default_action = "allow"
 


### PR DESCRIPTION
Reverts usdigitalresponse/usdr-gost#2245

See https://github.com/usdigitalresponse/usdr-gost/pull/1613#issuecomment-1632924004

Short term: We need to revert this change so that the version of the WAF module is compatible with our AWS provider.
Further out (should prioritize this): We need to update our Terraform and AWS provider versions.