### PR TITLE
Grant details close date explanation, step 3

### DIFF
--- a/packages/server/migrations/20240221164356_populate_close_date_explanation.js
+++ b/packages/server/migrations/20240221164356_populate_close_date_explanation.js
@@ -1,0 +1,22 @@
+/**
+ * Populates the new `close_date_explanation` field from existing data in the raw_body_json field
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function (knex) {
+    return knex('grants')
+        .update({
+            close_date_explanation: knex.raw(`raw_body_json->'opportunity'->'milestones'->'close'->>'explanation'`),
+        })
+        .whereNull('close_date_explanation');
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function () {
+    // Cannot accurately reverse the migration
+    // (but if you also reverse the preceding migration, the column will simply be removed, making this moot)
+    return Promise.resolve();
+};


### PR DESCRIPTION
### Ticket #2571
## Description
**NOTE: This PR must deploy after #2648** 

Step 3 of introducing close date explanations (for missing close dates) on the Grant Details page. (See https://github.com/usdigitalresponse/usdr-gost/pull/2647 for this step in context of the full plan.) 

Adds a backfill migration to populate the `close_date_explanation` column in the DB for all grants in the database. 

## Screenshots / Demo Video

## Testing
Ran the migration locally forward and backward on a staging db dump, and verified the results in a psql shell

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [ ] Provided ticket and description
- [ ] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers