### PR TITLE
Add ability to easily create/manage arpa treasury report queue locally

### DIFF
--- a/localstack/entrypoint/init-aws.sh
+++ b/localstack/entrypoint/init-aws.sh
@@ -18,3 +18,5 @@ awslocal s3api create-bucket --bucket arpa-audit-reports --region us-west-2 --cr
 
 awslocal sqs create-queue --queue-name grants-ingest-events
 awslocal sqs create-queue --queue-name arpa-queue
+
+awslocal sqs create-queue --queue-name arpa-treasury-queue --region us-west-2

--- a/packages/server/.env.example
+++ b/packages/server/.env.example
@@ -49,6 +49,7 @@ AUDIT_REPORT_BUCKET=arpa-audit-reports
 # SQS queue for grants-ingest events and arpa events
 GRANTS_INGEST_EVENTS_QUEUE_URL="http://localhost:4566/000000000000/grants-ingest-events"
 ARPA_AUDIT_REPORT_SQS_QUEUE_URL="http://sqs.us-west-2.localhost.localstack.cloud:4566/000000000000/arpa-queue"
+ARPA_TREASURY_REPORT_SQS_QUEUE_URL="http://sqs.us-west-2.localhost.localstack.cloud:4566/000000000000/arpa-treasury-queue"
 
 # for setting up the worker processes to run locally over localstack
 TASK_QUEUE_URL="http://sqs.us-west-2.localhost.localstack.cloud:4566/000000000000/arpa-queue"


### PR DESCRIPTION
### Ticket #Add ability to easily create/manage arpa treasury report queue locally

## Description
The task achieved was to add two env variable in two different files that will make easier to create/manage arpa treasure report queue locally. 

## Screenshots / Demo Video
N/A

## Testing

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [ ] Provided ticket and description
- [ ] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers