### PR TITLE
Add pdf to list of binary file types in .gitattributes.

### DIFF
--- a/packages/.gitattributes
+++ b/packages/.gitattributes
@@ -15,6 +15,7 @@
 *.ico               binary
 *.jar               binary
 *.jpg               binary
+*.pdf               binary
 *.png               binary
 *.ttf               binary
 *.woff              binary


### PR DESCRIPTION
`packages/server/src/static/forms/nevada_spoc.pdf` keeps showing up as modified, even though I haven't touched it, and I've gotten this warning:

> warning: in the working copy of 'packages/server/src/static/forms/nevada_spoc.pdf', CRLF will be replaced by LF the next time Git touches it