### PR TITLE
chore: add logging around safe links requests

### DIFF
--- a/packages/server/src/lib/access-helpers.js
+++ b/packages/server/src/lib/access-helpers.js
@@ -129,7 +129,11 @@ async function isMicrosoftSafeLinksRequest(req, res, next) {
     const userAgent = req.headers['user-agent'] || '';
     const nativeHost = req.headers['x-native-host'] || '';
     if (userAgent.toLowerCase().includes('oneoutlook') || nativeHost.toLowerCase().includes('oneoutlook')) {
-        log.info({ headers: req.headers }, 'Microsoft Safe Links request');
+        log.info({
+            'user-agent': userAgent,
+            'native-host': nativeHost,
+            headers: Object.keys(req.headers),
+        }, 'Microsoft Safe Links request');
         res.json({ message: 'Success' });
         return;
     }

--- a/packages/server/src/lib/access-helpers.js
+++ b/packages/server/src/lib/access-helpers.js
@@ -1,4 +1,5 @@
 const { getUser, inTenant } = require('../db');
+const { log } = require('./logging');
 
 const USDR_TENANT_ID = 1;
 const USDR_AGENCY_ID = 0;
@@ -128,6 +129,7 @@ async function isMicrosoftSafeLinksRequest(req, res, next) {
     const userAgent = req.headers['user-agent'] || '';
     const nativeHost = req.headers['x-native-host'] || '';
     if (userAgent.toLowerCase().includes('oneoutlook') || nativeHost.toLowerCase().includes('oneoutlook')) {
+        log.info({ headers: req.headers }, 'Microsoft Safe Links request');
         res.json({ message: 'Success' });
         return;
     }


### PR DESCRIPTION
### Ticket #2377 
## Description
This PR adds logging to capture request headers if we identify a request originating from Microsoft. The goal is to get an understanding of the volume of these requests and see if we are able to accurately intercept these requests purely based on the data present in the headers. Once we confirm that we are logging these requests appropriately, we can reduce the number of `MAX_ACCESS_TOKEN_USES` back down to 1.

## Screenshots / Demo Video
N/A

## Testing
N/A

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [x] Provided ticket and description
- [ ] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers