### PR TITLE
feat: Automatically invalidate CDN cache after deployment

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -12,6 +12,10 @@ on:
       website-artifacts-path:
         type: string
         required: true
+      clear-web-cache:
+        description: Whether to invalidate the CloudFront distribution cache as a post-deployment step.
+        type: boolean
+        default: true
       tf-plan-artifacts-key:
         type: string
         required: true
@@ -134,6 +138,15 @@ jobs:
           TF_CLI_ARGS_init: "-backend-config=${{ inputs.tf-backend-config-file }}"
       - name: Terraform Apply
         run: terraform apply tfplan
+        env:
+          AWS_ACCESS_KEY_ID: "${{ steps.decrypt-aws-access-key-id.outputs.out }}"
+          AWS_SECRET_ACCESS_KEY: "${{ steps.decrypt-aws-secret-access-key.outputs.out }}"
+          AWS_SESSION_TOKEN: "${{ steps.decrypt-aws-session-token.outputs.out }}"
+      - name: Invalidate CloudFront distribution cache
+        if: success() && inputs.clear-web-cache
+        run:
+          DISTRIBUTION_ID=$(terraform output -json | jq .website_cloudfront_distribution_id.value)
+          aws cloudfront create-invalidation --paths '/*' --distribution-id $DISTRIBUTION_ID
         env:
           AWS_ACCESS_KEY_ID: "${{ steps.decrypt-aws-access-key-id.outputs.out }}"
           AWS_SECRET_ACCESS_KEY: "${{ steps.decrypt-aws-secret-access-key.outputs.out }}"

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,4 @@
+output "website_cloudfront_distribution_id" {
+  description = "The ID of the CloudFront distribution serving the GOST website."
+  value       = module.website.cloudfront_distribution_id
+}


### PR DESCRIPTION
## Description

(This PR is pretty much the same thing as https://github.com/usdigitalresponse/cpf-reporter/pull/40.)

This PR adds a step to the "Terraform Apply" workflow that invalidates the CloudFront distribution cache automatically after a successful deployment, which helps ensure that the latest-deployed version of the web app is being served.

A new Terraform output provides the ID of the CloudFront distribution. Once terraform apply is run successfully from the GHA deployment workflow, the next step in the job (which is conditional, but enabled by default) retrieves the output and runs the AWS CLI command to create a new CloudFront invalidation.