### PR TITLE
Grant details close date explanation, step 1

### DIFF
--- a/packages/server/migrations/20240221163647_add_close_date_explanation.js
+++ b/packages/server/migrations/20240221163647_add_close_date_explanation.js
@@ -1,0 +1,20 @@
+/**
+ * Adds a new `close_date_explanation` nullable text field, which will be populated in the next migration
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function (knex) {
+    return knex.schema.table('grants', (table) => {
+        table.text('close_date_explanation');
+    });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function (knex) {
+    return knex.schema.table('grants', (table) => {
+        table.dropColumn('close_date_explanation');
+    });
+};


### PR DESCRIPTION
### Ticket #2571
## Description
Step 1 of introducing close date explanations (for missing close dates) on the Grant Details page. (See https://github.com/usdigitalresponse/usdr-gost/pull/2647 for this step in context of the full plan.) 

Adds a db migration to add a `close_date_explanation` text field. (This will be populated in the upcoming steps, which will come as PRs to be deployed separately.)

## Screenshots / Demo Video

## Testing
Ran the migration locally forward and backward on a staging db dump, and verified the results in a psql shell

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [ ] Provided ticket and description
- [ ] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers