### PR TITLE
fix: make new GrantDetails page a child of Layout

### DIFF
--- a/packages/client/src/router/index.js
+++ b/packages/client/src/router/index.js
@@ -5,7 +5,6 @@ import { myProfileEnabled, newTerminologyEnabled, newGrantsDetailPageEnabled } f
 import Login from '../views/Login.vue';
 import Layout from '../components/Layout.vue';
 import ArpaAnnualPerformanceReporter from '../views/ArpaAnnualPerformanceReporter.vue';
-import GrantDetail from '../views/GrantDetails.vue';
 
 import store from '../store';
 
@@ -64,6 +63,16 @@ const routes = [
         component: () => import('../views/Grants.vue'),
         meta: {
           requiresAuth: true,
+        },
+      },
+      {
+        path: '/grant/:id',
+        name: 'grantDetail',
+        component: () => import('../views/GrantDetails.vue'),
+        meta: {
+          hideLayoutTabs: true,
+          requiresAuth: true,
+          requiresNewGrantsDetailPageEnabled: true,
         },
       },
       {
@@ -136,16 +145,6 @@ const routes = [
   },
 ];
 
-if (newGrantsDetailPageEnabled()) {
-  routes.push(
-    {
-      path: '/grant/:id',
-      name: 'grantDetail',
-      component: GrantDetail,
-    },
-  );
-}
-
 const router = new VueRouter({
   base: process.env.BASE_URL,
   routes,
@@ -168,6 +167,7 @@ router.beforeEach((to, from, next) => {
   } else if (to.name === 'not-found'
     || (to.meta.requiresMyProfileEnabled && !myProfileEnabled())
     || (to.meta.requiresNewTerminologyEnabled && !newTerminologyEnabled())
+    || (to.meta.requiresNewGrantsDetailPageEnabled && !newGrantsDetailPageEnabled())
   ) {
     if (authenticated) {
       next({ name: 'grants' });


### PR DESCRIPTION
### Ticket #2370
## Description
First step to match the design. Moving GrantDetails to be a child of Layout, so you get the header

## Screenshots / Demo Video
<img width="1027" alt="Screenshot 2023-12-19 at 9 15 43 AM" src="https://github.com/usdigitalresponse/usdr-gost/assets/146878468/bc873155-ea5b-4cda-8b56-d9f0b08e46ce">

## Testing
Turn on the feature flag, and click to load a grant

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [x ] Added steps to test feature/functionality manually

## Checklist
- [x ] Provided ticket and description
- [x] Provided screenshots/demo
- [x ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [x ] Added PR reviewers