### PR TITLE
fix: update postgres in dev environment to version with arm64 build

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,8 +65,7 @@ services:
   postgres:
     container_name: gost-postgres
     hostname: postgres
-    image: 'bitnami/postgresql:14.4.0'
-    platform: linux/amd64
+    image: 'bitnami/postgresql:14.11.0'
     networks:
       - postgres
     environment:


### PR DESCRIPTION
## Description
I'm running Docker Desktop on an M1 Mac. I recently updated Docker Desktop to v4.27.x and, immediately afterwards, the Postgres container stopped starting up. I didn't spend much time debugging why - my theory is that the new Docker Desktop has some Rosetta-related bug. Even if my theory is wrong, it can't hurt to have an arm64 build for developers with Macs. `bitnami/postgresql:14.4.0` has no arm64 build - the earliest version that does is 14.7.0, but I figured using the latest minor version (14.11.0) wouldn't hurt.

In any case, updating to 14.11.0 fixed my problem. Incidentally, updating to 14.11.0 but keeping `platform: linux/amd64` did not fix my problem.


## Testing

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [ ] Provided ticket and description
- [ ] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers