### PR TITLE
Add jsonb column to store raw body in grants table

### DIFF
--- a/packages/server/migrations/20240105223338_add_raw_body_jsonb_column_to_grants.js
+++ b/packages/server/migrations/20240105223338_add_raw_body_jsonb_column_to_grants.js
@@ -1,0 +1,28 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function (knex) {
+    return knex.raw(`
+      ALTER TABLE grants ADD COLUMN raw_body_json jsonb;
+      
+      CREATE OR REPLACE FUNCTION jsonb_from_text(inval TEXT) RETURNS JSONB AS $$
+        BEGIN
+          RETURN inval::jsonb;
+          exception when others then return null;
+        END;
+      $$ LANGUAGE plpgsql IMMUTABLE;
+      
+      UPDATE grants SET raw_body_json = jsonb_from_text(raw_body) WHERE raw_body IS NOT NULL;
+      
+      DROP FUNCTION jsonb_from_text;
+    `);
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function (knex) {
+    return knex.raw('ALTER TABLE grants DROP COLUMN raw_body_json');
+};

--- a/packages/server/seeds/dev/01_main.js
+++ b/packages/server/seeds/dev/01_main.js
@@ -39,7 +39,7 @@ const globalCodes = [
 ];
 
 exports.seed = async (knex) => {
-    const tables = ['agency_eligibility_codes', 'keywords', 'eligibility_codes', 'grants', 'assigned_grants_agency', 'grants_interested'];
+    const tables = ['agency_eligibility_codes', 'keywords', 'eligibility_codes', 'grants', 'assigned_grants_agency', 'grants_interested', 'grants_saved_searches'];
 
     // eslint-disable-next-line no-restricted-syntax
     for (const table of tables) {

--- a/packages/server/seeds/dev/ref/grants.js
+++ b/packages/server/seeds/dev/ref/grants.js
@@ -48,7 +48,36 @@ const grants = [
         eligibility_codes: '25',
         funding_activity_category_codes: 'ST',
         opportunity_status: 'posted',
-        raw_body: 'raw body',
+        raw_body_json: {
+            opportunity: {
+                id: '335255',
+                number: '21-605',
+                title: 'EAR Postdoctoral Fellowships',
+                description: '<p class="MsoNormal">The Division of Earth Sciences (EAR) awards Postdoctoral Fellowships </p>',
+                milestones: {
+                    post_date: '2021-08-11',
+                    close: {
+                        date: '2021-11-03',
+                    },
+                },
+                category: { code: 'D', name: 'Discretionary' },
+            },
+            agency: { code: 'NSF' },
+            award: { ceiling: '6500' },
+            cost_sharing_or_matching_requirement: false,
+            cfda_numbers: ['47.050'],
+            eligible_applicants: [
+                { code: '25' },
+            ],
+            funding_activity: {
+                categories: [
+                    {
+                        name: 'Science and Technology and Other Research and Development',
+                        code: 'ST',
+                    },
+                ],
+            },
+        },
         created_at: '2021-08-11 11:30:38.89828-07',
         updated_at: '2021-08-11 12:30:39.531-07',
     },
@@ -71,9 +100,41 @@ const grants = [
         eligibility_codes: '11 07 25',
         funding_activity_category_codes: 'HL ISS',
         opportunity_status: 'posted',
-        raw_body: 'raw body',
+        raw_body_json: {
+            opportunity: {
+                id: '333816',
+                number: 'HHS-2021-IHS-TPI-0001',
+                title: 'Community Health Aide Program:  Tribal Planning & Implementation',
+                description: ' <p>Health Aide Program for Covid</p>',
+                milestones: {
+                    post_date: '2021-08-05',
+                },
+                category: { code: 'D', name: 'Discretionary' },
+            },
+            agency: { code: 'HHS-IHS' },
+            award: { ceiling: '500000' },
+            cost_sharing_or_matching_requirement: false,
+            cfda_numbers: ['93.382'],
+            eligible_applicants: [
+                { code: '11' }, { code: '07' }, { code: '25' },
+            ],
+            funding_activity: {
+                categories: [
+                    {
+                        name: 'Health',
+                        code: 'HL',
+                    },
+                    {
+                        name: 'Income Security and Social Services',
+                        code: 'ISS',
+                    },
+                ],
+            },
+            revision: { id: 'c3' },
+        },
         created_at: '2021-08-06 16:03:53.57025-07',
         updated_at: '2021-08-11 12:35:42.562-07',
+        revision_id: 'c3',
     },
     {
         status: 'inbox',
@@ -94,7 +155,33 @@ const grants = [
         eligibility_codes: '25',
         funding_activity_category_codes: 'HL',
         opportunity_status: 'posted',
-        raw_body: 'raw body',
+        raw_body_json: {
+            opportunity: {
+                id: '666999',
+                number: 'grant-number-666999',
+                title: 'Test Grant 666999',
+                description: '<p>Test Grant Description 666999</p>',
+                milestones: {
+                    post_date: '2021-09-04',
+                    close: {
+                        date: daysAhead(2),
+                    },
+                },
+                category: { code: 'D', name: 'Discretionary' },
+            },
+            agency: { code: 'NSF' },
+            award: { ceiling: '6500' },
+            cost_sharing_or_matching_requirement: false,
+            cfda_numbers: ['47.050'],
+            eligible_applicants: [
+                { code: '25' },
+            ],
+            funding_activity: {
+                categories: [
+                    { name: 'Health', code: 'HL' },
+                ],
+            },
+        },
         created_at: '2021-08-11 11:30:38.89828-07',
         updated_at: '2021-08-11 12:30:39.531-07',
     },
@@ -117,7 +204,32 @@ const grants = [
         eligibility_codes: '',
         funding_activity_category_codes: 'HL',
         opportunity_status: 'posted',
-        raw_body: 'raw body',
+        raw_body_json: {
+            opportunity: {
+                id: '0',
+                number: '0',
+                title: 'Test Grant 0',
+                description: '',
+                milestones: {
+                    post_date: '2021-08-05',
+                    close: {
+                        date: daysAhead(3),
+                    },
+                },
+                category: { code: 'D', name: 'Discretionary' },
+            },
+            agency: { code: 'HHS-IHS' },
+            award: { ceiling: '500000' },
+            cost_sharing_or_matching_requirement: false,
+            cfda_numbers: ['93.382'],
+            eligible_applicants: [
+            ],
+            funding_activity: {
+                categories: [
+                    { name: 'Health', code: 'HL' },
+                ],
+            },
+        },
         created_at: '2021-08-06 16:03:53.57025-07',
         updated_at: '2021-08-11 12:35:42.562-07',
     },
@@ -140,7 +252,33 @@ const grants = [
         eligibility_codes: '11 07 25',
         funding_activity_category_codes: 'O',
         opportunity_status: 'posted',
-        raw_body: 'raw body',
+        raw_body_json: {
+            opportunity: {
+                id: '333333',
+                number: 'HHS-2021-IHS-TPI-0002',
+                title: 'Community Health Aide Program:  County Planning & Implementation',
+                description: ' <p>Health Aide Program for Covid</p>',
+                milestones: {
+                    post_date: '2021-08-05',
+                    close: {
+                        date: daysAhead(4),
+                    },
+                },
+                category: { code: 'D', name: 'Discretionary' },
+            },
+            agency: { code: 'HHS-IHS' },
+            award: { ceiling: '500000' },
+            cost_sharing_or_matching_requirement: false,
+            cfda_numbers: ['93.382'],
+            eligible_applicants: [
+                { code: '11' }, { code: '07' }, { code: '25' },
+            ],
+            funding_activity: {
+                categories: [
+                    { name: 'Other', code: 'O' },
+                ],
+            },
+        },
         created_at: '2021-08-06 16:03:53.57025-07',
         updated_at: '2021-08-11 12:35:42.562-07',
     },


### PR DESCRIPTION
### Ticket #2408 
## Description
During the grants ingestion process, we receive a JSON object representing a grant and pull it apart to populate various columns in the `grants` db table. We also store the raw JSON object in the column `grants.raw_body`, but we store it as `text` rather than as JSON which makes it less useful than it could be. This PR creates a migration that adds a column `grants.raw_body_json` of type `jsonb` and populates it from the `grants.raw_body` column.

Note that this PR doesn't fix the ticket by itself. A second PR will be required that either:
1. Runs a migration that populates `funding_activity_category_codes` from `raw_body_json` using the function described in the implementation notes for this ticket (but slightly simpler since we won't have to worry about the cast to json failing).
2. Rewrite the db queries to read funding activity categories directly from the jsonb column, using Postgres's various jsonb operators.

## Screenshots / Demo Video
This PR does not have any user-facing effects.

## Testing
To test the migration locally, I did the following:
1. Checkout main branch and run `docker compose exec app yarn db:seed`.
2. In the database, execute:
`UPDATE grants 
SET raw_body = '{"opportunity":{"id":"333816","number":"HHS-2021-IHS-TPI-0001","title":"Community Health Aide Program:  Tribal Planning & Implementation","description":" <p>Health Aide Program for Covid</p>","milestones":{"post_date":"2021-08-05"},"category":{"code":"D","name":"Discretionary"}},"agency":{"code":"HHS-IHS"},"award":{"ceiling":"500000"},"cost_sharing_or_matching_requirement":false,"cfda_numbers":["93.382"],"eligible_applicants":[{"code":"11"},{"code":"07"},{"code":"25"}],"funding_activity":{"categories":[{"name":"Health","code":"HL"},{"name":"Income Security and Social Services","code":"ISS"}]},"revision":{"id":"c3"}}'
WHERE grant_id = '333816';`
3. Checkout PR branch and run `docker compose exec app yarn db:migrate`.
4. Check that `grants` table has new column `raw_body_json` that is null for all rows except for the grant with id 333816. In that row, the new column should have JSON matching the `raw_body` set in step 2.

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [x] Added steps to test feature/functionality manually

## Checklist
- [x] Provided ticket and description
- [ ] Provided screenshots/demo
- [x] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers