### PR TITLE
Implement URL updates and browser history for grants table interactions

### DIFF
--- a/packages/client/src/components/GrantsTable.vue
+++ b/packages/client/src/components/GrantsTable.vue
@@ -344,11 +344,13 @@ export default {
       this.searchId = Number(this.$route.query.search) || DEFAULT_SEARCH_ID;
 
       // Manage search state
-      const searchData = this.savedSearches.data.find((search) => search.id === this.searchId);
-      if (searchData) {
-        this.changeSelectedSearchId(this.searchId);
-        this.applyFilters(JSON.parse(searchData.criteria));
-        this.initViewResults();
+      if (this.searchId && this.savedSearches) {
+        const searchData = this.savedSearches.data.find((search) => search.id === this.searchId);
+        if (searchData) {
+          this.changeSelectedSearchId(this.searchId);
+          this.applyFilters(JSON.parse(searchData.criteria));
+          this.initViewResults();
+        }
       }
     },
     clearSearch() {

--- a/packages/client/src/components/Layout.vue
+++ b/packages/client/src/components/Layout.vue
@@ -62,12 +62,12 @@
     </b-navbar>
     <b-col cols="12" v-if="showTabs">
       <b-nav tabs justified fill style="margin-top: 20px">
-          <b-nav-item to="/my-grants" exact exact-active-class="active">My Grants</b-nav-item>
-          <b-nav-item to="/grants" exact exact-active-class="active">Browse Grants</b-nav-item>
-          <b-nav-item to="/dashboard" exact exact-active-class="active">Dashboard</b-nav-item>
-          <b-nav-item to="/users" exact exact-active-class="active" v-if="userRole === 'admin'">Users</b-nav-item>
-          <b-nav-item :to="newTerminologyEnabled ? '/teams' : '/agencies'" exact exact-active-class="active">{{newTerminologyEnabled ? 'Teams' : 'Agencies'}}</b-nav-item>
-          <b-nav-item v-if="canSeeOrganizationsTab" :to="newTerminologyEnabled ? '/organizations' : '/tenants'" exact exact-active-class="active">{{newTerminologyEnabled ? 'Organizations' : 'Tenants'}}</b-nav-item>
+          <b-nav-item to="/my-grants" active-class="active">My Grants</b-nav-item>
+          <b-nav-item to="/grants" active-class="active">Browse Grants</b-nav-item>
+          <b-nav-item to="/dashboard" active-class="active">Dashboard</b-nav-item>
+          <b-nav-item to="/users" active-class="active" v-if="userRole === 'admin'">Users</b-nav-item>
+          <b-nav-item :to="newTerminologyEnabled ? '/teams' : '/agencies'" active-class="active">{{newTerminologyEnabled ? 'Teams' : 'Agencies'}}</b-nav-item>
+          <b-nav-item v-if="canSeeOrganizationsTab" :to="newTerminologyEnabled ? '/organizations' : '/tenants'" active-class="active">{{newTerminologyEnabled ? 'Organizations' : 'Tenants'}}</b-nav-item>
       </b-nav>
     </b-col>
 

--- a/packages/client/src/router/index.js
+++ b/packages/client/src/router/index.js
@@ -80,10 +80,22 @@ export const routes = [
       },
       {
         path: '/my-grants',
+        redirect: '/my-grants/interested',
+      },
+      {
+        path: '/my-grants/:tab',
         name: 'myGrants',
         component: () => import('../views/MyGrants.vue'),
         meta: {
+          tabNames: ['interested', 'assigned', 'not-applying', 'applied'],
           requiresAuth: true,
+        },
+        beforeEnter: (to, _, next) => {
+          if (to.meta.tabNames.includes(to.params.tab)) {
+            next();
+          } else {
+            next('/404');
+          }
         },
       },
       {

--- a/packages/client/src/views/Grants.vue
+++ b/packages/client/src/views/Grants.vue
@@ -1,22 +1,13 @@
 <template>
-  <component :is="tableComponent" :hideGrantItems="true"/>
+  <GrantsTable hideGrantItems />
 </template>
 
 <script>
-
 import GrantsTable from '@/components/GrantsTable.vue';
 
 export default {
-  data() {
-    return {
-
-    };
-  },
-  methods: {},
-  computed: {
-    tableComponent() {
-      return GrantsTable;
-    },
+  components: {
+    GrantsTable,
   },
 };
 </script>

--- a/packages/client/src/views/MyGrants.vue
+++ b/packages/client/src/views/MyGrants.vue
@@ -2,16 +2,16 @@
   <div class="grants-tabs">
     <b-tabs align="left" style="margin-top: 1.5rem" lazy>
       <b-tab title="Interested" active>
-        <component :is="tableComponent" searchTitle="Interested" :showInterested="true" :showSearchControls="false"/>
+        <GrantsTable searchTitle="Interested" showInterested :showSearchControls="false"/>
       </b-tab>
       <b-tab title="Assigned">
-        <component :is="tableComponent" searchTitle="Assigned" :showAssignedToAgency="selectedAgencyId" :showSearchControls="false"/>
+        <GrantsTable searchTitle="Assigned" :showAssignedToAgency="selectedAgencyId" :showSearchControls="false"/>
       </b-tab>
       <b-tab title="Not Applying">
-        <component :is="tableComponent" searchTitle="Not Applying" :showRejected="true" :showSearchControls="false"/>
+        <GrantsTable searchTitle="Not Applying" showRejected :showSearchControls="false"/>
       </b-tab>
       <b-tab title="Applied">
-          <component :is="tableComponent" searchTitle="Applied" :showResult="true" :showSearchControls="false"/>
+        <GrantsTable searchTitle="Applied" showResult :showSearchControls="false"/>
       </b-tab>
     </b-tabs>
   </div>
@@ -19,26 +19,20 @@
 
 <script>
 import { mapGetters } from 'vuex';
-
 import GrantsTable from '@/components/GrantsTable.vue';
 
 export default {
-  data() {
-    return {
-
-    };
+  components: {
+    GrantsTable,
   },
   computed: {
     ...mapGetters({
       selectedAgencyId: 'users/selectedAgencyId',
     }),
-    tableComponent() {
-      return GrantsTable;
-    },
   },
-  methods: {},
 };
 </script>
+
 <style>
 .grants-tabs .nav-tabs {
   padding-left: 20px;

--- a/packages/client/src/views/MyGrants.vue
+++ b/packages/client/src/views/MyGrants.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="grants-tabs">
-    <b-tabs align="left" style="margin-top: 1.5rem" lazy>
-      <b-tab title="Interested" active>
+    <b-tabs align="left" style="margin-top: 1.5rem" lazy v-model="activeTab">
+      <b-tab title="Interested">
         <GrantsTable searchTitle="Interested" showInterested :showSearchControls="false"/>
       </b-tab>
       <b-tab title="Assigned">
@@ -24,6 +24,19 @@ import GrantsTable from '@/components/GrantsTable.vue';
 export default {
   components: {
     GrantsTable,
+  },
+  data() {
+    return {
+      activeTab: 0,
+    };
+  },
+  created() {
+    this.$watch('$route.params.tab', (tabName) => {
+      this.activeTab = this.$route.meta.tabNames.indexOf(tabName);
+    }, { immediate: true });
+    this.$watch('activeTab', (newActiveTab) => {
+      this.$router.push({ name: 'myGrants', params: { tab: this.$route.meta.tabNames[newActiveTab] } });
+    });
   },
   computed: {
     ...mapGetters({


### PR DESCRIPTION
### Ticket #2575
## Description
**Note: I wanted some early eyes on this code change to make sure it seems directionally correct. I'd still like us to do more manual testing on the feature, as I worry there are still outstanding edge cases or interactions e.g. with saved searches that I don't have full product context on.**

Implements browser history and URL updates when interacting with the grants table. The interactions are now represented in a URL query param and added to history (i.e., browser back/forward will take you to those states): 

- Pagination (going to page 2, 3, etc.) `?page=2`
- Sorting (sort a column ascending or descending) `?sort=close_date` or `?sort=close_date&desc=true`
- Saved search (you've searched/filtered the results) `?search=1234`
- Any combination of the above `?search=1234&sort=close_date&desc=true&page=2`

Additionally, adds the active tab into the URL when switching between interested, assigned, not applying, and applied sub-tabs on the My Grants tab: 

- My Grants sub-tab `/my-grants/interested` or `/my-grants/not-applying`
- Combinations with the table query params above `/my-grants/not-applying?search=1234&sort=close_date&desc=true&page=2`

By adding these as entries in the browser history, the "back" functionality from he Grants Detail page should now work as expected, taking you right back to where you were and ensuring the specific grant you were looking at is still listed where you left it in the grant table when you return. 

## Screenshots / Demo Video
<img width="822" alt="image" src="https://github.com/usdigitalresponse/usdr-gost/assets/126250/d0cd8df5-726a-4012-a02d-a860cc53cbb1">

## Testing
It can be very helpful to have a larger and more realistic dataset loaded up for testing sorting/searching/pagination. There may be a better way, but here's how I got a dump of staging data into my local environment: 

1. Download a staging db dump and unzip it
    - e.g., https://usdigitalresponse.slack.com/files/U042RBLELUT/F06A9P2KLFM/gost-dump-full_2023-12-12.sql.tar.gz
    - Slack reference: https://usdigitalresponse.slack.com/archives/C0324KDQSCR/p1707931613492139
2. `docker compose down` (to start from a fresh Postgres install)
3. `docker compose up -d`
4. `docker compose run -v ~/Downloads:/downloads app psql -d postgresql://postgres:password123@postgres:5432/usdr_grants -f /downloads/dump.sql`
    - Point the `-v` option to where your unzipped dump is located; point the `-f` option to the name of the dump
5. `docker compose exec app yarn db:migrate`

Once you have that, you can verify the URL gets updated as you interact with the grants tables throughout the site, and verify that the browser back/forward behavior works as expected. 

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [ ] Provided ticket and description
- [ ] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers