### PR TITLE
2569 dropdown display for assign grant and team status

### DIFF
--- a/packages/client/src/assets/adjust-vue-select.css
+++ b/packages/client/src/assets/adjust-vue-select.css
@@ -9,3 +9,7 @@
 .vs__open-indicator {
   cursor: pointer;
 }
+
+.vs__search::placeholder {
+  color: #878787;
+}

--- a/packages/client/src/assets/adjust-vue-select.css
+++ b/packages/client/src/assets/adjust-vue-select.css
@@ -13,3 +13,11 @@
 .vs__search::placeholder {
   color: #878787;
 }
+
+.vs__dropdown-option--disabled {
+  text-transform: uppercase;
+  font-size: 12px;
+}
+.vs__dropdown-option--disabled:not(:first-child) {
+  margin-top: 12px;
+}

--- a/packages/client/src/views/GrantDetails.vue
+++ b/packages/client/src/views/GrantDetails.vue
@@ -74,12 +74,13 @@
                   class="flex-grow-1 mr-3"
                   v-model="selectedAgencyToAssign"
                   :options="agencies"
-                  label="name" track-by="id"
+                  label="name" 
+                  track-by="id"
                   :placeholder="`Choose ${newTerminologyEnabled ? 'team': 'agency'}`"
                   :clearable="false"
                   data-dd-action-name="select team for grant assignment"
                 />
-                <b-button variant="outline-primary" @click="assignAgenciesToGrant" data-dd-action-name="assign team">
+                <b-button variant="outline-primary" @click="assignAgenciesToGrant" :disabled="!selectedAgencyToAssign" data-dd-action-name="assign team">
                   Submit
                 </b-button>
               </div>
@@ -105,13 +106,14 @@
                   v-model="selectedInterestedCode"
                   :reduce="(option) => option.id"
                   :options="interestedOptions"
-                  label="name" track-by="id"
+                  label="name" 
+                  track-by="id"
                   placeholder="Choose status"
                   :selectable="selectableOption"
                   :clearable="false"
                   data-dd-action-name="select team status"
                 />
-                <b-button variant="outline-primary" @click="markGrantAsInterested" data-dd-action-name="submit team status">
+                <b-button variant="outline-primary" @click="markGrantAsInterested" :disabled="!selectedInterestedCode" data-dd-action-name="submit team status">
                   Submit
                 </b-button>
               </div>
@@ -145,6 +147,8 @@ import { datadogRum } from '@datadog/browser-rum';
 import { debounce } from 'lodash';
 import { newTerminologyEnabled } from '@/helpers/featureFlags';
 import { DateTime } from 'luxon';
+
+const HEADER = '__HEADER__';
 
 export default {
   props: {
@@ -207,11 +211,14 @@ export default {
       currentGrant: 'grants/currentGrant',
     }),
     interestedOptions() {
-      const interestedHeader = [{ name: 'Interested', status_code: 'HEADER' }];
-      const appliedHeader = [{ name: 'Applied', status_code: 'HEADER' }];
-      const rejectedHeader = [{ name: 'Not Applying', status_code: 'HEADER' }];
-      return interestedHeader.concat(this.interestedCodes.interested, appliedHeader,
-        this.interestedCodes.result, rejectedHeader, this.interestedCodes.rejections);
+      return [
+        { name: 'Interested', status_code: HEADER },
+        ...this.interestedCodes.interested,
+        { name: 'Applied', status_code: HEADER },
+        ...this.interestedCodes.result,
+        { name: 'Not Applying', status_code: HEADER },
+        ...this.interestedCodes.rejections,
+        ]
     },
     tableData() {
       return [{
@@ -394,7 +401,7 @@ export default {
       return DateTime.fromISO(dateString).toLocaleString(DateTime.DATETIME_MED);
     },
     selectableOption(option) {
-      return option.status_code !== 'HEADER';
+      return option.status_code !== HEADER;
     },
   },
 };

--- a/packages/client/src/views/GrantDetails.vue
+++ b/packages/client/src/views/GrantDetails.vue
@@ -74,7 +74,6 @@
                   class="flex-grow-1 mr-3"
                   v-model="selectedAgencies"
                   :options="agencies"
-                  :multiple="true"
                   label="name" track-by="id"
                   :placeholder="`Choose ${newTerminologyEnabled ? 'team': 'agency'}`"
                   data-dd-action-name="select team for grant assignment"
@@ -100,28 +99,15 @@
             <div class="mb-5">
               <h3 class="mb-3">{{newTerminologyEnabled ? 'Team': 'Agency'}} Status</h3>
               <div class="d-flex print-d-none">
-                <b-form-select
+                <v-select
                   class="flex-grow-1 mr-3"
                   v-model="selectedInterestedCode"
+                  :options="interestedOptions"
+                  label="name" track-by="id"
+                  placeholder="Choose status"
+                  :selectable="selectableOption"
                   data-dd-action-name="select team status"
-                >
-                  <b-form-select-option :value="null">Choose Status</b-form-select-option>
-                  <b-form-select-option-group label="Interested">
-                    <b-form-select-option v-for="code in interestedCodes.interested" :key="code.id" :value="code.id">
-                      {{ code.name }}
-                    </b-form-select-option>
-                  </b-form-select-option-group>
-                  <b-form-select-option-group label="Applied">
-                    <b-form-select-option v-for="code in interestedCodes.result" :key="code.id" :value="code.id">
-                      {{ code.name }}
-                    </b-form-select-option>
-                  </b-form-select-option-group>
-                  <b-form-select-option-group label="Not Applying">
-                    <b-form-select-option v-for="code in interestedCodes.rejections" :key="code.id" :value="code.id">
-                      {{ code.name }}
-                    </b-form-select-option>
-                  </b-form-select-option-group>
-                </b-form-select>
+                />
                 <b-button variant="outline-primary" @click="markGrantAsInterested" data-dd-action-name="submit team status">
                   Submit
                 </b-button>
@@ -217,6 +203,13 @@ export default {
       selectedAgency: 'users/selectedAgency',
       currentGrant: 'grants/currentGrant',
     }),
+    interestedOptions() {
+      const interestedHeader = [ { name: "Interested", status_code: "HEADER" } ];
+      const appliedHeader = [ { name: "Applied", status_code: "HEADER" } ];
+      const rejectedHeader = [ { name: "Not Applying", status_code: "HEADER" } ];
+      return interestedHeader.concat(this.interestedCodes.interested, appliedHeader, 
+        this.interestedCodes.result, rejectedHeader, this.interestedCodes.rejections);
+    },
     tableData() {
       return [{
         name: 'Opportunity Number',
@@ -324,6 +317,7 @@ export default {
           agencyId: this.selectedAgencyId,
           interestedCode: this.selectedInterestedCode,
         });
+        this.selectedInterestedCode = null;
         datadogRum.addAction('submit team status for grant', { team: { id: this.selectedAgencyId }, status: this.selectedInterestedCode, grant: { id: this.selectedGrant.grant_id } });
       }
     },
@@ -391,6 +385,9 @@ export default {
     },
     formatDateTime(dateString) {
       return DateTime.fromISO(dateString).toLocaleString(DateTime.DATETIME_MED);
+    },
+    selectableOption(option) {
+      return option.status_code != 'HEADER';
     },
   },
 };

--- a/packages/client/src/views/GrantDetails.vue
+++ b/packages/client/src/views/GrantDetails.vue
@@ -73,8 +73,8 @@
                 <v-select
                   class="flex-grow-1 mr-3"
                   v-model="selectedAgencyToAssign"
-                  :options="agencies"
-                  label="name" 
+                  :options="unassignedAgencies"
+                  label="name"
                   track-by="id"
                   :placeholder="`Choose ${newTerminologyEnabled ? 'team': 'agency'}`"
                   :clearable="false"
@@ -106,7 +106,7 @@
                   v-model="selectedInterestedCode"
                   :reduce="(option) => option.id"
                   :options="interestedOptions"
-                  label="name" 
+                  label="name"
                   track-by="id"
                   placeholder="Choose status"
                   :selectable="selectableOption"
@@ -218,7 +218,7 @@ export default {
         ...this.interestedCodes.result,
         { name: 'Not Applying', status_code: HEADER },
         ...this.interestedCodes.rejections,
-        ]
+      ];
     },
     tableData() {
       return [{
@@ -283,6 +283,11 @@ export default {
     newTerminologyEnabled() {
       return newTerminologyEnabled();
     },
+    unassignedAgencies() {
+      return this.agencies.filter(
+        (agency) => !this.assignedAgencies.map((assigned) => assigned.id).includes(agency.id),
+      );
+    },
   },
   watch: {
     async selectedGrant() {
@@ -345,10 +350,9 @@ export default {
       datadogRum.addAction('remove team status for grant', { team: { id: agency.agency_id }, status: agency.interested_code_id, grant: { id: this.selectedGrant.grant_id } });
     },
     async assignAgenciesToGrant() {
-      const agencyIds = this.assignedAgencies.map((agency) => agency.id).concat(this.selectedAgencyToAssign.id);
       await this.assignAgenciesToGrantAction({
         grantId: this.selectedGrant.grant_id,
-        agencyIds,
+        agencyIds: this.assignedAgencies.map((agency) => agency.id).concat(this.selectedAgencyToAssign.id),
       });
       datadogRum.addAction('assign team to grant', { team: { id: this.selectedAgencyToAssign.id }, grant: { id: this.selectedGrant.grant_id } });
       this.selectedAgencyToAssign = null;

--- a/packages/client/src/views/GrantDetails.vue
+++ b/packages/client/src/views/GrantDetails.vue
@@ -76,6 +76,7 @@
                   :options="agencies"
                   label="name" track-by="id"
                   :placeholder="`Choose ${newTerminologyEnabled ? 'team': 'agency'}`"
+                  :clearable="false"
                   data-dd-action-name="select team for grant assignment"
                 />
                 <b-button variant="outline-primary" @click="assignAgenciesToGrant" data-dd-action-name="assign team">
@@ -107,6 +108,7 @@
                   label="name" track-by="id"
                   placeholder="Choose status"
                   :selectable="selectableOption"
+                  :clearable="false"
                   data-dd-action-name="select team status"
                 />
                 <b-button variant="outline-primary" @click="markGrantAsInterested" data-dd-action-name="submit team status">

--- a/packages/client/src/views/GrantDetails.vue
+++ b/packages/client/src/views/GrantDetails.vue
@@ -72,7 +72,7 @@
               <div class="d-flex print-d-none">
                 <v-select
                   class="flex-grow-1 mr-3"
-                  v-model="selectedAgencies"
+                  v-model="selectedAgencyToAssign"
                   :options="agencies"
                   label="name" track-by="id"
                   :placeholder="`Choose ${newTerminologyEnabled ? 'team': 'agency'}`"
@@ -168,7 +168,7 @@ export default {
         },
       ],
       assignedAgencies: [],
-      selectedAgencies: [],
+      selectedAgencyToAssign: null,
       selectedInterestedCode: null,
       searchInput: null,
       debouncedSearchInput: null,
@@ -331,14 +331,14 @@ export default {
       datadogRum.addAction('remove team status for grant', { team: { id: this.selectedAgencyId }, status: this.selectedInterestedCode, grant: { id: this.selectedGrant.grant_id } });
     },
     async assignAgenciesToGrant() {
-      const agencyIds = this.selectedAgencies.map((agency) => agency.id);
+      const agencyIds = this.assignedAgencies.map((agency) => agency.id).concat(this.selectedAgencyToAssign.id);
       await this.assignAgenciesToGrantAction({
         grantId: this.selectedGrant.grant_id,
         agencyIds,
       });
-      this.selectedAgencies = [];
+      datadogRum.addAction('assign team to grant', { team: { id: this.selectedAgencyToAssign.id }, grant: { id: this.selectedGrant.grant_id } });
+      this.selectedAgencyToAssign = null;
       this.assignedAgencies = await this.getGrantAssignedAgencies({ grantId: this.selectedGrant.grant_id });
-      datadogRum.addAction('assign team to grant', { team: { id: this.selectedAgencyId }, grant: { id: this.selectedGrant.grant_id } });
     },
     async unassignAgenciesToGrant(agency) {
       await this.unassignAgenciesToGrantAction({
@@ -359,7 +359,7 @@ export default {
     resetSelectedGrant() {
       this.$emit('update:selectedGrant', null);
       this.assignedAgencies = [];
-      this.selectedAgencies = [];
+      this.selectedAgencyToAssign = null;
     },
     async fetchData() {
       await this.fetchGrantDetails({ grantId: this.$route.params.id }).then(() => {


### PR DESCRIPTION
### Ticket #2569 
## Description
Update dropdowns to be single-selection vue-selects. Add functionality to not require removing Team Status first when updating.

## Screenshots / Demo Video
https://github.com/usdigitalresponse/usdr-gost/assets/146878468/9dfd091b-1bd4-474e-9bbe-587bf6d8ecb5


## Testing
Enable Grant Details Page feature flag. Make sure you can assign multiple teams to a grant. Make sure you can add, remove and update team statuses.

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [x] Added steps to test feature/functionality manually

## Checklist
- [x] Provided ticket and description
- [x] Provided screenshots/demo
- [x] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [x] Added PR reviewers