### PR TITLE
Set time-of-day for Dependabot schedules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://json.schemastore.org/dependabot-2.0.json
+
 # Please see the documentation for all configuration options:
 # https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 
@@ -8,29 +10,43 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+      time: "03:00"
+      timezone: "America/New_York"
   - package-ecosystem: "terraform"
     directory: "/terraform"
     schedule:
       interval: "daily"
+      time: "03:00"
+      timezone: "America/New_York"
   # Dependabot can't inspect nested directories so we need to list all local modules individually.
   # TODO: Consider switching to Rennovate.
   - package-ecosystem: "terraform"
     directory: "/terraform/modules/gost_api"
     schedule:
       interval: "daily"
+      time: "03:00"
+      timezone: "America/New_York"
   - package-ecosystem: "terraform"
     directory: "/terraform/modules/gost_consume_grants"
     schedule:
       interval: "daily"
+      time: "03:00"
+      timezone: "America/New_York"
   - package-ecosystem: "terraform"
     directory: "/terraform/modules/gost_website"
     schedule:
       interval: "daily"
+      time: "03:00"
+      timezone: "America/New_York"
   - package-ecosystem: "terraform"
     directory: "/terraform/modules/gost_postgres"
     schedule:
       interval: "daily"
+      time: "03:00"
+      timezone: "America/New_York"
   - package-ecosystem: "terraform"
     directory: "/terraform/modules/scheduled_ecs_task"
     schedule:
       interval: "daily"
+      time: "03:00"
+      timezone: "America/New_York"


### PR DESCRIPTION
## Description

This PR is simply a quality-of-life enhancement, which explicitly sets a time-of-day for Dependabot to run. Currently, Dependabot likes to run sometime during the afternoon. Since this is an active time for (human) developers, things end up getting slowed down when attempting to merge approved PRs, as frequent changes to `main` need to get merged into the PR branch, which re-runs CI workflows, etc. 

This PR schedules Dependabot runs for 3am Eastern (`America/New_York`), which will hopefully result in the bulk of automated updates completing during off-hours rather than in the middle of the day.