### PR TITLE
fix: #2105 - audit report enhancements

### DIFF
--- a/packages/server/src/arpa_reporter/lib/audit-report.js
+++ b/packages/server/src/arpa_reporter/lib/audit-report.js
@@ -4,6 +4,7 @@ const moment = require('moment');
 const { v4 } = require('uuid');
 const XLSX = require('xlsx');
 const { PutObjectCommand } = require('@aws-sdk/client-s3');
+const fs = require('fs/promises');
 const { log } = require('../../lib/logging');
 const aws = require('../../lib/gost-aws');
 const { ec } = require('./format');
@@ -311,6 +312,8 @@ async function createReportsGroupedByProject(periodId, tenantId, dateFormat = RE
             row[`${endDate} Total Expenditures for Awards Greater or Equal to $50k`] = 0;
             row[`${endDate} Total Aggregate Obligations`] = 0;
             row[`${endDate} Total Obligations for Awards Greater or Equal to $50k`] = 0;
+            row[`${endDate} Total Obligations for Aggregate Awards < $50k`] = 0;
+            row[`${endDate} Total Expenditures for Aggregate Awards < $50k`] = 0;
         });
 
         // Sum the total value of each initialized column from the corresponding subtotal
@@ -321,6 +324,8 @@ async function createReportsGroupedByProject(periodId, tenantId, dateFormat = RE
             row[`${endDate} Total Aggregate Obligations`] += (record.content.Total_Obligations__c || 0);
             row[`${endDate} Total Obligations for Awards Greater or Equal to $50k`] += (record.content.Award_Amount__c || 0);
             row[`${endDate} Total Expenditures for Awards Greater or Equal to $50k`] += (record.content.Expenditure_Amount__c || 0);
+            row[`${endDate} Total Obligations for Aggregate Awards < $50k`] += (record.content.Quarterly_Obligation_Amt_Aggregates__c || 0);
+            row[`${endDate} Total Expenditures for Aggregate Awards < $50k`] += (record.content.Quarterly_Expenditure_Amt_Aggregates__c || 0);
             row['Capital Expenditure Amount'] += (record.content.Total_Cost_Capital_Expenditure__c || 0);
         });
 
@@ -413,6 +418,8 @@ function createHeadersProjectSummariesV2(projectSummaryGroupedByProject) {
         'Total Aggregate Expenditures',
         'Total Obligations for Awards Greater or Equal to $50k',
         'Total Expenditures for Awards Greater or Equal to $50k',
+        'Total Obligations for Aggregate Awards < $50k',
+        'Total Expenditures for Aggregate Awards < $50k',
     ];
 
     // first add the properly ordered non-date headers,
@@ -548,8 +555,9 @@ async function generateAndSendEmail(requestHost, recipientEmail, tenantId = useT
     try {
         logger.info({ uploadParams: { Bucket: uploadParams.Bucket, Key: uploadParams.Key } },
             'uploading ARPA audit report to S3');
+        await fs.writeFile(report.filename, report.outputWorkBook, { flag: 'wx' });
         await s3.send(new PutObjectCommand(uploadParams));
-        await module.exports.sendEmailWithLink(reportKey, recipientEmail, logger);
+        // await module.exports.sendEmailWithLink(reportKey, recipientEmail, logger);
     } catch (err) {
         logger.error({ err }, 'failed to upload/email audit report');
         throw err;

--- a/packages/server/src/arpa_reporter/lib/audit-report.js
+++ b/packages/server/src/arpa_reporter/lib/audit-report.js
@@ -4,7 +4,6 @@ const moment = require('moment');
 const { v4 } = require('uuid');
 const XLSX = require('xlsx');
 const { PutObjectCommand } = require('@aws-sdk/client-s3');
-const fs = require('fs/promises');
 const { log } = require('../../lib/logging');
 const aws = require('../../lib/gost-aws');
 const { ec } = require('./format');
@@ -555,9 +554,8 @@ async function generateAndSendEmail(requestHost, recipientEmail, tenantId = useT
     try {
         logger.info({ uploadParams: { Bucket: uploadParams.Bucket, Key: uploadParams.Key } },
             'uploading ARPA audit report to S3');
-        await fs.writeFile(report.filename, report.outputWorkBook, { flag: 'wx' });
         await s3.send(new PutObjectCommand(uploadParams));
-        // await module.exports.sendEmailWithLink(reportKey, recipientEmail, logger);
+        await module.exports.sendEmailWithLink(reportKey, recipientEmail, logger);
     } catch (err) {
         logger.error({ err }, 'failed to upload/email audit report');
         throw err;

--- a/packages/server/src/arpa_reporter/services/records.js
+++ b/packages/server/src/arpa_reporter/services/records.js
@@ -93,7 +93,7 @@ async function loadRecordsForUpload(upload) {
         );
 
         // ignore hidden sheets
-        if (sheetAttributes.Hidden !== 0) {
+        if (sheetAttributes?.Hidden !== 0) {
             // eslint-disable-next-line no-continue
             continue;
         }
@@ -249,8 +249,7 @@ async function recordsForProject(periodId, tenantId) {
     const projectRecords = allRecords
         .flat()
         // exclude non-project records
-        .filter((record) => ([...Object.values(EC_SHEET_TYPES), 'awards50k', 'expenditures50k']).includes(record.type));
-
+        .filter((record) => ([...Object.values(EC_SHEET_TYPES), 'awards50k', 'expenditures50k', 'awards']).includes(record.type));
     return Object.values(projectRecords);
 }
 

--- a/packages/server/src/arpa_reporter/services/records.js
+++ b/packages/server/src/arpa_reporter/services/records.js
@@ -93,7 +93,7 @@ async function loadRecordsForUpload(upload) {
         );
 
         // ignore hidden sheets
-        if (sheetAttributes?.Hidden !== 0) {
+        if (sheetAttributes.Hidden !== 0) {
             // eslint-disable-next-line no-continue
             continue;
         }


### PR DESCRIPTION
### Ticket #2105
- added awards < 50k for filtering records
- added two aggregate columns for awards < 50k on the audit report

## Screenshots / Demo Video
![image](https://github.com/usdigitalresponse/usdr-gost/assets/842982/14c3aca9-46a7-4936-9a5e-d7155bfa4a04)

## Testing
We do not have testing setup for the audit report. It's a lot of mocking out data.
I tested this manually by running the audit report and checking the V2 tab.

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [x] Added steps to test feature/functionality manually

## Checklist
- [x] Provided ticket and description
- [x] Provided screenshots/demo
- [x] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [x] Added PR reviewers