### PR TITLE
Update job dependency chain to better reflect expected prerequisites

### DIFF
--- a/.github/workflows/aws-auth.yml
+++ b/.github/workflows/aws-auth.yml
@@ -6,6 +6,10 @@ on:
       aws-region:
         type: string
         required: true
+      concurrency-group:
+        description: Name of the concurrency group
+        type: string
+        default: run_terraform
     secrets:
       role-to-assume:
         required: true
@@ -30,6 +34,9 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    concurrency:
+      group: ${{ inputs.concurrency-group }}
+      cancel-in-progress: false
     outputs:
       aws-access-key-id: ${{ steps.encrypt-aws-access-key-id.outputs.out }}
       aws-secret-access-key: ${{ steps.encrypt-aws-secret-access-key.outputs.out }}

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -56,6 +56,7 @@ jobs:
     uses: ./.github/workflows/aws-auth.yml
     with:
       aws-region: us-west-2
+      concurrency-group: run_terraform-production
     secrets:
       gpg-passphrase: ${{ secrets.PRODUCTION_GPG_PASSPHRASE }}
       role-to-assume: ${{ secrets.PRODUCTION_ROLE_ARN }}
@@ -66,8 +67,8 @@ jobs:
       contents: read
     needs:
       - validate
-      - aws-auth-plan
       - build
+      - aws-auth-plan
     uses: ./.github/workflows/terraform-plan.yml
     with:
       ref: ${{ github.sha }}
@@ -115,10 +116,11 @@ jobs:
       contents: read
       id-token: write
     needs:
-      - validate
+      - publish-tf-plan
     uses: ./.github/workflows/aws-auth.yml
     with:
       aws-region: us-west-2
+      concurrency-group: run_terraform-production
     secrets:
       gpg-passphrase: ${{ secrets.PRODUCTION_GPG_PASSPHRASE }}
       role-to-assume: ${{ secrets.PRODUCTION_ROLE_ARN }}
@@ -127,8 +129,8 @@ jobs:
     name: Deploy to Production
     needs:
       - build
-      - aws-auth-apply
       - tf-plan
+      - aws-auth-apply
     if: needs.tf-plan.outputs.plan-exitcode == 2
     uses: ./.github/workflows/terraform-apply.yml
     with:


### PR DESCRIPTION
Attempts to address the problem of expired AWS credentials during the Terraform Apply step by:
- Updating the job dependencies to better reflect the expected job sequencing
- Grouping the job to fetch the credentials as part of the same concurrency group as the Terraform apply job