### PR TITLE
Adding breadcrumb with page title

### DIFF
--- a/packages/client/src/components/GrantsTable.vue
+++ b/packages/client/src/components/GrantsTable.vue
@@ -316,7 +316,7 @@ export default {
       if (!newGrantsDetailPageEnabled()) {
         return;
       }
-      this.$router.push(`grant/${item.grant_id}`);
+      this.$router.push({ name: 'grantDetail', params: {id: item.grant_id, backButton: true }});
       datadogRum.addAction('view grant details', { grant: item });
     },
     onRowSelected(items) {

--- a/packages/client/src/components/GrantsTable.vue
+++ b/packages/client/src/components/GrantsTable.vue
@@ -316,7 +316,7 @@ export default {
       if (!newGrantsDetailPageEnabled()) {
         return;
       }
-      this.$router.push({ name: 'grantDetail', params: { id: item.grant_id, backButton: true }});
+      this.$router.push({ name: 'grantDetail', params: { id: item.grant_id, backButton: true } });
       datadogRum.addAction('view grant details', { grant: item });
     },
     onRowSelected(items) {

--- a/packages/client/src/components/GrantsTable.vue
+++ b/packages/client/src/components/GrantsTable.vue
@@ -316,7 +316,7 @@ export default {
       if (!newGrantsDetailPageEnabled()) {
         return;
       }
-      this.$router.push({ name: 'grantDetail', params: {id: item.grant_id, backButton: true }});
+      this.$router.push({ name: 'grantDetail', params: { id: item.grant_id, backButton: true }});
       datadogRum.addAction('view grant details', { grant: item });
     },
     onRowSelected(items) {

--- a/packages/client/src/router/index.js
+++ b/packages/client/src/router/index.js
@@ -72,6 +72,7 @@ export const routes = [
         path: '/grant/:id',
         name: 'grantDetail',
         component: () => import('../views/GrantDetails.vue'),
+        props: true,
         meta: {
           hideLayoutTabs: true,
           requiresAuth: true,

--- a/packages/client/src/views/Dashboard.vue
+++ b/packages/client/src/views/Dashboard.vue
@@ -353,7 +353,7 @@ export default {
       if (!newGrantsDetailPageEnabled()) {
         return;
       }
-      this.$router.push({ name: 'grantDetail', params: {id: item.grant_id, backButton: true }});
+      this.$router.push({ name: 'grantDetail', params: { id: item.grant_id, backButton: true }});
     },
   },
 };

--- a/packages/client/src/views/Dashboard.vue
+++ b/packages/client/src/views/Dashboard.vue
@@ -353,7 +353,7 @@ export default {
       if (!newGrantsDetailPageEnabled()) {
         return;
       }
-      this.$router.push(`grant/${item.grant_id}`);
+      this.$router.push({ name: 'grantDetail', params: {id: item.grant_id, backButton: true }});
     },
   },
 };

--- a/packages/client/src/views/Dashboard.vue
+++ b/packages/client/src/views/Dashboard.vue
@@ -353,7 +353,7 @@ export default {
       if (!newGrantsDetailPageEnabled()) {
         return;
       }
-      this.$router.push({ name: 'grantDetail', params: { id: item.grant_id, backButton: true }});
+      this.$router.push({ name: 'grantDetail', params: { id: item.grant_id, backButton: true } });
     },
   },
 };

--- a/packages/client/src/views/GrantDetails.vue
+++ b/packages/client/src/views/GrantDetails.vue
@@ -1,5 +1,9 @@
 <template>
   <section class="container-fluid grants-details-container">
+    <b-breadcrumb class="mx-4 flex-nowrap">
+      <b-breadcrumb-item href="/grants">Home</b-breadcrumb-item>
+      <b-breadcrumb-item active class="text-truncate">{{ selectedGrant.title }}</b-breadcrumb-item>
+    </b-breadcrumb>
     <div>
       <div v-if="loading">
         Loading...
@@ -11,10 +15,6 @@
         <b-row>
           <!-- Left page column: title, table data, and grant description -->
           <b-col>
-            <b-breadcrumb class="px-0 flex-nowrap">
-              <b-breadcrumb-item href="/grants">Home</b-breadcrumb-item>
-     	      <b-breadcrumb-item active class="text-truncate">{{ selectedGrant.title }}</b-breadcrumb-item>
-            </b-breadcrumb>
             <h2 class="mb-5">{{ selectedGrant.title }}</h2>
             <b-table
               class="grant-details-table mb-5"

--- a/packages/client/src/views/GrantDetails.vue
+++ b/packages/client/src/views/GrantDetails.vue
@@ -1,6 +1,9 @@
 <template>
   <section class="container-fluid grants-details-container">
-    <b-breadcrumb class="mx-4 flex-nowrap">
+    <router-link v-if="backButton" class="d-inline-block" to="">
+      <span @click="$router.back()" style="color: black"><b-icon icon="arrow-left" aria-hidden="true" class="mr-3" scale="2.0"></b-icon>Back</span>
+    </router-link>
+    <b-breadcrumb v-else class="mx-4 flex-nowrap">
       <b-breadcrumb-item href="/grants">Home</b-breadcrumb-item>
       <b-breadcrumb-item active class="text-truncate">{{ selectedGrant.title }}</b-breadcrumb-item>
     </b-breadcrumb>
@@ -165,6 +168,7 @@ import { DateTime } from 'luxon';
 export default {
   props: {
     selectedGrant: Object,
+    backButton: Boolean,
   },
   data() {
     return {

--- a/packages/client/src/views/GrantDetails.vue
+++ b/packages/client/src/views/GrantDetails.vue
@@ -1,9 +1,11 @@
 <template>
-  <section class="container-fluid grants-details-container">
-    <router-link v-if="backButton" class="d-inline-block" to="">
-      <span @click="$router.back()" style="color: black"><b-icon icon="arrow-left" aria-hidden="true" class="mr-3" scale="2.0"></b-icon>Back</span>
+  <section class="container-fluid">
+    <router-link v-if="backButton" class="d-inline-block text-dark" to="">
+      <h4 @click="$router.back()">
+        <b-icon icon="arrow-left" aria-hidden="true" class="mx-3" scale="2.5"></b-icon>Back
+      </h4>
     </router-link>
-    <b-breadcrumb v-else class="mx-4 flex-nowrap">
+    <b-breadcrumb v-else class="flex-nowrap bg-white">
       <b-breadcrumb-item href="/grants">Home</b-breadcrumb-item>
       <b-breadcrumb-item active class="text-truncate">{{ selectedGrant.title }}</b-breadcrumb-item>
     </b-breadcrumb>
@@ -14,7 +16,7 @@
       <div v-if="!selectedGrant && !loading">
         No grant found
       </div>
-      <b-container fluid v-if="selectedGrant && !loading" class="mt-5">
+      <b-container fluid v-if="selectedGrant && !loading" class="mt-4">
         <b-row>
           <!-- Left page column: title, table data, and grant description -->
           <b-col>
@@ -406,11 +408,8 @@ export default {
 </script>
 
 <style lang="css">
-.breadcrumb {
-  background-color: #ffffff;
-}
-.grants-details-container {
-    padding: 80px;
+.breadcrumb a {
+  color: #6D7278;
 }
 .grants-details-sidebar {
   flex-basis: 500px;

--- a/packages/client/src/views/GrantDetails.vue
+++ b/packages/client/src/views/GrantDetails.vue
@@ -1,7 +1,7 @@
 <template>
   <section class="container-fluid grants-details-container">
     <b-breadcrumb>
-        <b-breadcrumb-item href="/#/grants">Home</b-breadcrumb-item>
+        <b-breadcrumb-item href="/grants">Home</b-breadcrumb-item>
      	<b-breadcrumb-item active>{{ selectedGrant.title }}</b-breadcrumb-item>
     </b-breadcrumb>
     <div>

--- a/packages/client/src/views/GrantDetails.vue
+++ b/packages/client/src/views/GrantDetails.vue
@@ -1,9 +1,5 @@
 <template>
   <section class="container-fluid grants-details-container">
-    <b-breadcrumb>
-        <b-breadcrumb-item href="/grants">Home</b-breadcrumb-item>
-     	<b-breadcrumb-item active>{{ selectedGrant.title }}</b-breadcrumb-item>
-    </b-breadcrumb>
     <div>
       <div v-if="loading">
         Loading...
@@ -15,6 +11,10 @@
         <b-row>
           <!-- Left page column: title, table data, and grant description -->
           <b-col>
+            <b-breadcrumb class="px-0 flex-nowrap">
+              <b-breadcrumb-item href="/grants">Home</b-breadcrumb-item>
+     	      <b-breadcrumb-item active class="text-truncate">{{ selectedGrant.title }}</b-breadcrumb-item>
+            </b-breadcrumb>
             <h2 class="mb-5">{{ selectedGrant.title }}</h2>
             <b-table
               class="grant-details-table mb-5"
@@ -431,3 +431,4 @@ export default {
   }
 }
 </style>
+Ƞį怀 

--- a/packages/client/src/views/GrantDetails.vue
+++ b/packages/client/src/views/GrantDetails.vue
@@ -1,5 +1,9 @@
 <template>
   <section class="container-fluid grants-details-container">
+    <b-breadcrumb>
+        <b-breadcrumb-item href="/#/grants">Home</b-breadcrumb-item>
+     	<b-breadcrumb-item active>{{ selectedGrant.title }}</b-breadcrumb-item>
+    </b-breadcrumb>
     <div>
       <div v-if="loading">
         Loading...
@@ -9,7 +13,6 @@
       </div>
       <b-container fluid v-if="selectedGrant && !loading" class="mt-5">
         <b-row>
-
           <!-- Left page column: title, table data, and grant description -->
           <b-col>
             <h2 class="mb-5">{{ selectedGrant.title }}</h2>
@@ -399,6 +402,12 @@ export default {
 </script>
 
 <style lang="css">
+.breadcrumb {
+  background-color: #ffffff;
+}
+.grants-details-container {
+    padding: 80px;
+}
 .grants-details-sidebar {
   flex-basis: 500px;
   flex-grow: 0;

--- a/packages/client/src/views/GrantDetails.vue
+++ b/packages/client/src/views/GrantDetails.vue
@@ -431,4 +431,3 @@ export default {
   }
 }
 </style>
-Ƞį怀 

--- a/packages/client/src/views/GrantDetails.vue
+++ b/packages/client/src/views/GrantDetails.vue
@@ -18,6 +18,7 @@
       </div>
       <b-container fluid v-if="selectedGrant && !loading" class="mt-4">
         <b-row>
+
           <!-- Left page column: title, table data, and grant description -->
           <b-col>
             <h2 class="mb-5">{{ selectedGrant.title }}</h2>

--- a/packages/client/src/views/RecentActivity.vue
+++ b/packages/client/src/views/RecentActivity.vue
@@ -200,7 +200,7 @@ export default {
       if (!newGrantsDetailPageEnabled()) {
         return;
       }
-      this.$router.push({ name: 'grantDetail', params: {id: item.grant_id, backButton: true }});
+      this.$router.push({ name: 'grantDetail', params: { id: item.grant_id, backButton: true }});
     },
     exportCSV() {
       this.exportCSVRecentActivities();

--- a/packages/client/src/views/RecentActivity.vue
+++ b/packages/client/src/views/RecentActivity.vue
@@ -200,7 +200,7 @@ export default {
       if (!newGrantsDetailPageEnabled()) {
         return;
       }
-      this.$router.push({ name: 'grantDetail', params: { id: item.grant_id, backButton: true }});
+      this.$router.push({ name: 'grantDetail', params: { id: item.grant_id, backButton: true } });
     },
     exportCSV() {
       this.exportCSVRecentActivities();

--- a/packages/client/src/views/RecentActivity.vue
+++ b/packages/client/src/views/RecentActivity.vue
@@ -200,7 +200,7 @@ export default {
       if (!newGrantsDetailPageEnabled()) {
         return;
       }
-      this.$router.push(`grant/${item.grant_id}`);
+      this.$router.push({ name: 'grantDetail', params: {id: item.grant_id, backButton: true }});
     },
     exportCSV() {
       this.exportCSVRecentActivities();

--- a/packages/client/src/views/UpcomingClosingDates.vue
+++ b/packages/client/src/views/UpcomingClosingDates.vue
@@ -179,7 +179,7 @@ export default {
       if (!newGrantsDetailPageEnabled()) {
         return;
       }
-      this.$router.push({ name: 'grantDetail', params: { id: item.grant_id, backButton: true }});
+      this.$router.push({ name: 'grantDetail', params: { id: item.grant_id, backButton: true } });
     },
     formatDate(value) {
       // value is the close date of grant

--- a/packages/client/src/views/UpcomingClosingDates.vue
+++ b/packages/client/src/views/UpcomingClosingDates.vue
@@ -179,7 +179,7 @@ export default {
       if (!newGrantsDetailPageEnabled()) {
         return;
       }
-      this.$router.push({ name: 'grantDetail', params: {id: item.grant_id, backButton: true }});
+      this.$router.push({ name: 'grantDetail', params: { id: item.grant_id, backButton: true }});
     },
     formatDate(value) {
       // value is the close date of grant

--- a/packages/client/src/views/UpcomingClosingDates.vue
+++ b/packages/client/src/views/UpcomingClosingDates.vue
@@ -179,7 +179,7 @@ export default {
       if (!newGrantsDetailPageEnabled()) {
         return;
       }
-      this.$router.push(`grant/${item.grant_id}`);
+      this.$router.push({ name: 'grantDetail', params: {id: item.grant_id, backButton: true }});
     },
     formatDate(value) {
       // value is the close date of grant


### PR DESCRIPTION
### Ticket #2369 
## Description
Adding breadcrumb with page title

## Screenshots / Demo Video
<img width="1402" alt="Screenshot 2024-01-29 at 11 16 10 AM" src="https://github.com/usdigitalresponse/usdr-gost/assets/146878468/cb06f8f9-2b11-4c3f-a2a7-a624cc937e96">
<img width="1402" alt="Screenshot 2024-01-29 at 11 16 04 AM" src="https://github.com/usdigitalresponse/usdr-gost/assets/146878468/c1c9d19d-be92-4dad-aa23-bbba6973c13f">

## Testing
Enable the GrantsDetailPage feature flag and navigate to different grant pages. Verify the Home breadcrumb takes you to the Browse Grants tab.

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [x] Added steps to test feature/functionality manually

## Checklist
- [x] Provided ticket and description
- [x] Provided screenshots/demo
- [x] Provided testing information
- [x] Provided adequate test coverage for all new code
- [x] Added PR reviewers