### PR TITLE
fix: ensure we ignore microsoft safe links requests

### DIFF
--- a/packages/server/__tests__/lib/access-helpers.test.js
+++ b/packages/server/__tests__/lib/access-helpers.test.js
@@ -92,6 +92,7 @@ describe('Acces Helper Module', () => {
     context('isMicrosoftSafeLinksRequest', () => {
         it('early-returns if request is from Microsoft Safe Links', async () => {
             const resFake = sinon.fake.returns(true);
+            resFake.json = sinon.fake.returns(true);
             const nextFake = sinon.fake.returns(true);
             const requestFake = {
                 headers: {
@@ -105,6 +106,7 @@ describe('Acces Helper Module', () => {
         });
         it('proceeds normally if request is not from Microsoft Safe Links', async () => {
             const resFake = sinon.fake.returns(true);
+            resFake.json = sinon.fake.returns(true);
             const nextFake = sinon.fake.returns(true);
             const requestFake = {
                 headers: {

--- a/packages/server/__tests__/lib/grants-ingest.test.js
+++ b/packages/server/__tests__/lib/grants-ingest.test.js
@@ -36,9 +36,12 @@ describe('processMessages', async () => {
         };
         knexStub = sinon.stub().returns(knexQuery);
         sqsStub = { send: sinon.stub() };
+        this.clockFn = (date) => sinon.useFakeTimers(new Date(date));
+        this.clock = this.clockFn('2023-12-05');
     });
 
     afterEach(() => {
+        this.clock.restore();
         sinon.restore();
     });
 

--- a/packages/server/src/lib/access-helpers.js
+++ b/packages/server/src/lib/access-helpers.js
@@ -124,6 +124,17 @@ async function requireUSDRSuperAdminUser(req, res, next) {
     });
 }
 
+async function isMicrosoftSafeLinksRequest(req, res, next) {
+    const userAgent = req.headers['user-agent'] || '';
+    const nativeHost = req.headers['x-native-host'] || '';
+    if (userAgent.toLowerCase().includes('oneoutlook') || nativeHost.toLowerCase().includes('oneoutlook')) {
+        res.json({ message: 'Success' });
+        return;
+    }
+
+    next();
+}
+
 module.exports = {
-    requireAdminUser, requireUser, isAuthorizedForAgency, isUserAuthorized, isUSDRSuperAdmin, requireUSDRSuperAdminUser, getAdminAuthInfo,
+    requireAdminUser, requireUser, isAuthorizedForAgency, isUserAuthorized, isUSDRSuperAdmin, requireUSDRSuperAdminUser, getAdminAuthInfo, isMicrosoftSafeLinksRequest,
 };

--- a/packages/server/src/routes/sessions.js
+++ b/packages/server/src/routes/sessions.js
@@ -3,6 +3,7 @@ const _ = require('lodash-checkit');
 const path = require('path');
 const { sendPassCode } = require('../lib/email');
 const { validatePostLoginRedirectPath } = require('../lib/redirect_validation');
+const { isMicrosoftSafeLinksRequest } = require('../lib/access-helpers');
 
 const router = express.Router({ mergeParams: true });
 const {
@@ -14,22 +15,14 @@ const {
 } = require('../db');
 const { isUSDRSuperAdmin } = require('../lib/access-helpers');
 
-// NOTE(mbroussard): previously we allowed 2 uses to accommodate automated email systems that prefetch
-// links. Now, we send login links through a clientside redirect instead so this should not be necessary.
-// This has been updated to accommodate Microsoft Safe Links which will prefetch the link twice.
+// Increasing the max-uses to ensure users are able to log-in even if their email client/security provider has clicked on the link already.
+// Specifically the issue was identified with Microsoft Safe Links, which clicks on the link to check if it is safe.
 const MAX_ACCESS_TOKEN_USES = 4;
 
 // the validation URL is sent in the authentication email:
 //     http://localhost:8080/api/sessions/?passcode=97fa7091-77ae-4905-b62e-97a7b4699abd
 //
-router.get('/', async (req, res) => {
-    const userAgent = req.headers['user-agent'] || '';
-    const nativeHost = req.headers['x-native-host'] || '';
-    if (userAgent.toLowerCase().includes('oneoutlook') || nativeHost.toLowerCase().includes('oneoutlook')) {
-        res.json({ message: 'Success' });
-        return;
-    }
-
+router.get('/', isMicrosoftSafeLinksRequest, async (req, res) => {
     const { passcode } = req.query;
     if (passcode) {
         res.sendFile(path.join(__dirname, '../static/login_redirect.html'));

--- a/packages/server/src/routes/sessions.js
+++ b/packages/server/src/routes/sessions.js
@@ -16,12 +16,20 @@ const { isUSDRSuperAdmin } = require('../lib/access-helpers');
 
 // NOTE(mbroussard): previously we allowed 2 uses to accommodate automated email systems that prefetch
 // links. Now, we send login links through a clientside redirect instead so this should not be necessary.
-const MAX_ACCESS_TOKEN_USES = 1;
+// This has been updated to accommodate Microsoft Safe Links which will prefetch the link twice.
+const MAX_ACCESS_TOKEN_USES = 4;
 
 // the validation URL is sent in the authentication email:
 //     http://localhost:8080/api/sessions/?passcode=97fa7091-77ae-4905-b62e-97a7b4699abd
 //
 router.get('/', async (req, res) => {
+    const userAgent = req.headers['user-agent'] || '';
+    const nativeHost = req.headers['x-native-host'] || '';
+    if (userAgent.toLowerCase().includes('oneoutlook') || nativeHost.toLowerCase().includes('oneoutlook')) {
+        res.json({ message: 'Success' });
+        return;
+    }
+
     const { passcode } = req.query;
     if (passcode) {
         res.sendFile(path.join(__dirname, '../static/login_redirect.html'));


### PR DESCRIPTION
### Ticket #2377 
## Description
This PR adds the following:
1. Increases the number of clicks of the passcode link that will allow the user to login.
2. Ignores any requests originating from Microsoft Safe Links

## Screenshots / Demo Video

## Testing

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [ ] Provided ticket and description
- [ ] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers