### PR TITLE
feat: Load current GrantDetail modal as a new page

### DIFF
--- a/packages/client/src/components/GrantsTable.vue
+++ b/packages/client/src/components/GrantsTable.vue
@@ -25,7 +25,7 @@
         <b-table id="grants-table" hover responsive stacked="sm" :items="formattedGrants"
           :fields="fields.filter(field => !field.hideGrantItem)" selectable striped :sort-by.sync="orderBy"
           :sort-desc.sync="orderDesc" :no-local-sorting="true" :bordered="true" select-mode="single" :busy="loading"
-          @row-selected="onRowSelected" show-empty emptyText="No matches found">
+          @row-selected="onRowSelected" @row-clicked="onRowClicked" show-empty emptyText="No matches found">
           <template #cell(award_floor)="row">
             <p> {{ formatMoney(row.item.award_floor) }}</p>
           </template>
@@ -334,6 +334,12 @@ export default {
         return undefined;
       }
       return floor;
+    },
+    onRowClicked(item) {
+      if (!newGrantsDetailPageEnabled()) {
+        return;
+      }
+      this.$router.push(`grant/${item.grant_id}`);
     },
     onRowSelected(items) {
       const [row] = items;

--- a/packages/client/src/router/index.js
+++ b/packages/client/src/router/index.js
@@ -1,10 +1,11 @@
 import Vue from 'vue';
 import VueRouter from 'vue-router';
 
-import { myProfileEnabled, newTerminologyEnabled } from '@/helpers/featureFlags';
+import { myProfileEnabled, newTerminologyEnabled, newGrantsDetailPageEnabled } from '@/helpers/featureFlags';
 import Login from '../views/Login.vue';
 import Layout from '../components/Layout.vue';
 import ArpaAnnualPerformanceReporter from '../views/ArpaAnnualPerformanceReporter.vue';
+import GrantDetail from '../views/GrantDetails.vue';
 
 import store from '../store';
 
@@ -134,6 +135,16 @@ const routes = [
     redirect: '/my-grants',
   },
 ];
+
+if (newGrantsDetailPageEnabled()) {
+  routes.push(
+    {
+      path: '/grant/:id',
+      name: 'grantDetail',
+      component: GrantDetail,
+    },
+  );
+}
 
 const router = new VueRouter({
   base: process.env.BASE_URL,

--- a/packages/client/src/views/Dashboard.vue
+++ b/packages/client/src/views/Dashboard.vue
@@ -15,7 +15,9 @@
                 :sort-by.sync="sortBy" :sort-desc.sync="sortAsc" class='table table-borderless overflow-hidden' thead-class="d-none"
                 selectable
                 select-mode="single"
-                @row-selected="onRowSelected">
+                @row-selected="onRowSelected"
+                @row-clicked="onRowClicked"
+                >
                 <template #cell(icon)="list">
                   <div class="gutter-icon row">
                     <b-icon v-if="list.item.interested === 0" icon="x-circle-fill" scale="1" variant="danger"></b-icon>
@@ -56,7 +58,9 @@
                 class='table table-borderless' thead-class="d-none"
                 selectable
                 select-mode="single"
-                @row-selected="onRowSelected">
+                @row-selected="onRowSelected"
+                @row-clicked="onRowClicked"
+                >
                 <template #cell()="{ field, value, index }">
                   <div v-if="field.key === 'title'">{{value}}</div>
                   <div v-if="field.key === 'close_date' && yellowDate === true" :style="field.trStyle" v-text="value"></div>
@@ -471,6 +475,12 @@ export default {
           this.selectedGrant = this.currentGrant;
         });
       }
+    },
+    onRowClicked(item) {
+      if (!newGrantsDetailPageEnabled()) {
+        return;
+      }
+      this.$router.push(`grant/${item.grant_id}`);
     },
   },
 };

--- a/packages/client/src/views/RecentActivity.vue
+++ b/packages/client/src/views/RecentActivity.vue
@@ -21,6 +21,7 @@
       selectable
       select-mode="single"
       @row-selected="onRowSelected"
+      @row-clicked="onRowClicked"
     >
       <template #cell(icon)="list">
         <div class="gutter-icon row">
@@ -194,6 +195,12 @@ export default {
           this.selectedGrant = this.currentGrant;
         });
       }
+    },
+    onRowClicked(item) {
+      if (!newGrantsDetailPageEnabled()) {
+        return;
+      }
+      this.$router.push(`grant/${item.grant_id}`);
     },
     exportCSV() {
       this.exportCSVRecentActivities();

--- a/packages/client/src/views/UpcomingClosingDates.vue
+++ b/packages/client/src/views/UpcomingClosingDates.vue
@@ -14,6 +14,7 @@
       selectable
       select-mode="single"
       @row-selected="onRowSelected"
+      @row-clicked="onRowClicked"
     >
       <template #cell()="{ field, value, index }">
         <div v-if="field.key == 'title'">{{value}}</div>
@@ -173,6 +174,12 @@ export default {
           this.selectedGrant = this.currentGrant;
         });
       }
+    },
+    onRowClicked(item) {
+      if (!newGrantsDetailPageEnabled()) {
+        return;
+      }
+      this.$router.push(`grant/${item.grant_id}`);
     },
     formatDate(value) {
       // value is the close date of grant


### PR DESCRIPTION
### Ticket #2368 
## Description
Conditional on the feature flag. this change:
* Adds a grant details page to the router
* Links from the various tables that used the legacy modal to the grant details page instead
* enables forward and back functionality

## Screenshots / Demo Video
[Screencast from 12-17-2023 03:30:53 PM.webm](https://github.com/usdigitalresponse/usdr-gost/assets/64168322/af87ad93-0c17-4038-b7b4-65b217fe6e26)

## Testing

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [ ] Provided ticket and description
- [ ] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers