### PR TITLE
Fix yaml syntax issue (#2325)

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -144,7 +144,7 @@ jobs:
           AWS_SESSION_TOKEN: "${{ steps.decrypt-aws-session-token.outputs.out }}"
       - name: Invalidate CloudFront distribution cache
         if: success() && inputs.clear-web-cache
-        run:
+        run: |
           DISTRIBUTION_ID=$(terraform output -json | jq .website_cloudfront_distribution_id.value)
           aws cloudfront create-invalidation --paths '/*' --distribution-id $DISTRIBUTION_ID
         env:


### PR DESCRIPTION
Relates to #2325 

## Description

This PR is a quick one-liner fix to a YAML syntax issue introduced in #2325. I neglected to add the new workflow step as a multiline string, so GHA is interpreting the two lines of the step as a single command.