### PR TITLE
Grant details page design updates

### DIFF
--- a/packages/client/src/views/GrantDetails.vue
+++ b/packages/client/src/views/GrantDetails.vue
@@ -7,139 +7,143 @@
       <div v-if="!selectedGrant && !loading">
         No grant found
       </div>
-      <div v-if="selectedGrant && !loading" class="mb-3 d-flex align-items-start">
-        <b-col class="mx-4">
-          <h2 class="mb-5">{{ selectedGrant.title }}</h2>
-          <b-table
-            class="grant-details-table mb-5"
-            :items="tableData"
-            :fields="[
-              {key: 'name', class: 'color-gray grants-details-table-fit-content'},
-              {key: 'value', class: 'font-weight-bold'},
-            ]"
-            thead-class="d-none"
-            borderless
-            hover
-          ></b-table>
-          <h3 class="mb-3">Description</h3>
-          <!-- TODO: spike on removing v-html usage https://github.com/usdigitalresponse/usdr-gost/issues/2572 -->
-          <div style="white-space: pre-line" v-html="selectedGrant.description"></div>
-          <br />
-        </b-col>
-        <b-col class="mx-auto my-5 px-2 col-md-4 col-lg-3">
-          <b-row>
-            <b-button
-              :href="`https://www.grants.gov/search-results-detail/${selectedGrant.grant_id}`"
-              target="_blank"
-              rel="noopener noreferrer"
-              variant="primary"
-              class="btn-block mx-1 my-2"
-              data-dd-action-name="view on grants.gov"
-            >
-              <b-icon icon="box-arrow-up-right" aria-hidden="true" class="mr-2" />
-              Apply on Grants.gov
-            </b-button>
-            <b-button
-              target="_blank"
-              rel="noopener noreferrer"
-              variant="outline-primary"
-              class="col mx-1"
-              @click="printPage"
-            >
-              <b-icon icon="printer-fill" aria-hidden="true" class="mr-2" />
-              Print
-            </b-button>
-            <b-button
-              target="_blank"
-              rel="noopener noreferrer"
-              variant="outline-primary"
-              class="col mx-1"
-              @click="copyUrl"
-            >
-              <b-icon icon="files" aria-hidden="true" class="mr-2" />
-              Copy Link
-            </b-button>
-          </b-row>
-          <br />
-          <b-row class="mt-4">
-            <h4>Assign Grant</h4>
-          </b-row>
-          <b-row>
-            <b-col>
-              <v-select
-                v-model="selectedAgencies"
-                :options="agencies"
-                :multiple="true"
-                label="name" track-by="id"
-                :placeholder="`Choose ${newTerminologyEnabled ? 'team': 'agency'}`"
-                data-dd-action-name="select team for grant assignment"
-              />
-            </b-col>
-            <b-col>
-              <b-button variant="primary" @click="assignAgenciesToGrant" data-dd-action-name="assign team">
-                Submit
+      <b-container fluid v-if="selectedGrant && !loading" class="mt-5">
+        <b-row>
+          <!-- Left page column: title, table data, and grant description -->
+          <b-col>
+            <h2 class="mb-5">{{ selectedGrant.title }}</h2>
+            <b-table
+              class="grant-details-table mb-5"
+              :items="tableData"
+              :fields="[
+                {key: 'name', class: 'color-gray grants-details-table-fit-content'},
+                {key: 'value', class: 'font-weight-bold'},
+              ]"
+              thead-class="d-none"
+              borderless
+              hover
+            ></b-table>
+            <h3 class="mb-3">Description</h3>
+            <!-- TODO: spike on removing v-html usage https://github.com/usdigitalresponse/usdr-gost/issues/2572 -->
+            <div style="white-space: pre-line" v-html="selectedGrant.description"></div>
+          </b-col>
+
+          <!-- Right page column: apply, assign, and status actions -->
+          <b-col class="grants-details-sidebar">
+            <b-row>
+              <b-button
+                :href="`https://www.grants.gov/search-results-detail/${selectedGrant.grant_id}`"
+                target="_blank"
+                rel="noopener noreferrer"
+                variant="primary"
+                class="btn-block mx-1 my-2"
+                data-dd-action-name="view on grants.gov"
+              >
+                <b-icon icon="box-arrow-up-right" aria-hidden="true" class="mr-2" />
+                Apply on Grants.gov
               </b-button>
-            </b-col>
-          </b-row>
-          <b-row>
-            <div v-for="agency in assignedAgencies" :key="agency">
-              <p>
-                <span>{{ agency.name }}</span>
-                <button
-                  type="button"
-                  class="btn btn-close"
-                  @click="unassignAgenciesToGrant(agency)"
-                  data-dd-action-name="remove team assignment"
-                >
-                  <b-icon icon="x" aria-hidden="true" />
-                </button>
-              </p>
-            </div>
-          </b-row>
-          <b-row>
-            <h4>{{newTerminologyEnabled ? 'Team': 'Agency'}} Status</h4>
-          </b-row>
-          <b-row>
-            <b-col>
-              <b-form-select v-model="selectedInterestedCode" data-dd-action-name="select team status">
-                <b-form-select-option :value="null">Choose Status</b-form-select-option>
-                <b-form-select-option-group label="Interested">
-                  <b-form-select-option v-for="code in interestedCodes.interested" :key="code.id" :value="code.id">
-                    {{ code.name }}
-                  </b-form-select-option>
-                </b-form-select-option-group>
-                <b-form-select-option-group label="Applied">
-                  <b-form-select-option v-for="code in interestedCodes.result" :key="code.id" :value="code.id">
-                    {{ code.name }}
-                  </b-form-select-option>
-                </b-form-select-option-group>
-                <b-form-select-option-group label="Not Applying">
-                  <b-form-select-option v-for="code in interestedCodes.rejections" :key="code.id" :value="code.id">
-                    {{ code.name }}
-                  </b-form-select-option>
-                </b-form-select-option-group>
-              </b-form-select>
-            </b-col>
-            <b-col>
-              <b-button variant="primary" @click="markGrantAsInterested" data-dd-action-name="submit team status">Submit</b-button>
-            </b-col>
-          </b-row>
-          <b-row>
-            <div v-for="agency in selectedGrant.interested_agencies" :key="agency">
-              <p v-if="(String(agency.agency_id) === selectedAgencyId) || isAbleToUnmark(agency.agency_id)">
-                <span class="data-label">{{ agency.user_name }}</span>
-                <span> updated </span>
-                <span class="data-label">{{ agency.agency_name }}</span>
-                <span> team status to </span>
-                <span class="data-label">{{ agency.interested_code_name }}</span>
-                <button type="button" class="btn btn-close" @click="unmarkGrantAsInterested(agency)" data-dd-action-name="remove team status">
-                  <b-icon icon="x" aria-hidden="true" />
-                </button>
-              </p>
-            </div>
-          </b-row>
-        </b-col>
-      </div>
+              <b-button
+                target="_blank"
+                rel="noopener noreferrer"
+                variant="outline-primary"
+                class="col mx-1"
+                @click="printPage"
+              >
+                <b-icon icon="printer-fill" aria-hidden="true" class="mr-2" />
+                Print
+              </b-button>
+              <b-button
+                target="_blank"
+                rel="noopener noreferrer"
+                variant="outline-primary"
+                class="col mx-1"
+                @click="copyUrl"
+              >
+                <b-icon icon="files" aria-hidden="true" class="mr-2" />
+                Copy Link
+              </b-button>
+            </b-row>
+            <br />
+            <b-row class="mt-4">
+              <h4>Assign Grant</h4>
+            </b-row>
+            <b-row>
+              <b-col>
+                <v-select
+                  v-model="selectedAgencies"
+                  :options="agencies"
+                  :multiple="true"
+                  label="name" track-by="id"
+                  :placeholder="`Choose ${newTerminologyEnabled ? 'team': 'agency'}`"
+                  data-dd-action-name="select team for grant assignment"
+                />
+              </b-col>
+              <b-col>
+                <b-button variant="primary" @click="assignAgenciesToGrant" data-dd-action-name="assign team">
+                  Submit
+                </b-button>
+              </b-col>
+            </b-row>
+            <b-row>
+              <div v-for="agency in assignedAgencies" :key="agency.id">
+                <p>
+                  <span>{{ agency.name }}</span>
+                  <button
+                    type="button"
+                    class="btn btn-close"
+                    @click="unassignAgenciesToGrant(agency)"
+                    data-dd-action-name="remove team assignment"
+                  >
+                    <b-icon icon="x" aria-hidden="true" />
+                  </button>
+                </p>
+              </div>
+            </b-row>
+            <b-row>
+              <h4>{{newTerminologyEnabled ? 'Team': 'Agency'}} Status</h4>
+            </b-row>
+            <b-row>
+              <b-col>
+                <b-form-select v-model="selectedInterestedCode" data-dd-action-name="select team status">
+                  <b-form-select-option :value="null">Choose Status</b-form-select-option>
+                  <b-form-select-option-group label="Interested">
+                    <b-form-select-option v-for="code in interestedCodes.interested" :key="code.id" :value="code.id">
+                      {{ code.name }}
+                    </b-form-select-option>
+                  </b-form-select-option-group>
+                  <b-form-select-option-group label="Applied">
+                    <b-form-select-option v-for="code in interestedCodes.result" :key="code.id" :value="code.id">
+                      {{ code.name }}
+                    </b-form-select-option>
+                  </b-form-select-option-group>
+                  <b-form-select-option-group label="Not Applying">
+                    <b-form-select-option v-for="code in interestedCodes.rejections" :key="code.id" :value="code.id">
+                      {{ code.name }}
+                    </b-form-select-option>
+                  </b-form-select-option-group>
+                </b-form-select>
+              </b-col>
+              <b-col>
+                <b-button variant="primary" @click="markGrantAsInterested" data-dd-action-name="submit team status">Submit</b-button>
+              </b-col>
+            </b-row>
+            <b-row>
+              <div v-for="agency in selectedGrant.interested_agencies" :key="agency.id">
+                <p v-if="(String(agency.agency_id) === selectedAgencyId) || isAbleToUnmark(agency.agency_id)">
+                  <span class="data-label">{{ agency.user_name }}</span>
+                  <span> updated </span>
+                  <span class="data-label">{{ agency.agency_name }}</span>
+                  <span> team status to </span>
+                  <span class="data-label">{{ agency.interested_code_name }}</span>
+                  <button type="button" class="btn btn-close" @click="unmarkGrantAsInterested(agency)" data-dd-action-name="remove team status">
+                    <b-icon icon="x" aria-hidden="true" />
+                  </button>
+                </p>
+              </div>
+            </b-row>
+          </b-col>
+        </b-row>
+      </b-container>
     </div>
   </section>
 </template>
@@ -376,7 +380,12 @@ export default {
 </script>
 
 <style lang="css">
+.grants-details-sidebar {
+  flex-basis: 500px;
+  flex-grow: 0;
+}
 .grant-details-table tr:nth-of-type(odd) {
+  /* Design color differs from default bootstrap, so making our own striped background here */
   background-color: #F9F9F9;
 }
 .grants-details-table-fit-content {

--- a/packages/client/src/views/GrantDetails.vue
+++ b/packages/client/src/views/GrantDetails.vue
@@ -65,12 +65,13 @@
                 </b-button>
               </div>
             </div>
-            <b-row class="mt-4">
-              <h4>Assign Grant</h4>
-            </b-row>
-            <b-row>
-              <b-col>
+
+            <!-- Assign grant section -->
+            <div class="mb-5">
+              <h4 class="mb-3">Assign Grant</h4>
+              <div class="d-flex">
                 <v-select
+                  class="flex-grow-1 mr-3"
                   v-model="selectedAgencies"
                   :options="agencies"
                   :multiple="true"
@@ -78,28 +79,23 @@
                   :placeholder="`Choose ${newTerminologyEnabled ? 'team': 'agency'}`"
                   data-dd-action-name="select team for grant assignment"
                 />
-              </b-col>
-              <b-col>
                 <b-button variant="primary" @click="assignAgenciesToGrant" data-dd-action-name="assign team">
                   Submit
                 </b-button>
-              </b-col>
-            </b-row>
-            <b-row>
-              <div v-for="agency in assignedAgencies" :key="agency.id">
-                <p>
-                  <span>{{ agency.name }}</span>
-                  <button
-                    type="button"
-                    class="btn btn-close"
-                    @click="unassignAgenciesToGrant(agency)"
-                    data-dd-action-name="remove team assignment"
-                  >
-                    <b-icon icon="x" aria-hidden="true" />
-                  </button>
-                </p>
               </div>
-            </b-row>
+              <div v-for="agency in assignedAgencies" :key="agency.id" class="d-flex justify-content-between align-items-start my-3">
+                <div class="mr-3">
+                  <p class="m-0">{{ agency.name }}</p>
+                  <p class="m-0 text-muted"><small>{{ agency.created_at }}</small></p>
+                </div>
+                <b-button-close
+                  @click="unassignAgenciesToGrant(agency)"
+                  data-dd-action-name="remove team assignment"
+                />
+              </div>
+            </div>
+
+            <!-- Team status section -->
             <b-row>
               <h4>{{newTerminologyEnabled ? 'Team': 'Agency'}} Status</h4>
             </b-row>

--- a/packages/client/src/views/GrantDetails.vue
+++ b/packages/client/src/views/GrantDetails.vue
@@ -1,4 +1,3 @@
-<!-- eslint-disable max-len -->
 <template>
   <section class="container-fluid grants-details-container">
   <div>
@@ -10,55 +9,18 @@
     </div>
     <div v-if="selectedGrant && !loading" class="mb-3 d-flex align-items-start">
       <b-col class="mx-4">
-          <h1 class="mb-0 h2">{{ selectedGrant.title }}</h1>
-          <table class="table table-striped table-responsive-md mr-5 mt-5">
-          <tbody>
-            <tr>
-                  <th>Opportunity Number</th>
-                  <td>{{ selectedGrant.grant_number }}</td>
-            </tr>
-            <tr>
-                  <th>Open Date</th>
-                  <td>{{ formatDate(selectedGrant.open_date) }}</td>
-            </tr>
-            <tr>
-                  <th>Close Date</th>
-                  <td>{{ formatDate(selectedGrant.close_date) }}</td>
-            </tr>
-             <tr>
-                  <th>Grant ID</th>
-                  <td>{{ selectedGrant.grant_id }}</td>
-            </tr>
-            <tr>
-                  <th>Federal Awarding Agency Code</th>
-                  <td>{{ selectedGrant.agency_code }}</td>
-            </tr>
-            <tr>
-                  <th>Award Ceiling</th>
-                  <td>{{ selectedGrant.award_ceiling }}</td>
-            </tr>
-            <tr>
-                  <th>Category of Funding Activity</th>
-                  <td>{{ selectedGrant['funding_activity_categories']?.join(', ') }}</td>
-            </tr>
-            <tr>
-                  <th>Opportunity Category</th>
-                  <td>{{ selectedGrant.opportunity_category }}</td>
-            </tr>
-            <tr>
-                  <th>Opportunity Status</th>
-                  <td>{{ selectedGrant.opportunity_status }}</td>
-            </tr>
-            <tr>
-                  <th>Appropriation Bill</th>
-                  <td>{{ selectedGrant.bill }}</td>
-            </tr>
-            <tr>
-                  <th>Cost Sharing</th>
-                  <td>{{ selectedGrant.cost_sharing }}</td>
-            </tr>
-           </tbody>
-        </table>
+      <h2>{{ selectedGrant.title }}</h2>
+      <b-table
+        class="grant-details-table"
+        :items="tableData"
+        :fields="[
+          {key: 'name', class: 'color-gray grants-details-table-fit-content'},
+          {key: 'value', class: 'font-weight-bold'},
+        ]"
+        thead-class="d-none"
+        borderless
+        hover
+      ></b-table>
       <p class="data-label">Description:</p>
         <div style="white-space: pre-line" v-html="selectedGrant.description"></div>
       <br />
@@ -215,6 +177,43 @@ export default {
       selectedAgency: 'users/selectedAgency',
       currentGrant: 'grants/currentGrant',
     }),
+    tableData() {
+      return [{
+        name: 'Opportunity Number',
+        value: this.selectedGrant.grant_number,
+      }, {
+        name: 'Open Date',
+        value: this.formatDate(this.selectedGrant.open_date),
+      }, {
+        name: 'Close Date',
+        value: this.formatDate(this.selectedGrant.close_date),
+      }, {
+        name: 'Grant ID',
+        value: this.selectedGrant.grant_id,
+      }, {
+        name: 'Federal Awarding',
+        value: this.selectedGrant.agency_code,
+      }, {
+        name: 'Award Ceiling',
+        value: this.selectedGrant.award_ceiling,
+      }, {
+        name: 'Category of',
+        value: this.selectedGrant.funding_activity_categories?.join(', '),
+      }, {
+        name: 'Opportunity Category',
+        value: this.selectedGrant.opportunity_category,
+      }, {
+        name: 'Opportunity Status',
+        value: this.selectedGrant.opportunity_status,
+      }, {
+        name: 'Appropriation Bill',
+        value: this.selectedGrant.bill,
+      }, {
+        name: 'Cost Sharing',
+        value: this.selectedGrant.cost_sharing,
+      },
+      ];
+    },
     alreadyViewed() {
       if (!this.selectedGrant) {
         return false;
@@ -342,16 +341,14 @@ export default {
   },
 };
 </script>
-<style>
-  .grants-details-container {
-    padding: 80px;
-  }
 
-  .grants-details-container th {
-    font-weight: normal;
-  }
-
-  .grants-details-container td {
-    font-weight: bold;
-  }
+<style lang="css">
+.grant-details-table tr:nth-of-type(odd) {
+  background-color: #F9F9F9;
+}
+.grants-details-table-fit-content {
+  /* Make a table column that's the width of its content */
+  white-space: nowrap;
+  width: 1%;
+}
 </style>

--- a/packages/client/src/views/GrantDetails.vue
+++ b/packages/client/src/views/GrantDetails.vue
@@ -9,9 +9,9 @@
     </div>
     <div v-if="selectedGrant && !loading" class="mb-3 d-flex align-items-start">
       <b-col class="mx-4">
-      <h2>{{ selectedGrant.title }}</h2>
+      <h2 class="mb-5">{{ selectedGrant.title }}</h2>
       <b-table
-        class="grant-details-table"
+        class="grant-details-table mb-5"
         :items="tableData"
         :fields="[
           {key: 'name', class: 'color-gray grants-details-table-fit-content'},
@@ -21,8 +21,8 @@
         borderless
         hover
       ></b-table>
-      <p class="data-label">Description:</p>
-        <div style="white-space: pre-line" v-html="selectedGrant.description"></div>
+      <h3 class="mb-3">Description</h3>
+      <div style="white-space: pre-line" v-html="selectedGrant.description"></div>
       <br />
 
       </b-col>

--- a/packages/client/src/views/GrantDetails.vue
+++ b/packages/client/src/views/GrantDetails.vue
@@ -9,6 +9,7 @@
       </div>
       <b-container fluid v-if="selectedGrant && !loading" class="mt-5">
         <b-row>
+
           <!-- Left page column: title, table data, and grant description -->
           <b-col>
             <h2 class="mb-5">{{ selectedGrant.title }}</h2>
@@ -68,7 +69,7 @@
 
             <!-- Assign grant section -->
             <div class="mb-5">
-              <h4 class="mb-3">Assign Grant</h4>
+              <h3 class="mb-3">Assign Grant</h3>
               <div class="d-flex">
                 <v-select
                   class="flex-grow-1 mr-3"
@@ -97,7 +98,7 @@
 
             <!-- Team status section -->
             <div class="mb-5">
-              <h4 class="mb-3">{{newTerminologyEnabled ? 'Team': 'Agency'}} Status</h4>
+              <h3 class="mb-3">{{newTerminologyEnabled ? 'Team': 'Agency'}} Status</h3>
               <div class="d-flex">
                 <b-form-select
                   class="flex-grow-1 mr-3"
@@ -142,6 +143,7 @@
             </div>
 
           </b-col>
+
         </b-row>
       </b-container>
     </div>

--- a/packages/client/src/views/GrantDetails.vue
+++ b/packages/client/src/views/GrantDetails.vue
@@ -96,12 +96,14 @@
             </div>
 
             <!-- Team status section -->
-            <b-row>
-              <h4>{{newTerminologyEnabled ? 'Team': 'Agency'}} Status</h4>
-            </b-row>
-            <b-row>
-              <b-col>
-                <b-form-select v-model="selectedInterestedCode" data-dd-action-name="select team status">
+            <div class="mb-5">
+              <h4 class="mb-3">{{newTerminologyEnabled ? 'Team': 'Agency'}} Status</h4>
+              <div class="d-flex">
+                <b-form-select
+                  class="flex-grow-1 mr-3"
+                  v-model="selectedInterestedCode"
+                  data-dd-action-name="select team status"
+                >
                   <b-form-select-option :value="null">Choose Status</b-form-select-option>
                   <b-form-select-option-group label="Interested">
                     <b-form-select-option v-for="code in interestedCodes.interested" :key="code.id" :value="code.id">
@@ -119,25 +121,26 @@
                     </b-form-select-option>
                   </b-form-select-option-group>
                 </b-form-select>
-              </b-col>
-              <b-col>
-                <b-button variant="primary" @click="markGrantAsInterested" data-dd-action-name="submit team status">Submit</b-button>
-              </b-col>
-            </b-row>
-            <b-row>
-              <div v-for="agency in selectedGrant.interested_agencies" :key="agency.id">
-                <p v-if="(String(agency.agency_id) === selectedAgencyId) || isAbleToUnmark(agency.agency_id)">
-                  <span class="data-label">{{ agency.user_name }}</span>
-                  <span> updated </span>
-                  <span class="data-label">{{ agency.agency_name }}</span>
-                  <span> team status to </span>
-                  <span class="data-label">{{ agency.interested_code_name }}</span>
-                  <button type="button" class="btn btn-close" @click="unmarkGrantAsInterested(agency)" data-dd-action-name="remove team status">
-                    <b-icon icon="x" aria-hidden="true" />
-                  </button>
-                </p>
+                <b-button variant="primary" @click="markGrantAsInterested" data-dd-action-name="submit team status">
+                  Submit
+                </b-button>
               </div>
-            </b-row>
+              <div v-for="agency in visibleInterestedAgencies" :key="agency.id" class="d-flex justify-content-between align-items-start my-3">
+                <!-- TODO: adopt updated design for what to show on each line item here -->
+                <div>
+                  <p class="m-0">
+                    <strong>{{ agency.user_name }}</strong> updated
+                    <strong>{{ agency.agency_name }}</strong> team status to
+                    <strong>{{ agency.interested_code_name }}</strong>
+                  </p>
+                </div>
+                <b-button-close
+                  @click="unmarkGrantAsInterested(agency)"
+                  data-dd-action-name="remove team status"
+                />
+              </div>
+            </div>
+
           </b-col>
         </b-row>
       </b-container>
@@ -247,6 +250,10 @@ export default {
         value: this.selectedGrant.cost_sharing,
       },
       ];
+    },
+    visibleInterestedAgencies() {
+      return this.selectedGrant.interested_agencies
+        .filter((agency) => String(agency.agency_id) === this.selectedAgencyId || this.isAbleToUnmark(agency.agency_id));
     },
     alreadyViewed() {
       if (!this.selectedGrant) {

--- a/packages/client/src/views/GrantDetails.vue
+++ b/packages/client/src/views/GrantDetails.vue
@@ -30,40 +30,41 @@
 
           <!-- Right page column: apply, assign, and status actions -->
           <b-col class="grants-details-sidebar">
-            <b-row>
+
+            <!-- Main action buttons section -->
+            <div class="mb-5">
               <b-button
+                size="lg"
+                variant="primary"
+                block
+                class="mb-3"
                 :href="`https://www.grants.gov/search-results-detail/${selectedGrant.grant_id}`"
                 target="_blank"
                 rel="noopener noreferrer"
-                variant="primary"
-                class="btn-block mx-1 my-2"
                 data-dd-action-name="view on grants.gov"
               >
                 <b-icon icon="box-arrow-up-right" aria-hidden="true" class="mr-2" />
                 Apply on Grants.gov
               </b-button>
-              <b-button
-                target="_blank"
-                rel="noopener noreferrer"
-                variant="outline-primary"
-                class="col mx-1"
-                @click="printPage"
-              >
-                <b-icon icon="printer-fill" aria-hidden="true" class="mr-2" />
-                Print
-              </b-button>
-              <b-button
-                target="_blank"
-                rel="noopener noreferrer"
-                variant="outline-primary"
-                class="col mx-1"
-                @click="copyUrl"
-              >
-                <b-icon icon="files" aria-hidden="true" class="mr-2" />
-                Copy Link
-              </b-button>
-            </b-row>
-            <br />
+              <div class="d-flex">
+                <b-button
+                  class="w-50 flex-shrink-1 mr-3"
+                  variant="outline-primary"
+                  @click="printPage"
+                >
+                  <b-icon icon="printer-fill" aria-hidden="true" class="mr-2" />
+                  Print
+                </b-button>
+                <b-button
+                  class="w-50 flex-shrink-1"
+                  variant="outline-primary"
+                  @click="copyUrl"
+                >
+                  <b-icon icon="files" aria-hidden="true" class="mr-2" />
+                  Copy Link
+                </b-button>
+              </div>
+            </div>
             <b-row class="mt-4">
               <h4>Assign Grant</h4>
             </b-row>

--- a/packages/client/src/views/GrantDetails.vue
+++ b/packages/client/src/views/GrantDetails.vue
@@ -1,115 +1,147 @@
 <template>
   <section class="container-fluid grants-details-container">
-  <div>
-    <div v-if="loading">
-      Loading...
-    </div>
-    <div v-if="!selectedGrant && !loading">
-      No grant found
-    </div>
-    <div v-if="selectedGrant && !loading" class="mb-3 d-flex align-items-start">
-      <b-col class="mx-4">
-      <h2 class="mb-5">{{ selectedGrant.title }}</h2>
-      <b-table
-        class="grant-details-table mb-5"
-        :items="tableData"
-        :fields="[
-          {key: 'name', class: 'color-gray grants-details-table-fit-content'},
-          {key: 'value', class: 'font-weight-bold'},
-        ]"
-        thead-class="d-none"
-        borderless
-        hover
-      ></b-table>
-      <h3 class="mb-3">Description</h3>
-      <!-- TODO: spike on removing v-html usage https://github.com/usdigitalresponse/usdr-gost/issues/2572 -->
-      <div style="white-space: pre-line" v-html="selectedGrant.description"></div>
-      <br />
-
-      </b-col>
-      <b-col class="mx-auto my-5 px-2 col-md-4 col-lg-3">
-        <b-row>
-          <b-button :href="`https://www.grants.gov/search-results-detail/${selectedGrant.grant_id}`"
-            target="_blank" rel="noopener noreferrer" variant="primary" class="btn-block mx-1 my-2" data-dd-action-name="view on grants.gov">
-            <b-icon icon="box-arrow-up-right" aria-hidden="true" class="mr-2"></b-icon>Apply on Grants.gov
-          </b-button>
-          <b-button target="_blank" rel="noopener noreferrer" variant="outline-primary" class="col mx-1" @click="printPage">
-            <b-icon icon="printer-fill" aria-hidden="true" class="mr-2"></b-icon>Print
-          </b-button>
-          <b-button target="_blank" rel="noopener noreferrer" variant="outline-primary" class="col mx-1" @click="copyUrl">
-            <b-icon icon="files" aria-hidden="true" class="mr-2"></b-icon>Copy Link
-          </b-button>
-          </b-row>
-      <br />
-        <b-row class="mt-4">
-        <h4>Assign Grant</h4>
-        </b-row>
-        <b-row>
-          <b-col>
-            <v-select v-model="selectedAgencies" :options="agencies" :multiple="true"
-              label="name" track-by="id"
-              :placeholder="`Choose ${newTerminologyEnabled ? 'team': 'agency'}`"
-              data-dd-action-name="select team for grant assignment"
+    <div>
+      <div v-if="loading">
+        Loading...
+      </div>
+      <div v-if="!selectedGrant && !loading">
+        No grant found
+      </div>
+      <div v-if="selectedGrant && !loading" class="mb-3 d-flex align-items-start">
+        <b-col class="mx-4">
+          <h2 class="mb-5">{{ selectedGrant.title }}</h2>
+          <b-table
+            class="grant-details-table mb-5"
+            :items="tableData"
+            :fields="[
+              {key: 'name', class: 'color-gray grants-details-table-fit-content'},
+              {key: 'value', class: 'font-weight-bold'},
+            ]"
+            thead-class="d-none"
+            borderless
+            hover
+          ></b-table>
+          <h3 class="mb-3">Description</h3>
+          <!-- TODO: spike on removing v-html usage https://github.com/usdigitalresponse/usdr-gost/issues/2572 -->
+          <div style="white-space: pre-line" v-html="selectedGrant.description"></div>
+          <br />
+        </b-col>
+        <b-col class="mx-auto my-5 px-2 col-md-4 col-lg-3">
+          <b-row>
+            <b-button
+              :href="`https://www.grants.gov/search-results-detail/${selectedGrant.grant_id}`"
+              target="_blank"
+              rel="noopener noreferrer"
+              variant="primary"
+              class="btn-block mx-1 my-2"
+              data-dd-action-name="view on grants.gov"
             >
-            </v-select>
-          </b-col>
-          <b-col>
-          <b-button variant="primary" @click="assignAgenciesToGrant" data-dd-action-name="assign team">Submit</b-button>
-          </b-col>
-        </b-row>
-        <b-row>
-            <div v-for="agency in assignedAgencies" :key="agency">
-            <p>
-              <span>{{ agency.name }} </span>
-              <button type="button" class="btn btn-close" @click="unassignAgenciesToGrant(agency)"
-                data-dd-action-name="remove team assignment"><b-icon icon="x" aria-hidden="true"></b-icon></button>
-            </p>
-            </div>
-        </b-row>
-        <b-row>
-        <h4>{{newTerminologyEnabled ? 'Team': 'Agency'}} Status</h4>
-        </b-row>
-        <b-row>
+              <b-icon icon="box-arrow-up-right" aria-hidden="true" class="mr-2" />
+              Apply on Grants.gov
+            </b-button>
+            <b-button
+              target="_blank"
+              rel="noopener noreferrer"
+              variant="outline-primary"
+              class="col mx-1"
+              @click="printPage"
+            >
+              <b-icon icon="printer-fill" aria-hidden="true" class="mr-2" />
+              Print
+            </b-button>
+            <b-button
+              target="_blank"
+              rel="noopener noreferrer"
+              variant="outline-primary"
+              class="col mx-1"
+              @click="copyUrl"
+            >
+              <b-icon icon="files" aria-hidden="true" class="mr-2" />
+              Copy Link
+            </b-button>
+          </b-row>
+          <br />
+          <b-row class="mt-4">
+            <h4>Assign Grant</h4>
+          </b-row>
+          <b-row>
             <b-col>
-             <b-form-select v-model="selectedInterestedCode" data-dd-action-name="select team status">
+              <v-select
+                v-model="selectedAgencies"
+                :options="agencies"
+                :multiple="true"
+                label="name" track-by="id"
+                :placeholder="`Choose ${newTerminologyEnabled ? 'team': 'agency'}`"
+                data-dd-action-name="select team for grant assignment"
+              />
+            </b-col>
+            <b-col>
+              <b-button variant="primary" @click="assignAgenciesToGrant" data-dd-action-name="assign team">
+                Submit
+              </b-button>
+            </b-col>
+          </b-row>
+          <b-row>
+            <div v-for="agency in assignedAgencies" :key="agency">
+              <p>
+                <span>{{ agency.name }}</span>
+                <button
+                  type="button"
+                  class="btn btn-close"
+                  @click="unassignAgenciesToGrant(agency)"
+                  data-dd-action-name="remove team assignment"
+                >
+                  <b-icon icon="x" aria-hidden="true" />
+                </button>
+              </p>
+            </div>
+          </b-row>
+          <b-row>
+            <h4>{{newTerminologyEnabled ? 'Team': 'Agency'}} Status</h4>
+          </b-row>
+          <b-row>
+            <b-col>
+              <b-form-select v-model="selectedInterestedCode" data-dd-action-name="select team status">
                 <b-form-select-option :value="null">Choose Status</b-form-select-option>
                 <b-form-select-option-group label="Interested">
                   <b-form-select-option v-for="code in interestedCodes.interested" :key="code.id" :value="code.id">
-                    {{ code.name }}</b-form-select-option>
+                    {{ code.name }}
+                  </b-form-select-option>
                 </b-form-select-option-group>
                 <b-form-select-option-group label="Applied">
                   <b-form-select-option v-for="code in interestedCodes.result" :key="code.id" :value="code.id">
-                    {{ code.name }}</b-form-select-option>
+                    {{ code.name }}
+                  </b-form-select-option>
                 </b-form-select-option-group>
                 <b-form-select-option-group label="Not Applying">
                   <b-form-select-option v-for="code in interestedCodes.rejections" :key="code.id" :value="code.id">
-                    {{ code.name }}</b-form-select-option>
+                    {{ code.name }}
+                  </b-form-select-option>
                 </b-form-select-option-group>
               </b-form-select>
-</b-col>
-<b-col>
-          <b-button variant="primary" @click="markGrantAsInterested" data-dd-action-name="submit team status">Submit</b-button>
-          </b-col>
+            </b-col>
+            <b-col>
+              <b-button variant="primary" @click="markGrantAsInterested" data-dd-action-name="submit team status">Submit</b-button>
+            </b-col>
           </b-row>
           <b-row>
             <div v-for="agency in selectedGrant.interested_agencies" :key="agency">
-                <p v-if="(String(agency.agency_id) === selectedAgencyId) || isAbleToUnmark(agency.agency_id)">
-                    <span class="data-label">{{ agency.user_name }}</span>
-                    <span> updated </span>
-                    <span class="data-label">{{ agency.agency_name }}</span>
-                    <span> team status to </span>
-                    <span class="data-label">{{ agency.interested_code_name }}</span>
-                    <button type="button" class="btn btn-close"
-                       @click="unmarkGrantAsInterested(agency)" data-dd-action-name="remove team status">
-                       <b-icon icon="x" aria-hidden="true"></b-icon>
-                    </button>
-                </p>
-              </div>
+              <p v-if="(String(agency.agency_id) === selectedAgencyId) || isAbleToUnmark(agency.agency_id)">
+                <span class="data-label">{{ agency.user_name }}</span>
+                <span> updated </span>
+                <span class="data-label">{{ agency.agency_name }}</span>
+                <span> team status to </span>
+                <span class="data-label">{{ agency.interested_code_name }}</span>
+                <button type="button" class="btn btn-close" @click="unmarkGrantAsInterested(agency)" data-dd-action-name="remove team status">
+                  <b-icon icon="x" aria-hidden="true" />
+                </button>
+              </p>
+            </div>
           </b-row>
-      </b-col>
+        </b-col>
+      </div>
     </div>
-</div>
-</section>
+  </section>
 </template>
 
 <script>

--- a/packages/client/src/views/GrantDetails.vue
+++ b/packages/client/src/views/GrantDetails.vue
@@ -22,6 +22,7 @@
         hover
       ></b-table>
       <h3 class="mb-3">Description</h3>
+      <!-- TODO: spike on removing v-html usage https://github.com/usdigitalresponse/usdr-gost/issues/2572 -->
       <div style="white-space: pre-line" v-html="selectedGrant.description"></div>
       <br />
 

--- a/packages/client/src/views/GrantDetails.vue
+++ b/packages/client/src/views/GrantDetails.vue
@@ -87,7 +87,7 @@
               <div v-for="agency in assignedAgencies" :key="agency.id" class="d-flex justify-content-between align-items-start my-3">
                 <div class="mr-3">
                   <p class="m-0">{{ agency.name }}</p>
-                  <p class="m-0 text-muted"><small>{{ agency.created_at }}</small></p>
+                  <p class="m-0 text-muted"><small>{{ formatDateTime(agency.created_at) }}</small></p>
                 </div>
                 <b-button-close
                   @click="unassignAgenciesToGrant(agency)"
@@ -380,6 +380,9 @@ export default {
     },
     formatDate(dateString) {
       return DateTime.fromISO(dateString).toLocaleString(DateTime.DATE_MED);
+    },
+    formatDateTime(dateString) {
+      return DateTime.fromISO(dateString).toLocaleString(DateTime.DATETIME_MED);
     },
   },
 };


### PR DESCRIPTION
### Ticket #2558 
## Description
Updates the new grant details page design, spacing, etc. to more closely match the [figma design spec](https://www.figma.com/file/yQx55VTr5awPYClHIJCz8y/Grant-Details?type=design&node-id=1284-2779&mode=design&t=8cjFJ4wLmfpZBgQL-0). Specifically: 

- Two-column layout with right column fixed width
- Headline size and spacing
- Table data sizing and colors
- Update button design/spacing in right column
- Update agency status and assign grants section spacing and sizing

Note for reviewer: I had to re-indent and re-organize a lot of code in this PR, so the overall diff might be tough to read. I recommend reviewing commit by commit, which I've tried to keep pretty atomic and readable. 

Note that I tried to find the best compromise between the core components/tools bootstrap gives us vs the exact design files. (For example, we'd be fighting our bootstrap design system to achieve exact margins in all cases or the exact same close `x` icon. In cases where the design felt like it worked with core bootstrap components, I used those instead of introducing lots of new code to fight against it. That said, we should get a final pass from the designer once this is ready to confirm.) 

## Screenshots / Demo Video
<img width="2007" alt="image" src="https://github.com/usdigitalresponse/usdr-gost/assets/126250/ba03eed5-96fe-4532-a1a5-867cac18f097">

## Testing
Visual comparison to figma designs

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [ ] Provided ticket and description
- [ ] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers