### PR TITLE
[issue-2585] Make Grants tab the default tab

### DIFF
--- a/packages/client/src/components/Layout.vue
+++ b/packages/client/src/components/Layout.vue
@@ -62,8 +62,8 @@
     </b-navbar>
     <b-col cols="12" v-if="showTabs">
       <b-nav tabs justified fill style="margin-top: 20px">
-          <b-nav-item to="/my-grants" exact exact-active-class="active">My Grants</b-nav-item>
           <b-nav-item to="/grants" exact exact-active-class="active">Browse Grants</b-nav-item>
+          <b-nav-item to="/my-grants" exact exact-active-class="active">My Grants</b-nav-item>
           <b-nav-item to="/dashboard" exact exact-active-class="active">Dashboard</b-nav-item>
           <b-nav-item to="/users" exact exact-active-class="active" v-if="userRole === 'admin'">Users</b-nav-item>
           <b-nav-item :to="newTerminologyEnabled ? '/teams' : '/agencies'" exact exact-active-class="active">{{newTerminologyEnabled ? 'Teams' : 'Agencies'}}</b-nav-item>

--- a/packages/client/src/router/index.js
+++ b/packages/client/src/router/index.js
@@ -29,7 +29,7 @@ export const routes = [
         // Redirect any old hash-style URLs to the new history API URL.
         return { path: to.hash.substring(1), hash: '' };
       }
-      return 'grants';
+      return { name: 'grants' };
     },
     component: Layout,
     meta: {

--- a/packages/client/src/router/index.js
+++ b/packages/client/src/router/index.js
@@ -29,7 +29,7 @@ export const routes = [
         // Redirect any old hash-style URLs to the new history API URL.
         return { path: to.hash.substring(1), hash: '' };
       }
-      return 'my-grants';
+      return 'grants';
     },
     component: Layout,
     meta: {


### PR DESCRIPTION
### Ticket #<Enter Number Here To Auto-Link>
## Description
This pull request addresses the issue related to updating the behavior of the Finder app as outlined in Issue #2585.

## Screenshots / Demo Video
<img width="875" alt="Screenshot 2024-02-21 at 10 13 42 AM" src="https://github.com/usdigitalresponse/usdr-gost/assets/485547/3bc32c5b-724c-45fc-a2dd-5076f949fcb9">

## Testing
- When root path it will redirect to '/grants' instead of '/my-grants'

### Automated and Unit Tests 
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Login and verify that page land on /grants which is the tab for 'Browse Grants'
- [ ] Enter root path '/' and it should always redirect to '/grants'
- [ ] Verify 'Browse Grants' is the first tab

## Checklist
- [ ] Provided ticket and description
- [ ] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers