### PR TITLE
Only .gitignore the root data folder in the server package

### DIFF
--- a/packages/server/.gitignore
+++ b/packages/server/.gitignore
@@ -1,7 +1,7 @@
 src/static/forms/generated
 
 # ARPA Reporter uploads
-data
+/data
 
 # ARPA Reporter uploads dir used by mocha tests
 __tests__/arpa_reporter/server/mocha_uploads


### PR DESCRIPTION
Quick change to .gitignore rules to ensure that only the root `/data` directory in the server package.