### PR TITLE
Clicking top level nav bar items from grant details page doesn't work

### DIFF
--- a/packages/client/src/components/Layout.vue
+++ b/packages/client/src/components/Layout.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <b-navbar :type="navBarType" :variant="navBarVariant" class="header-dropshadow py-1">
-      <b-navbar-brand to="grants" class="d-flex align-items-center">
+      <b-navbar-brand :to="{ name: 'grants' }" class="d-flex align-items-center">
       <b-img v-if="myProfileEnabled" :src="require('../assets/usdr_logo_standard_wide.svg')" style="height: 2.5rem;" class="" alt="United States Digital Response - Home" />
       <b-img v-else :src="require('../assets/usdr_logo_white_wide.svg')" style="height: 2.5rem;" class="" alt="United States Digital Response - Home" />
       <h1 class="ml-3 mb-0 h4">Federal Grant Finder</h1>
@@ -25,7 +25,7 @@
             <template v-else #button-content>
               <em>{{loggedInUser.email}}</em>
             </template>
-            <b-dropdown-item to="my-profile">
+            <b-dropdown-item :to="{ name: 'myProfile' }">
               <b-icon icon="person-circle" scale="1" class="dropdown-icon"></b-icon>
               <p class="dropdown-item-text">My profile</p>
             </b-dropdown-item>


### PR DESCRIPTION
Clicking top level nav bar items from grant details page doesn't work

### Ticket #2570
## Description
Use named routes for the top level nav bar items

## Screenshots / Demo Video
https://github.com/usdigitalresponse/usdr-gost/assets/146878468/34b2ed41-5cd4-4bf1-b757-7db026f0478b


## Testing
Enable grant details page feature flag. Click on a grant. Click on the Federal Grant Finder text at the top, verify you get to Browse Grants. Click back. Click on the My Profile link, verify you get to the My Profile page.

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [x ] Added steps to test feature/functionality manually

## Checklist
- [x] Provided ticket and description
- [x ] Provided screenshots/demo
- [x] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [x] Added PR reviewers