### PR TITLE
Adjust RUM sample rates in Production

### DIFF
--- a/terraform/prod.tfvars
+++ b/terraform/prod.tfvars
@@ -40,8 +40,8 @@ website_managed_waf_rules = {
 }
 website_datadog_rum_enabled = true
 website_datadog_rum_options = {
-  sessionSampleRate       = 80
-  sessionReplaySampleRate = 20
+  sessionSampleRate       = 100
+  sessionReplaySampleRate = 80
   trackUserInteractions   = true
   trackResources          = true
   trackLongTasks          = true


### PR DESCRIPTION
## Description

This PR is a simple adjustment to the sampling rates configured for Datadog RUM in Production. Initial sampling rates were intentionally a bit conservative; after reviewing costs based on actual usage, it seems worthwhile to sample a bit more aggressively.

The new rates will sample all sessions in Production and make 80% of them available for replay analysis.