### PR TITLE
feat: Add github-actions ecosystem to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,14 @@ updates:
       interval: "daily"
       time: "03:00"
       timezone: "America/New_York"
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+      time: "03:00"
+      timezone: "America/New_York"
+    commit-message:
+      prefix: 'Chore [deps:github-actions]'
   - package-ecosystem: "terraform"
     directory: "/terraform"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,8 @@ updates:
       interval: "daily"
       time: "03:00"
       timezone: "America/New_York"
+    commit-message:
+      prefix: 'Chore [deps:npm]'
   - package-ecosystem: github-actions
     directory: /
     schedule:
@@ -26,6 +28,8 @@ updates:
       interval: "daily"
       time: "03:00"
       timezone: "America/New_York"
+    commit-message:
+      prefix: 'Chore [deps:terraform]'
   # Dependabot can't inspect nested directories so we need to list all local modules individually.
   # TODO: Consider switching to Rennovate.
   - package-ecosystem: "terraform"
@@ -34,27 +38,37 @@ updates:
       interval: "daily"
       time: "03:00"
       timezone: "America/New_York"
+    commit-message:
+      prefix: 'Chore [deps:terraform]'
   - package-ecosystem: "terraform"
     directory: "/terraform/modules/gost_consume_grants"
     schedule:
       interval: "daily"
       time: "03:00"
       timezone: "America/New_York"
+    commit-message:
+      prefix: 'Chore [deps:terraform]'
   - package-ecosystem: "terraform"
     directory: "/terraform/modules/gost_website"
     schedule:
       interval: "daily"
       time: "03:00"
       timezone: "America/New_York"
+    commit-message:
+      prefix: 'Chore [deps:terraform]'
   - package-ecosystem: "terraform"
     directory: "/terraform/modules/gost_postgres"
     schedule:
       interval: "daily"
       time: "03:00"
       timezone: "America/New_York"
+    commit-message:
+      prefix: 'Chore [deps:terraform]'
   - package-ecosystem: "terraform"
     directory: "/terraform/modules/scheduled_ecs_task"
     schedule:
       interval: "daily"
       time: "03:00"
       timezone: "America/New_York"
+    commit-message:
+      prefix: 'Chore [deps:terraform]'


### PR DESCRIPTION
## Description

This PR updates the repository's [Dependabot](https://docs.github.com/en/code-security/dependabot) configuration so that GitHub Actions dependencies (i.e. third-party actions) are kept up-to-date. Updates for this new ecosystem occur according the same daily-at-3am (America/New_York timezone) schedule as all other Dependabot runs.

Additionally, this PR includes a tweak to Dependabot behavior for all package ecosystems, which is simply to include the name of the ecosystem as a prefix for Dependabot commit messages. Currently, all Dependabot commits (and their corresponding PR titles) are prefixed with `chore (deps):` or `chore(deps-dev)` (the latter case is for NPM dev dependencies). Updating the prefix to include the ecosystem related to the changes (e.g. `Chore [deps:npm]`, `Chore [deps:github-actions]`, `Chore [deps:terraform]`) helps improve readability and searchability, in particular for PRs.

NB: These configuration changes are similar to [those used in the `usdigitalresponse/grants-ingest` repo](https://github.com/usdigitalresponse/grants-ingest/blob/0434a05b022bc5993fd4c01e93a234aca1bca4c0/.github/dependabot.yml).