### PR TITLE
feat: update preferences link in emails to point to the new profile page 

### DIFF
--- a/packages/server/src/lib/email.js
+++ b/packages/server/src/lib/email.js
@@ -163,7 +163,7 @@ async function sendGrantAssignedNotficationForAgency(assignee_agency, grantDetai
     const emailHTML = module.exports.addBaseBranding(grantAssignedBody, {
         tool_name: 'Grants Identification Tool',
         title: 'Grants Assigned Notification',
-        notifications_url: `${process.env.WEBSITE_DOMAIN}/grants?manageSettings=true`,
+        notifications_url: (process.env.ENABLE_MY_PROFILE === 'true') ? `${process.env.WEBSITE_DOMAIN}/my-profile` : `${process.env.WEBSITE_DOMAIN}/grants?manageSettings=true`,
     });
 
     // TODO: add plain text version of the email
@@ -238,7 +238,7 @@ async function sendGrantDigest({
     const emailHTML = module.exports.addBaseBranding(formattedBody, {
         tool_name: 'Federal Grant Finder',
         title: 'New Grants Digest',
-        notifications_url: `${process.env.WEBSITE_DOMAIN}/grants?manageSettings=true`,
+        notifications_url: (process.env.ENABLE_MY_PROFILE === 'true') ? `${process.env.WEBSITE_DOMAIN}/my-profile` : `${process.env.WEBSITE_DOMAIN}/grants?manageSettings=true`,
     });
 
     // TODO: add plain text version of the email
@@ -304,7 +304,7 @@ async function buildAndSendUserSavedSearchGrantDigest(userId, openDate) {
 
     await asyncBatch(inputs, getAndSendGrantForSavedSearch, 2);
 
-    console.log(`Successfully built and sent grants digest emails for ${openDate}`);
+    console.log(`Successfully built and sent grants digest emails for ${inputs.length} saved searches on ${openDate}`);
 }
 
 async function buildAndSendGrantDigest() {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -176,6 +176,7 @@ module "api" {
   enable_grants_scraper             = var.api_enable_grants_scraper
   enable_grants_digest              = var.api_enable_grants_digest
   enable_new_team_terminology       = var.api_enable_new_team_terminology
+  enable_my_profile                 = var.api_enable_my_profile
   enable_saved_search_grants_digest = var.api_enable_saved_search_grants_digest
   unified_service_tags              = local.unified_service_tags
   datadog_environment_variables     = var.api_datadog_environment_variables

--- a/terraform/modules/gost_api/task.tf
+++ b/terraform/modules/gost_api/task.tf
@@ -51,6 +51,7 @@ module "api_container_definition" {
       ENABLE_SAVED_SEARCH_GRANTS_DIGEST = var.enable_saved_search_grants_digest ? "true" : "false"
       ENABLE_GRANTS_SCRAPER             = "false"
       ENABLE_NEW_TEAM_TERMINOLOGY       = var.enable_new_team_terminology ? "true" : "false"
+      ENABLE_MY_PROFILE                 = var.enable_my_profile ? "true" : "false"
       GRANTS_SCRAPER_DATE_RANGE         = 7
       GRANTS_SCRAPER_DELAY              = 1000
       NODE_OPTIONS                      = "--max_old_space_size=1024"

--- a/terraform/modules/gost_api/variables.tf
+++ b/terraform/modules/gost_api/variables.tf
@@ -174,6 +174,12 @@ variable "enable_new_team_terminology" {
   default     = false
 }
 
+variable "enable_my_profile" {
+  description = "When true, sets the ENABLE_MY_PROFILE environment variable to true in the API container."
+  type        = bool
+  default     = false
+}
+
 variable "enable_saved_search_grants_digest" {
   description = "When true, sets the ENABLE_SAVED_SEARCH_GRANTS_DIGEST environment variable to true in the API container."
   type        = bool

--- a/terraform/prod.tfvars
+++ b/terraform/prod.tfvars
@@ -64,6 +64,7 @@ api_maximum_task_count                = 5
 api_enable_grants_scraper             = false
 api_enable_grants_digest              = false
 api_enable_new_team_terminology       = false
+api_enable_my_profile                 = false
 api_enable_saved_search_grants_digest = true
 api_log_retention_in_days             = 30
 api_datadog_environment_variables = {

--- a/terraform/sandbox.tfvars
+++ b/terraform/sandbox.tfvars
@@ -32,6 +32,7 @@ api_maximum_task_count                = 5
 api_enable_grants_scraper             = false
 api_enable_grants_digest              = false
 api_enable_new_team_terminology       = false
+api_enable_my_profile                 = true
 api_enable_saved_search_grants_digest = false
 api_log_retention_in_days             = 7
 

--- a/terraform/staging.tfvars
+++ b/terraform/staging.tfvars
@@ -61,6 +61,7 @@ api_maximum_task_count                = 5
 api_enable_grants_scraper             = false
 api_enable_grants_digest              = false
 api_enable_new_team_terminology       = true
+api_enable_my_profile                 = true
 api_enable_saved_search_grants_digest = true
 api_log_retention_in_days             = 14
 api_datadog_environment_variables = {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -199,6 +199,10 @@ variable "api_enable_new_team_terminology" {
   type = bool
 }
 
+variable "api_enable_my_profile" {
+  type = bool
+}
+
 variable "api_enable_saved_search_grants_digest" {
   type = bool
 }


### PR DESCRIPTION
### Ticket #2268 
## Description
See ticket for description. This was a simple change except that it required adding a new server-side feature flag, named `api_enable_my_profile` in Terraform.

## Screenshots / Demo Video

## Testing
Steps to test:

1. Enable the server-side feature flag by adding `ENABLE_MY_PROFILE=true` to the .env file under packages/server.
2. Start up the app.
3. Log in as a user whose email you can receive.
4. Go to "My Profile" and make sure that the "Grants Assignment" toggle is on.
5. Assign a grant to your own organization.
6. Check your email for a "Grant Assigned" email.
7. Find the "Change Notification Preferences" link at the bottom of the email and verify that the link URL is "http://localhost:8080/my-profile" (or whatever website domain you have set).

Triggering a Grants Digest email is more complicated but feel free to check that too. 😄  

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [x] Added steps to test feature/functionality manually

## Checklist
- [x] Provided ticket and description
- [ ] Provided screenshots/demo
- [x] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [x] Added PR reviewers