### PR TITLE
Add UTM tags to Grant Email URLs

### DIFF
--- a/packages/server/src/lib/email.js
+++ b/packages/server/src/lib/email.js
@@ -119,7 +119,15 @@ function getGrantDetail(grant, emailNotificationType) {
     const grantDetailTemplate = fileSystem.readFileSync(path.join(__dirname, '../static/email_templates/_grant_detail.html'));
 
     const description = grant.description.substring(0, 380).replace(/(<([^>]+)>)/ig, '');
-
+    const grantsUrl = new URL(process.env.WEBSITE_DOMAIN);
+    if (emailNotificationType === notificationType.grantDigest) {
+        grantsUrl.pathname = 'grants';
+    } else {
+        grantsUrl.pathname = 'my-grants';
+    }
+    grantsUrl.searchParams.set('utm_source', 'subscription');
+    grantsUrl.searchParams.set('utm_medium', 'email');
+    grantsUrl.searchParams.set('utm_campaign', emailNotificationType);
     const grantDetail = mustache.render(
         grantDetailTemplate.toString(), {
             title: grant.title,
@@ -133,7 +141,7 @@ function getGrantDetail(grant, emailNotificationType) {
             // estimated_funding: grant.estimated_funding, TODO: add once field is available in the database.
             cost_sharing: grant.cost_sharing,
             link_url: `https://www.grants.gov/web/grants/view-opportunity.html?oppId=${grant.grant_id}`,
-            grants_url: `${process.env.WEBSITE_DOMAIN}/${emailNotificationType === notificationType.grantDigest ? 'grants' : 'my-grants'}`,
+            grants_url: grantsUrl.toString(),
             view_grant_label: emailNotificationType === notificationType.grantDigest ? undefined : 'View My Grants',
         },
     );
@@ -159,11 +167,15 @@ async function sendGrantAssignedNotficationForAgency(assignee_agency, grantDetai
     }, {
         grant_detail: grantDetail,
     });
-
+    const baseUrl = new URL(process.env.WEBSITE_DOMAIN);
+    baseUrl.pathname = 'my-grants';
+    baseUrl.searchParams.set('utm_source', 'subscription');
+    baseUrl.searchParams.set('utm_medium', 'email');
+    baseUrl.searchParams.set('utm_campaign', 'GRANT_ASSIGNMENT');
     const emailHTML = module.exports.addBaseBranding(grantAssignedBody, {
         tool_name: 'Grants Identification Tool',
         title: 'Grants Assigned Notification',
-        notifications_url: (process.env.ENABLE_MY_PROFILE === 'true') ? `${process.env.WEBSITE_DOMAIN}/my-profile` : `${process.env.WEBSITE_DOMAIN}/grants?manageSettings=true`,
+        notifications_url: baseUrl.toString(),
     });
 
     // TODO: add plain text version of the email

--- a/packages/server/src/static/email_templates/_grant_detail.html
+++ b/packages/server/src/static/email_templates/_grant_detail.html
@@ -70,7 +70,7 @@
                                                 <!--[if !mso]><!-- --><span class="msohide es-button-border"
                                                     style="border-style:solid;border-color:#75B6C9;background:#007bff;border-width:1px;display:inline-block;border-radius:28px;width:auto;mso-hide:all"><a
                                                         href="{{grants_url}}" class="es-button" target="_blank"
-                                                        style="mso-style-priority:100 !important;text-decoration:none;-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;color:#FFFFFF;font-size:16px;border-style:solid;border-color:#007bff;border-width:15px 25px 15px 25px;display:inline-block;background:#007bff;border-radius:28px;font-family:arial, 'helvetica neue', helvetica, sans-serif;font-weight:normal;font-style:normal;line-height:19px;width:auto;text-align:center">{{view_grant_label}}</a></span>
+                                                        utm-content="view my grants" style="mso-style-priority:100 !important;text-decoration:none;-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;color:#FFFFFF;font-size:16px;border-style:solid;border-color:#007bff;border-width:15px 25px 15px 25px;display:inline-block;background:#007bff;border-radius:28px;font-family:arial, 'helvetica neue', helvetica, sans-serif;font-weight:normal;font-style:normal;line-height:19px;width:auto;text-align:center">{{view_grant_label}}</a></span>
                                                 <!--<![endif]-->
                                             </td>
                                         </tr>

--- a/packages/server/src/static/email_templates/base.html
+++ b/packages/server/src/static/email_templates/base.html
@@ -494,7 +494,7 @@
                                                                 <td align="center" style="padding:0;Margin:0">
                                                                     <p
                                                                         style="Margin:0;-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;font-family:'open sans', 'helvetica neue', helvetica, arial, sans-serif;line-height:21px;color:#999999;font-size:14px;">
-                                                                        <u style="text-decoration:none;" ><a style="color:#0068D6;text-decoration:none;" href="{{notifications_url}}">Change
+                                                                        <u style="text-decoration:none;" ><a style="color:#0068D6;text-decoration:none;" href="{{notifications_url}}" utm-content="change notification preferences">Change
                                                                                 notification preferences</a></u>
                                                                     </p>
                                                                 </td>


### PR DESCRIPTION
### Ticket #2516 
## Description
Added UTM tags to the URLs associated with the "View My Grants" button within an assigned grant email and the "Change notification preferences" link. 

## Testing
Saved grant assigned emails in an HTML file format and could see the UTM parameters within the links associated with the elements.

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [ ] Provided ticket and description
- [ ] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers