### PR TITLE
feat: add feature flag for category of funding activity search field

### DIFF
--- a/packages/client/public/deploy-config.js
+++ b/packages/client/public/deploy-config.js
@@ -23,4 +23,5 @@ window.APP_CONFIG.featureFlags = {
   myProfileEnabled: true,
   newTerminologyEnabled: true,
   newGrantsDetailPageEnabled: false,
+  categoryOfFundingActivitySearchFieldEnabled: true,
 };

--- a/packages/client/src/components/Modals/GrantDetailsLegacy.vue
+++ b/packages/client/src/components/Modals/GrantDetailsLegacy.vue
@@ -22,7 +22,7 @@
       <div v-for="field in dialogFields" :key="field">
         <p><span class="data-label">{{ titleize(field) }}:</span> {{ selectedGrant[field] }}</p>
       </div>
-      <p>
+      <p v-if="categoryOfFundingActivitySearchFieldEnabled">
         <span class="data-label">Category of Funding Activity:</span>
         {{ selectedGrant['funding_activity_categories']?.join(', ') }}
       </p>
@@ -95,7 +95,7 @@
 <script>
 import { mapActions, mapGetters } from 'vuex';
 import { debounce } from 'lodash';
-import { newTerminologyEnabled } from '@/helpers/featureFlags';
+import { newTerminologyEnabled, categoryOfFundingActivitySearchFieldEnabled } from '@/helpers/featureFlags';
 import { titleize } from '../../helpers/form-helpers';
 
 export default {
@@ -190,6 +190,9 @@ export default {
     },
     newTerminologyEnabled() {
       return newTerminologyEnabled();
+    },
+    categoryOfFundingActivitySearchFieldEnabled() {
+      return categoryOfFundingActivitySearchFieldEnabled();
     },
   },
   watch: {

--- a/packages/client/src/components/Modals/SearchPanel.vue
+++ b/packages/client/src/components/Modals/SearchPanel.vue
@@ -156,7 +156,7 @@
                 :clearable="false"
               />
             </b-form-group>
-            <b-form-group
+            <b-form-group v-if="categoryOfFundingActivitySearchFieldEnabled"
               id="category-of-funding-activity-group"
               label="Category of Funding Activity"
               label-for="category-of-funding-activity"
@@ -235,8 +235,9 @@
 
 import { mapActions, mapGetters } from 'vuex';
 import { VBToggle } from 'bootstrap-vue';
-import { billOptions } from '@/helpers/constants';
 import { DateTime } from 'luxon';
+import { billOptions } from '@/helpers/constants';
+import { categoryOfFundingActivitySearchFieldEnabled } from '@/helpers/featureFlags';
 
 const defaultCriteria = {
   includeKeywords: null,
@@ -328,6 +329,9 @@ export default {
     },
     invalidTitleFeedback() {
       return 'Search Title is required';
+    },
+    categoryOfFundingActivitySearchFieldEnabled() {
+      return categoryOfFundingActivitySearchFieldEnabled();
     },
   },
   methods: {

--- a/packages/client/src/helpers/featureFlags/index.js
+++ b/packages/client/src/helpers/featureFlags/index.js
@@ -15,3 +15,7 @@ export function newTerminologyEnabled() {
 export function newGrantsDetailPageEnabled() {
   return getFeatureFlags().newGrantsDetailPageEnabled === true;
 }
+
+export function categoryOfFundingActivitySearchFieldEnabled() {
+  return getFeatureFlags().categoryOfFundingActivitySearchFieldEnabled === true;
+}

--- a/terraform/prod.tfvars
+++ b/terraform/prod.tfvars
@@ -47,9 +47,10 @@ website_datadog_rum_options = {
   trackLongTasks          = true
 }
 website_feature_flags = {
-  myProfileEnabled           = false,
-  newTerminologyEnabled      = false,
-  newGrantsDetailPageEnabled = false
+  myProfileEnabled                            = false,
+  newTerminologyEnabled                       = false,
+  newGrantsDetailPageEnabled                  = false,
+  categoryOfFundingActivitySearchFieldEnabled = false,
 }
 
 // ECS Cluster

--- a/terraform/sandbox.tfvars
+++ b/terraform/sandbox.tfvars
@@ -14,9 +14,10 @@ website_enabled           = true
 website_domain_name       = "sandbox.grants.usdr.dev"
 website_managed_waf_rules = {}
 website_feature_flags = {
-  myProfileEnabled           = true,
-  newTerminologyEnabled      = false,
-  newGrantsDetailPageEnabled = false
+  myProfileEnabled                            = true,
+  newTerminologyEnabled                       = false,
+  newGrantsDetailPageEnabled                  = false,
+  categoryOfFundingActivitySearchFieldEnabled = false,
 }
 
 // ECS Cluster

--- a/terraform/staging.tfvars
+++ b/terraform/staging.tfvars
@@ -44,9 +44,10 @@ website_datadog_rum_options = {
   trackLongTasks          = true
 }
 website_feature_flags = {
-  myProfileEnabled           = true,
-  newTerminologyEnabled      = true,
-  newGrantsDetailPageEnabled = false
+  myProfileEnabled                            = true,
+  newTerminologyEnabled                       = true,
+  newGrantsDetailPageEnabled                  = false,
+  categoryOfFundingActivitySearchFieldEnabled = false,
 }
 
 // ECS Cluster


### PR DESCRIPTION
### Ticket #2267 
## Description
Adds a feature flag for the new "Category of Funding Activity" search field, since there will be a delay in populating that field for all grants (see [Slack](https://usdigitalresponse.slack.com/archives/C0324KDQSCR/p1702502826238319?thread_ts=1702499999.626319&cid=C0324KDQSCR)) which is likely to cause confusion if users start using the search field. The flag will be enabled once we get all the data loaded.

The flag hides the "Category of Funding Activity" select input on the search panel and the same field on the legacy/current Grant Details page (the new in-progress Grant Details page doesn't have this field yet). Existing searches already created with this new search parameter will not be cleaned up but that shouldn't be a problem since no production users have had a chance to create such searches yet.

## Screenshots / Demo Video

## Testing
The feature is enabled by default in dev so, to test the disabled state, you'll have to toggle the flag to false. The feature is disabled in staging so the disabled state can easily be tested once the PR is merged.

The flag is named `categoryOfFundingActivitySearchFieldEnabled`.
### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [x] Added steps to test feature/functionality manually

## Checklist
- [x] Provided ticket and description
- [ ] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [x] Added PR reviewers