### PR TITLE
Grant details close date explanation, step 2

### DIFF
--- a/packages/server/src/lib/grants-ingest.js
+++ b/packages/server/src/lib/grants-ingest.js
@@ -51,6 +51,7 @@ function mapSourceDataToGrant(source) {
     grant.open_date = milestones.post_date;
     grant.close_date = milestones.close && milestones.close.date
         ? milestones.close.date : '2100-01-01';
+    grant.close_date_explanation = milestones?.close?.explanation ?? undefined;
     grant.archive_date = milestones.archive_date;
     const today = moment().startOf('day');
     if (milestones.archive_date && today.isSameOrAfter(moment(milestones.archive_date), 'date')) {


### PR DESCRIPTION
### Ticket #2571
## Description
**NOTE: This PR must deploy after #2648** 

Step 2 of introducing close date explanations (for missing close dates) on the Grant Details page. (See https://github.com/usdigitalresponse/usdr-gost/pull/2647 for this step in context of the full plan.) 

Updates the `mapSourceDataToGrant` method to pull `close_date_explanation` out of the milestones data for grants-ingest messages. 

## Screenshots / Demo Video

## Testing
Added unit tests for the new field

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [ ] Provided ticket and description
- [ ] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers