### PR TITLE
Add app global context

### DIFF
--- a/packages/client/src/arpa_reporter/main.js
+++ b/packages/client/src/arpa_reporter/main.js
@@ -3,6 +3,7 @@ import { datadogRum } from '@datadog/browser-rum';
 
 if (window.APP_CONFIG?.DD_RUM_ENABLED === true) {
   datadogRum.init(window.APP_CONFIG.DD_RUM_CONFIG);
+  datadogRum.setGlobalContextProperty('app', 'arpa-reporter');
 }
 
 import Vue from 'vue';

--- a/packages/client/src/main.js
+++ b/packages/client/src/main.js
@@ -3,6 +3,7 @@ import { datadogRum } from '@datadog/browser-rum';
 
 if (window.APP_CONFIG?.DD_RUM_ENABLED === true) {
   datadogRum.init(window.APP_CONFIG.DD_RUM_CONFIG);
+  datadogRum.setGlobalContextProperty('app', 'finder');
 }
 
 import Vue from 'vue';


### PR DESCRIPTION
### Ticket #2546 
## Description
Added a call to Datadog's `setGlobalContextProperty` after initialization. Set grant finder tool context as 'finder' and arpa reporter context as 'arpa-reporter'. This enables us to easily distinguish the tools in analysis.

## Testing
Global context is shown accordingly in the debug console as events are sent to Datadog.

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [ ] Provided ticket and description
- [ ] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers