### PR TITLE
Add Datadog RUM to client (issue #2067)

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@braid/vue-formulate": "^2.5.3",
+    "@datadog/browser-rum": "^5.5.0",
     "bootstrap": "^4.6.1",
     "bootstrap-vue": "^2.19.0",
     "core-js": "^3.21.1",

--- a/packages/client/src/arpa_reporter/main.js
+++ b/packages/client/src/arpa_reporter/main.js
@@ -1,3 +1,10 @@
+/* eslint-disable import/first */
+import { datadogRum } from '@datadog/browser-rum';
+
+if (window.APP_CONFIG?.DD_RUM_ENABLED === true) {
+  datadogRum.init(window.APP_CONFIG.DD_RUM_CONFIG);
+}
+
 import Vue from 'vue';
 import { BootstrapVue, IconsPlugin } from 'bootstrap-vue';
 import App from './App.vue';

--- a/packages/client/src/main.js
+++ b/packages/client/src/main.js
@@ -1,3 +1,10 @@
+/* eslint-disable import/first */
+import { datadogRum } from '@datadog/browser-rum';
+
+if (window.APP_CONFIG?.DD_RUM_ENABLED === true) {
+  datadogRum.init(window.APP_CONFIG.DD_RUM_CONFIG);
+}
+
 import Vue from 'vue';
 import { BootstrapVue, IconsPlugin } from 'bootstrap-vue';
 import vSelect from 'vue-select';

--- a/service.datadog.yaml
+++ b/service.datadog.yaml
@@ -1,0 +1,35 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/DataDog/schema/main/service-catalog/v2.1/schema.json
+schema-version: v2.1
+application: GOST
+description: >
+  GOST is a platform that hosts tools to enable state and local government officials to
+  more easily apply for and report on their federal grants.
+dd-service: gost
+team: usdr-grants
+contacts:
+  - type: slack
+    contact: https://usdigitalresponse.slack.com/archives/C0324KDQSCR
+links:
+  - name: Source
+    type: repo
+    provider: github
+    url: https://github.com/usdigitalresponse/usdr-gost
+  - name: Service Monitoring Dashboard
+    type: dashboard
+    url: https://app.datadoghq.com/dashboard/kdw-rtz-5pb/
+  - name: ARPA Audit Report Dashboard
+    type: dashboard
+    url: https://app.datadoghq.com/dashboard/5gk-g5h-p7t
+  - name: Project Development Board
+    type: other
+    url: https://github.com/orgs/usdigitalresponse/projects/5/views/1
+  - name: Grants Program Wiki
+    type: doc
+    url: https://www.notion.so/usdr/Grants-Program-Wiki-44d6252c85344eb3b0077a9eb4f0fc5c
+  - name: Federal Grant Finder product documentation
+    type: doc
+    url: https://www.notion.so/usdr/Federal-Grant-Finder-54ffac3935ec478aa3c78c31e98a81ed
+  - name: ARPA Quarterly Reporter product documentation
+    type: doc
+    url: https://www.notion.so/usdr/ARPA-Quarterly-P-E-Reporter-ebd0a1ac2a7f4653b35517819befa9ea

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -69,6 +69,18 @@ module "website" {
   origin_artifacts_dist_path = coalesce(
     var.website_origin_artifacts_dist_path, "${path.root}/../packages/client/dist"
   )
+
+  datadog_rum_enabled = var.website_datadog_rum_enabled
+  datadog_rum_config = merge(var.website_datadog_rum_options, {
+    applicationId       = "15db471e-2ccb-4d3c-a6bf-99b750d748f5"
+    clientToken         = "pub50834fcc1999d53e546519b1a0f03934"
+    site                = "datadoghq.com"
+    service             = local.unified_service_tags.service
+    env                 = local.unified_service_tags.env
+    version             = local.unified_service_tags.version
+    defaultPrivacyLevel = "mask"
+    allowedTracingUrls  = ["https://${local.api_domain_name}"]
+  })
 }
 
 module "api_to_postgres_security_group" {

--- a/terraform/modules/gost_api/gateway.tf
+++ b/terraform/modules/gost_api/gateway.tf
@@ -54,10 +54,15 @@ module "api_gateway" {
     allow_headers = [
       "authorization",
       "content-type",
+      "traceparent",
       "x-amz-date",
       "x-amz-security-token",
       "x-amz-user-agent",
       "x-api-key",
+      "x-datadog-trace-id",
+      "x-datadog-parent-id",
+      "x-datadog-origin",
+      "x-datadog-sampling-priority",
     ]
     max_age = 86400 // 24 hours, in seconds
   }

--- a/terraform/modules/gost_website/runtime_config.tf
+++ b/terraform/modules/gost_website/runtime_config.tf
@@ -2,10 +2,10 @@ locals {
   deployConfigContents = templatefile(
     "${path.module}/tpl/deploy-config.js",
     {
-      gost_api_domain     = var.gost_api_domain
-      feature_flags       = jsonencode(var.feature_flags)
-      datadog_rum_enabled = var.datadog_rum_enabled
-      datadog_rum_config  = jsonencode(var.datadog_rum_config)
+      gost_api_domain = var.gost_api_domain
+      feature_flags   = jsonencode(var.feature_flags)
+      dd_rum_enabled  = var.datadog_rum_enabled
+      dd_rum_config   = jsonencode(var.datadog_rum_config)
     }
   )
 }

--- a/terraform/modules/gost_website/runtime_config.tf
+++ b/terraform/modules/gost_website/runtime_config.tf
@@ -2,8 +2,10 @@ locals {
   deployConfigContents = templatefile(
     "${path.module}/tpl/deploy-config.js",
     {
-      gost_api_domain = var.gost_api_domain,
-      feature_flags   = jsonencode(var.feature_flags),
+      gost_api_domain     = var.gost_api_domain
+      feature_flags       = jsonencode(var.feature_flags)
+      datadog_rum_enabled = var.datadog_rum_enabled
+      datadog_rum_config  = jsonencode(var.datadog_rum_config)
     }
   )
 }

--- a/terraform/modules/gost_website/tpl/deploy-config.js
+++ b/terraform/modules/gost_website/tpl/deploy-config.js
@@ -1,6 +1,10 @@
 window.APP_CONFIG = window.APP_CONFIG || {};
 window.APP_CONFIG.apiURLForGOST = 'https://${gost_api_domain}/';
 window.apiURLForGOST = window.APP_CONFIG.apiURLForGOST; // Legacy
+
+window.APP_CONFIG.DD_RUM_ENABLED = ${dd_rum_enabled};
+window.APP_CONFIG.DD_RUM_CONFIG = JSON.parse(${dd_rum_config});
+
 window.APP_CONFIG.featureFlags = ${feature_flags};
 
 window.APP_CONFIG.overrideFeatureFlag = (flagName, overrideValue) => {

--- a/terraform/modules/gost_website/variables.tf
+++ b/terraform/modules/gost_website/variables.tf
@@ -35,6 +35,37 @@ variable "gost_api_domain" {
   type        = string
 }
 
+variable "datadog_rum_enabled" {
+  description = "Whether to enable Datadog RUM."
+  type        = bool
+  default     = false
+}
+
+variable "datadog_rum_config" {
+  description = "Runtime configuration options for Datadog RUM."
+  type = object({
+    applicationId           = string
+    clientToken             = string
+    site                    = string
+    service                 = string
+    env                     = string
+    version                 = string
+    sessionSampleRate       = number
+    sessionReplaySampleRate = number
+    trackUserInteractions   = bool
+    trackResources          = bool
+    trackLongTasks          = bool
+    defaultPrivacyLevel     = string
+    allowedTracingUrls      = list(string)
+  })
+  default = null
+
+  validation {
+    condition     = can(jsonencode(var.datadog_rum_config))
+    error_message = "Value must be JSON-serializable."
+  }
+}
+
 variable "feature_flags" {
   description = "Feature flags for configuring the website runtime"
   type        = any

--- a/terraform/prod.tfvars
+++ b/terraform/prod.tfvars
@@ -40,7 +40,7 @@ website_managed_waf_rules = {
 }
 website_datadog_rum_enabled = true
 website_datadog_rum_options = {
-  sessionSampleRate       = 100
+  sessionSampleRate       = 80
   sessionReplaySampleRate = 20
   trackUserInteractions   = true
   trackResources          = true

--- a/terraform/prod.tfvars
+++ b/terraform/prod.tfvars
@@ -38,6 +38,14 @@ website_managed_waf_rules = {
     metric_visibility = true
   }
 }
+website_datadog_rum_enabled = true
+website_datadog_rum_options = {
+  sessionSampleRate       = 100
+  sessionReplaySampleRate = 20
+  trackUserInteractions   = true
+  trackResources          = true
+  trackLongTasks          = true
+}
 website_feature_flags = {
   myProfileEnabled      = false,
   newTerminologyEnabled = false

--- a/terraform/staging.tfvars
+++ b/terraform/staging.tfvars
@@ -35,6 +35,14 @@ website_managed_waf_rules = {
     metric_visibility = true
   }
 }
+website_datadog_rum_enabled = true
+website_datadog_rum_options = {
+  sessionSampleRate       = 10
+  sessionReplaySampleRate = 1
+  trackUserInteractions   = true
+  trackResources          = true
+  trackLongTasks          = true
+}
 website_feature_flags = {
   myProfileEnabled      = true,
   newTerminologyEnabled = true

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -133,13 +133,13 @@ variable "website_datadog_rum_options" {
     trackResources          = bool
     trackLongTasks          = bool
   })
-  default = object({
+  default = {
     sessionSampleRate       = 100
     sessionReplaySampleRate = 20
     trackUserInteractions   = true
     trackResources          = true
     trackLongTasks          = true
-  })
+  }
 }
 
 variable "website_feature_flags" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -118,6 +118,30 @@ variable "website_origin_artifacts_dist_path" {
   default     = ""
 }
 
+variable "website_datadog_rum_enabled" {
+  description = "Whether to enable Datadog RUM on the website."
+  type        = bool
+  default     = false
+}
+
+variable "website_datadog_rum_options" {
+  description = "Configuration options for Datadog RUM data collection (if var.website_datadog_rum_enabled is true)."
+  type = object({
+    sessionSampleRate       = number
+    sessionReplaySampleRate = number
+    trackUserInteractions   = bool
+    trackResources          = bool
+    trackLongTasks          = bool
+  })
+  default = object({
+    sessionSampleRate       = 100
+    sessionReplaySampleRate = 20
+    trackUserInteractions   = true
+    trackResources          = true
+    trackLongTasks          = true
+  })
+}
+
 variable "website_feature_flags" {
   description = "Map of website feature flag names and their values."
   type        = any

--- a/yarn.lock
+++ b/yarn.lock
@@ -2386,6 +2386,26 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
+"@datadog/browser-core@5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@datadog/browser-core/-/browser-core-5.5.0.tgz#9de07fd46fbabbce0a30368394f612512869053c"
+  integrity sha512-orkbetqiXBrF3r9/WImwJG32tEtNjx2hfP7cyBvPw5qhdjOHkl87IdrKqELaadIAc7Tjgmn38TWccSmcRa1rVw==
+
+"@datadog/browser-rum-core@5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@datadog/browser-rum-core/-/browser-rum-core-5.5.0.tgz#fffb23643cd8be62f12e9781024a3f3fda09e1f9"
+  integrity sha512-VWI91gwKYTGMycpN5a8kgJ/YCdcnvYAhU2uk6HbTLNg2xj4368FyOdSFOQgQzBvmM323AFS+G0v5u+eQgtNgfQ==
+  dependencies:
+    "@datadog/browser-core" "5.5.0"
+
+"@datadog/browser-rum@^5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@datadog/browser-rum/-/browser-rum-5.5.0.tgz#b677b5684773db11a24c8b8dec3b0674416f625a"
+  integrity sha512-nsK9hrD4yuyiSJ2B+R0KVeb61Xj4rwVIIF6mGsNYIaX4sN51Qw/lz5GkOca3YwskS0zMoyicjEWKFZnzq5Q7ew==
+  dependencies:
+    "@datadog/browser-core" "5.5.0"
+    "@datadog/browser-rum-core" "5.5.0"
+
 "@datadog/native-appsec@4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@datadog/native-appsec/-/native-appsec-4.0.0.tgz#ee08138b987dec557eac3650a43a972dac85b6a6"


### PR DESCRIPTION
### Ticket #2067

## Description

This PR adds Datadog RUM to the GOST website (both Finder and ARPA apps) and allows it to be conditionally enabled based on runtime configuration parameters, which is managed by Terraform. These changes will allow better observability for client-side behaviors and enable correlation of client-side API requests to server-side traces. Of particular note, this enables the ability to record and monitor (redacted/masked) user sessions, which should be beneficial for debugging as well as UX research.

Note that sampling rates for Staging are quite low, especially for replayable sessions (20% and 1%, respectively). In Production, 80% of sessions will be sampled and 20% of sessions will be available for replay.

Summary of changes:
- Add the Datadog RUM library as a client-side dependency
- Conditional initialize the RUM library during web app startup
- Manage RUM settings with Terraform
- Update API Gateway CORS configuration with new tracing headers
- Add a Datadog service manifest for the repository (enables Datadog service discovery)

## Screenshots / Demo Video

## Testing

These changes should have no impact on development environments or test suites. Once deployed to staging, sampled RUM sessions may be viewed in Datadog (see notes on sampling rates in the PR description above).

## Checklist
- [x] Provided ticket and description
- [ ] Provided screenshots/demo
- [x] Provided testing information
- [X] Provided adequate test coverage for all new code
- [X] Added PR reviewers