### PR TITLE
Update nv.gov emails to prevent accidental external emails being sent

### DIFF
--- a/packages/server/__tests__/api/agencies.test.js
+++ b/packages/server/__tests__/api/agencies.test.js
@@ -59,7 +59,7 @@ describe('`/api/organizations/:organizationId/agencies` endpoint', () => {
         this.timeout(9000); // Getting session cookies can exceed default timeout.
         fetchOptions.admin.headers.cookie = await getSessionCookie('mindy@usdigitalresponse.org');
         fetchOptions.nonUSDRAdmin.headers.cookie = await getSessionCookie('joecomeau01@gmail.com');
-        fetchOptions.staff.headers.cookie = await getSessionCookie('user2@nv.gov');
+        fetchOptions.staff.headers.cookie = await getSessionCookie('user2@nv.example.com');
 
         testServer = await makeTestServer();
         fetchApi = testServer.fetchApi;

--- a/packages/server/__tests__/api/grants.test.js
+++ b/packages/server/__tests__/api/grants.test.js
@@ -44,8 +44,8 @@ describe('`/api/grants` endpoint', () => {
     let fetchApi;
     before(async function beforeHook() {
         this.timeout(9000); // Getting session cookies can exceed default timeout.
-        fetchOptions.admin.headers.cookie = await getSessionCookie('admin1@nv.gov');
-        fetchOptions.staff.headers.cookie = await getSessionCookie('user1@nv.gov');
+        fetchOptions.admin.headers.cookie = await getSessionCookie('admin1@nv.example.com');
+        fetchOptions.staff.headers.cookie = await getSessionCookie('user1@nv.example.com');
         fetchOptions.dallasAdmin.headers.cookie = await getSessionCookie('user1@dallas.gov');
 
         testServer = await makeTestServer();

--- a/packages/server/__tests__/api/grantsSavedSearch.test.js
+++ b/packages/server/__tests__/api/grantsSavedSearch.test.js
@@ -39,8 +39,8 @@ describe('`/api/grants-saved-search` endpoint', () => {
     let fetchApi;
     before(async function beforeHook() {
         this.timeout(9000); // Getting session cookies can exceed default timeout.
-        fetchOptions.admin.headers.cookie = await getSessionCookie('admin1@nv.gov');
-        fetchOptions.staff.headers.cookie = await getSessionCookie('user1@nv.gov');
+        fetchOptions.admin.headers.cookie = await getSessionCookie('admin1@nv.example.com');
+        fetchOptions.staff.headers.cookie = await getSessionCookie('user1@nv.example.com');
 
         const allAgencyIds = new Set(Object.values(agencies.admin).concat(Object.values(agencies.staff)));
         const testSavedSearches = [];

--- a/packages/server/__tests__/api/keywords.test.js
+++ b/packages/server/__tests__/api/keywords.test.js
@@ -38,8 +38,8 @@ describe('`/api/keywords` endpoint', () => {
     let fetchApi;
     before(async function beforeHook() {
         this.timeout(9000); // Getting session cookies can exceed default timeout.
-        fetchOptions.admin.headers.cookie = await getSessionCookie('admin1@nv.gov');
-        fetchOptions.staff.headers.cookie = await getSessionCookie('user1@nv.gov');
+        fetchOptions.admin.headers.cookie = await getSessionCookie('admin1@nv.example.com');
+        fetchOptions.staff.headers.cookie = await getSessionCookie('user1@nv.example.com');
 
         // Tests below assume the presence of at least one keyword per agency. Previously, we had
         // a db seed that created some default COVID-related keywords but now that that is gone, we

--- a/packages/server/seeds/dev/ref/users.js
+++ b/packages/server/seeds/dev/ref/users.js
@@ -58,7 +58,7 @@ module.exports = [
     },
     {
         id: 6,
-        email: 'user1@nv.gov', // fake email for testing
+        email: 'user1@nv.example.com', // fake email for testing
         name: 'nv.gov User 1',
         agency_id: nevadaAgency.id,
         role_id: roles[1].id,
@@ -66,7 +66,7 @@ module.exports = [
     },
     {
         id: 7,
-        email: 'user2@nv.gov', // fake email for testing
+        email: 'user2@nv.example.com', // fake email for testing
         name: 'nv.gov User 2',
         agency_id: nevadaAgency.id,
         role_id: roles[1].id,
@@ -74,7 +74,7 @@ module.exports = [
     },
     {
         id: 8,
-        email: 'user3@nv.gov', // fake email for testing
+        email: 'user3@nv.example.com', // fake email for testing
         name: 'nv.gov User 3',
         agency_id: nevadaAgency.id,
         role_id: roles[1].id,
@@ -114,7 +114,7 @@ module.exports = [
     },
     {
         id: 13,
-        email: 'admin1@nv.gov', // fake email for testing
+        email: 'admin1@nv.example.com', // fake email for testing
         name: 'nv.gov Admin User 1',
         agency_id: nevadaAgency.id,
         role_id: roles[0].id,


### PR DESCRIPTION
### Ticket #<Enter Number Here To Auto-Link>
## Description

While working on https://github.com/usdigitalresponse/usdr-gost/pull/2540, we discovered it was easy to accidentally send real emails (if you've set up email following the doc here: https://github.com/usdigitalresponse/usdr-gost/blob/main/docs/setup-gmail.md). To make it even harder to accidentally send real emails externally, this PR removes all external email domains from the user seed data. 

We might eventually want to remove these NV users entirely from the seed data, since it seems the feature they relate to is deprecated and unused. However, they're currently used in various tests, so it seemed least disruptive to just change the domain.

Based on my searching, it doesn't appear these NV emails are part of any other processes besides these tests, but if they're in use somewhere I'm missing, please let me know!

## Screenshots / Demo Video

## Testing

Ran the server tests and they continue passing

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [ ] Provided ticket and description
- [ ] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers