### PR TITLE
ARPA subrecipients — invert null check typo

### DIFF
--- a/packages/server/src/arpa_reporter/db/arpa-subrecipients.js
+++ b/packages/server/src/arpa_reporter/db/arpa-subrecipients.js
@@ -93,7 +93,7 @@ async function listRecipients(trns = knex) {
 }
 
 async function listRecipientsForReportingPeriod(periodId, trns = knex) {
-    return baseQuery(trns).where('reporting_period_id', periodId).whereNotNull('archived_at');
+    return baseQuery(trns).where('reporting_period_id', periodId).whereNull('archived_at');
 }
 
 module.exports = {


### PR DESCRIPTION
Fixes a typo in #2164 