### PR TITLE
fix: remove unnecessary JSON.parse() call in RUM config template

### DIFF
--- a/terraform/modules/gost_website/tpl/deploy-config.js
+++ b/terraform/modules/gost_website/tpl/deploy-config.js
@@ -3,7 +3,7 @@ window.APP_CONFIG.apiURLForGOST = 'https://${gost_api_domain}/';
 window.apiURLForGOST = window.APP_CONFIG.apiURLForGOST; // Legacy
 
 window.APP_CONFIG.DD_RUM_ENABLED = ${dd_rum_enabled};
-window.APP_CONFIG.DD_RUM_CONFIG = JSON.parse(${dd_rum_config});
+window.APP_CONFIG.DD_RUM_CONFIG = ${dd_rum_config};
 
 window.APP_CONFIG.featureFlags = ${feature_flags};
 


### PR DESCRIPTION
### Fix for #2067, follow-up to #2343 

## Description

This PR removes an unnecessary call to `JSON.parse()` in the `deploy-config.js` Terraform template, which is currently preventing proper initialization of Datadog RUM in Staging.