### PR TITLE
fix: #1801 - closed period reporting

### DIFF
--- a/packages/client/src/arpa_reporter/views/Home.vue
+++ b/packages/client/src/arpa_reporter/views/Home.vue
@@ -3,20 +3,19 @@
     <div class="row">
       <AlertBox v-if="alert" :text="alert.text" :level="alert.level" v-on:dismiss="clearAlert" />
     </div>
-    <div class="row mt-5 mb-5" v-if="viewingOpenPeriod">
-      <div class="col" v-if="this.$route.query.sync_treasury_download && isAdmin">
-        <DownloadButton :href="downloadTreasuryReportURL()" class="btn btn-primary btn-block">Download Treasury Report</DownloadButton>
-      </div>
 
+    <div class="row border border-danger rounded m-3 mb-3 p-3" v-if="!viewingOpenPeriod">
+      <div class="col" id="closedReportingPeriodMessage">
+        This reporting period is closed.
+      </div>
+    </div>
+
+    <div class="row mt-5 mb-5" v-if="viewingOpenPeriod || isAdmin">
       <div class="col" v-if="isAdmin">
         <button class="btn btn-primary btn-block" @click="sendTreasuryReport" :disabled="sending" id="sendTreasuryReportButton">
           <span v-if="sending">Sending...</span>
           <span v-else>Send Treasury Report by Email</span>
         </button>
-      </div>
-
-      <div class="col" v-if="this.$route.query.sync_audit_download && isAdmin">
-        <DownloadButton :href="downloadAuditReportURL()" class="btn btn-info btn-block">Download Audit Report</DownloadButton>
       </div>
 
       <div class="col" v-if="isAdmin">
@@ -26,18 +25,12 @@
         </button>
       </div>
 
-      <div class="col">
-        <button @click.prevent="startUpload" class="btn btn-primary btn-block" id="submitWorkbookButton">Submit Workbook</button>
+      <div class="col" v-if="viewingOpenPeriod">
+        <button @click.prevent="startUpload" class="btn btn-primary btn-block" id="submitWorkbookButton"  :disabled="!viewingOpenPeriod">Submit Workbook</button>
       </div>
 
-      <div class="col">
+      <div class="col" v-if="viewingOpenPeriod">
         <DownloadTemplateBtn :block="true" />
-      </div>
-    </div>
-
-    <div class="row border border-danger rounded m-3 mb-3 p-3" v-else>
-      <div class="col" id="closedReportingPeriodMessage">
-        This reporting period is closed.
       </div>
     </div>
 
@@ -60,9 +53,7 @@
 </template>
 
 <script>
-import { apiURL } from '@/helpers/fetchApi';
 import AlertBox from '../components/AlertBox.vue';
-import DownloadButton from '../components/DownloadButton.vue';
 import DownloadTemplateBtn from '../components/DownloadTemplateBtn.vue';
 import { getJson } from '../store/index';
 
@@ -98,14 +89,16 @@ export default {
     clearAlert() {
       this.alert = null;
     },
-    downloadAuditReportURL() {
-      return apiURL('/api/audit_report');
-    },
     async sendAuditReport() {
       this.sending = true;
 
       try {
-        const result = await getJson('/api/audit_report?queue=true');
+        const periodId = this.$store.getters.viewPeriod.id || 0;
+        const query = new URLSearchParams({ queue: true });
+        if (periodId && !this.viewingOpenPeriod) {
+          query.set('period_id', periodId);
+        }
+        const result = await getJson(`/api/audit_report?${query}`);
 
         if (result.error) {
           this.alert = {
@@ -129,15 +122,16 @@ export default {
 
       this.sending = false;
     },
-    downloadTreasuryReportURL() {
-      const periodId = this.$store.getters.viewPeriod.id || 0;
-      return apiURL(`/api/exports?period_id=${periodId}`);
-    },
     async sendTreasuryReport() {
       this.sending = true;
 
       try {
-        const result = await getJson('/api/exports?queue=true');
+        const periodId = this.$store.getters.viewPeriod.id || 0;
+        const query = new URLSearchParams({ queue: true });
+        if (periodId && !this.viewingOpenPeriod) {
+          query.set('period_id', periodId);
+        }
+        const result = await getJson(`/api/exports?${query}`);
 
         if (result.error) {
           this.alert = {
@@ -168,7 +162,6 @@ export default {
     },
   },
   components: {
-    DownloadButton,
     DownloadTemplateBtn,
     AlertBox,
   },

--- a/packages/client/src/assets/adjust-vue-select.css
+++ b/packages/client/src/assets/adjust-vue-select.css
@@ -9,15 +9,3 @@
 .vs__open-indicator {
   cursor: pointer;
 }
-
-.vs__search::placeholder {
-  color: #878787;
-}
-
-.vs__dropdown-option--disabled {
-  text-transform: uppercase;
-  font-size: 12px;
-}
-.vs__dropdown-option--disabled:not(:first-child) {
-  margin-top: 12px;
-}

--- a/packages/client/tests/unit/arpa_reporter/views/Home.spec.js
+++ b/packages/client/tests/unit/arpa_reporter/views/Home.spec.js
@@ -39,6 +39,10 @@ describe('Home.vue', () => {
         const reportingPeriodClosed = wrapper.get('#closedReportingPeriodMessage');
         expect(reportingPeriodClosed.text()).to.include('This reporting period is closed.');
       });
+      it('should not show a download button', () => {
+        const sendTreasuryReportButton = wrapper.find('#sendTreasuryReportButton');
+        expect(sendTreasuryReportButton.exists()).to.not.true;
+      });
     });
     describe('during the reporting period', () => {
       beforeEach(() => {
@@ -108,9 +112,9 @@ describe('Home.vue', () => {
           mocks: { $route: route },
         });
       });
-      it('should show the Download Treasury Report button', () => {
-        const downloadButton = wrapper.getComponent({ name: 'DownloadButton' });
-        expect(downloadButton.text()).to.include('Download Treasury Report');
+      it('should show the Send Treasury Report button', () => {
+        const sendTreasuryReportButton = wrapper.get('#sendTreasuryReportButton');
+        expect(sendTreasuryReportButton.text()).to.include('Send Treasury Report by Email');
       });
     });
     describe('with the sync_audit_download param', () => {
@@ -129,9 +133,40 @@ describe('Home.vue', () => {
           mocks: { $route: route },
         });
       });
-      it('should show the Download Treasury Report button', () => {
-        const downloadAuditButton = wrapper.getComponent({ name: 'DownloadButton' });
-        expect(downloadAuditButton.text()).to.include('Download Audit Report');
+      it('should show the Send Treasury Report button', () => {
+        const sendTreasuryReportButton = wrapper.get('#sendTreasuryReportButton');
+        expect(sendTreasuryReportButton.text()).to.include('Send Treasury Report by Email');
+      });
+    });
+  });
+  describe('when an admin loads the home page outside the reporting period', () => {
+    describe('without query params', () => {
+      beforeEach(() => {
+        store = new Vuex.Store({
+          state: { },
+          getters: {
+            user: () => ({ role: { name: 'admin' } }),
+            viewPeriodIsCurrent: () => false,
+          },
+        });
+        route = { query: { } };
+        wrapper = shallowMount(Home, {
+          store,
+          localVue,
+          mocks: { $route: route },
+        });
+      });
+      it('should not show the submit workbook button', () => {
+        const submitWorkbookButton = wrapper.find('#submitWorkbookButton');
+        expect(submitWorkbookButton.exists()).to.not.true;
+      });
+      it('should show the Send Treasury Report by Email Button', () => {
+        const sendTreasuryReportButton = wrapper.get('#sendTreasuryReportButton');
+        expect(sendTreasuryReportButton.text()).to.include('Send Treasury Report by Email');
+      });
+      it('should show the reporting period as closed', () => {
+        const reportingPeriodClosed = wrapper.get('#closedReportingPeriodMessage');
+        expect(reportingPeriodClosed.text()).to.include('This reporting period is closed.');
       });
     });
   });

--- a/packages/server/__tests__/arpa_reporter/server/routes/audit_report.spec.js
+++ b/packages/server/__tests__/arpa_reporter/server/routes/audit_report.spec.js
@@ -46,6 +46,14 @@ describe('/api/audit_report', () => {
             .set('Cookie', tenantACookie)
             .expect(200);
     });
+    it('Ensures async audit report generation with period id returns 200', async () => {
+        audit_report.generateAndSendEmail = () => 'success';
+
+        await server
+            .get('/api/audit_report?async=true&period_id=1')
+            .set('Cookie', tenantACookie)
+            .expect(200);
+    });
     it('Ensures it returns an error property when there is an issue', async () => {
         audit_report.generateAndSendEmail = () => {
             throw new Error('Some error message');

--- a/packages/server/src/arpa_reporter/db/reporting-periods.js
+++ b/packages/server/src/arpa_reporter/db/reporting-periods.js
@@ -42,6 +42,9 @@ async function getAllReportingPeriods(trns = knex, tenantId = useTenantId()) {
 /* getReportingPeriod() returns a record from the reporting_periods table.
   */
 async function getReportingPeriod(period_id = undefined, trns = knex, tenantId = useTenantId()) {
+    if (trns == null) {
+        trns = knex;
+    }
     if (period_id && Number(period_id)) {
         return baseQuery(trns)
             .where('reporting_periods.tenant_id', tenantId)

--- a/packages/server/src/arpa_reporter/routes/exports.js
+++ b/packages/server/src/arpa_reporter/routes/exports.js
@@ -48,7 +48,7 @@ router.get('/:tenantId/:periodId/:filename', async (req, res) => {
 });
 
 router.get('/', requireUser, async (req, res) => {
-    const periodId = await getReportingPeriodID(req.query.period_id);
+    const periodId = req.query.period_id ?? await getReportingPeriodID(req.query.period_id);
     const period = await getReportingPeriod(periodId);
     if (!period) {
         res.status(404).json({ error: 'invalid reporting period' });

--- a/packages/server/src/arpa_reporter/services/records.js
+++ b/packages/server/src/arpa_reporter/services/records.js
@@ -92,6 +92,11 @@ async function loadRecordsForUpload(upload) {
             ({ name }) => name === sheetName,
         );
 
+        if (sheetAttributes == null) {
+            // eslint-disable-next-line no-continue
+            continue;
+        }
+
         // ignore hidden sheets
         if (sheetAttributes.Hidden !== 0) {
             // eslint-disable-next-line no-continue
@@ -250,7 +255,21 @@ async function recordsForProject(periodId, tenantId) {
         .flat()
         // exclude non-project records
         .filter((record) => ([...Object.values(EC_SHEET_TYPES), 'awards50k', 'expenditures50k', 'awards']).includes(record.type));
-    return Object.values(projectRecords);
+
+    // expenditures do not have projects on them, but awards do under Project_Identification_Number__c
+    // we can map the two by Subawards
+    const subawardProjectMapping = projectRecords.filter((record) => record.type === 'awards50k').reduce((accumulator, record) => {
+        accumulator[record.content.Award_No__c] = record.content.Project_Identification_Number__c;
+        return accumulator;
+    }, {});
+
+    const records = Object.values(projectRecords).map((record) => {
+        if (record.type !== 'expenditures50k') {
+            return record;
+        }
+        return { ...record, content: { ...record.content, Project_Identification_Number__c: subawardProjectMapping[record.content.Sub_Award_Lookup__c] } };
+    });
+    return records;
 }
 
 module.exports = {


### PR DESCRIPTION
### Ticket #1801
## Description
* periodId added as optional argument to backend reporting functions
* report download buttons available on closed reporting periods
* test cases added

This is a follow up from https://github.com/usdigitalresponse/usdr-gost/pull/2282
The last branch was too old, so I recreated it off of main.

## Screenshots / Demo Video
See other PR

## Testing
Run the application, run reports, choose different reporting periods, run more reports

### Automated and Unit Tests
- [x] Added Unit tests

### Manual tests for Reviewer
- [x] Added steps to test feature/functionality manually

## Checklist
- [x] Provided ticket and description
- [x] Provided screenshots/demo
- [x] Provided testing information
- [x] Provided adequate test coverage for all new code
- [x] Added PR reviewers