### PR TITLE
Fix `startsWith()` call in update-release condition

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -136,7 +136,7 @@ jobs:
   update-release:
     name: Update release
     runs-on: ubuntu-latest
-    if: startsWith('refs/tags/release/', github.ref)
+    if: startsWith(github.ref, 'refs/tags/release/')
     permissions:
       contents: write
     needs:


### PR DESCRIPTION
## Description

Just like the title says, this PR addresses invalid argument order in a call to the [`startsWith()` GHA expression](https://docs.github.com/en/actions/learn-github-actions/expressions#startswith) used to determine whether a release needs to be updated following a Production deployment. The `startsWith()` function signature is `(searchString, searchValue)`, which is the opposite of our current usage, meaning the step will always be skipped.

The net result of this change should be that the "Update Release" job in the "Deploy to Production" workflow runs as long as the job was executed in the context of a release tag (which should pretty much always be the case).

## Testing

This change is difficult to test outside of actually running it, which only happens when deploying to Production. However, this particular `startsWith()` usage can be mock-tested using [`act`](https://github.com/nektos/act) in the following manner:

<details>
<summary><code>.github/workflows/test-startswith.yml</code></summary>

```yaml
name: Test

on:
  workflow_dispatch:

jobs:
  do_test_startswith:
    runs-on: ubuntu-latest
    if: startsWith(github.ref, 'refs/tags/release/')
    steps:
      - run: |
          echo "Wrong order (should be false): $WRONG_ORDER"
          echo "Correct order (should be true): $CORRECT_ORDER"
        env:
          WRONG_ORDER: ${{ startsWith('refs/tags/release/', github.ref) }}
          CORRECT_ORDER: ${{ startsWith(github.ref, 'refs/tags/release/') }}
```

</details>
<details>
<summary><code>payload.json</code></summary>

```json
{
    "action": "push",
    "ref": "refs/tags/release/2023.1234",
    "inputs": {},
    "parallelTasks": 1
}
```

</details>

```cli
$ act --eventpath payload.json -W .github/workflows/test-startswith.yml -q
[Test/do_test_startswith] 🚀  Start image=node:16-buster-slim
INFO[0000] Parallel tasks (0) below minimum, setting to 1 
[Test/do_test_startswith]   🐳  docker pull image=node:16-buster-slim platform= username= forcePull=true
INFO[0000] Parallel tasks (0) below minimum, setting to 1 
[Test/do_test_startswith]   🐳  docker create image=node:16-buster-slim platform= entrypoint=["tail" "-f" "/dev/null"] cmd=[] network="host"
[Test/do_test_startswith]   🐳  docker run image=node:16-buster-slim platform= entrypoint=["tail" "-f" "/dev/null"] cmd=[] network="host"
[Test/do_test_startswith] ⭐ Run Main echo "Wrong order (should be false): $WRONG_ORDER"
echo "Correct order (should be true): $CORRECT_ORDER"
[Test/do_test_startswith]   🐳  docker exec cmd=[bash --noprofile --norc -e -o pipefail /var/run/act/workflow/0] user= workdir=
[Test/do_test_startswith]   ✅  Success - Main echo "Wrong order (should be false): $WRONG_ORDER"
echo "Correct order (should be true): $CORRECT_ORDER"
[Test/do_test_startswith] Cleaning up container for job do_test_startswith
[Test/do_test_startswith] 🏁  Job succeeded
```
