### PR TITLE
fix: #2273 use stacked table layout for narrow windows

### DIFF
--- a/packages/client/src/components/GrantsTableNext.vue
+++ b/packages/client/src/components/GrantsTableNext.vue
@@ -21,7 +21,7 @@
     </b-row>
     <b-row align-v="center">
       <b-col cols="12">
-        <b-table id="grants-table" hover responsive :items="formattedGrants"
+        <b-table id="grants-table" hover responsive stacked="sm" :items="formattedGrants"
           :fields="fields.filter(field => !field.hideGrantItem)" selectable striped :sort-by.sync="orderBy"
           :sort-desc.sync="orderDesc" :no-local-sorting="true" :bordered="true" select-mode="single" :busy="loading"
           @row-selected="onRowSelected" show-empty emptyText="No matches found">


### PR DESCRIPTION
### Ticket #2273
## Grants table layout should become stacked when the window is narrow

## Screenshots / Demo Video

https://github.com/usdigitalresponse/usdr-gost/assets/146878468/fb5ade1a-0dbf-4f2e-bd7c-5767136614a3

## Testing
Test on mobile and with different window sizes

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [x ] Added steps to test feature/functionality manually

## Checklist
- [x ] Provided ticket and description
- [ x] Provided screenshots/demo
- [x ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [x ] Added PR reviewers