### PR TITLE
Grant details close date explanation, step 4

### DIFF
--- a/packages/client/src/views/GrantDetails.vue
+++ b/packages/client/src/views/GrantDetails.vue
@@ -22,7 +22,13 @@
               thead-class="d-none"
               borderless
               hover
-            ></b-table>
+            >
+              <template #cell()="data">
+                <span :class="{'text-muted font-weight-normal': data.item.displayMuted}">
+                  {{ data.value }}
+                </span>
+              </template>
+            </b-table>
             <h3 class="mb-3">Description</h3>
             <!-- TODO: spike on removing v-html usage https://github.com/usdigitalresponse/usdr-gost/issues/2572 -->
             <div style="white-space: pre-line" v-html="selectedGrant.description"></div>
@@ -149,6 +155,8 @@ import { newTerminologyEnabled } from '@/helpers/featureFlags';
 import { DateTime } from 'luxon';
 
 const HEADER = '__HEADER__';
+const FAR_FUTURE_CLOSE_DATE = '2100-01-01';
+const NOT_AVAILABLE_TEXT = 'Not available';
 
 export default {
   props: {
@@ -229,7 +237,8 @@ export default {
         value: this.formatDate(this.selectedGrant.open_date),
       }, {
         name: 'Close Date',
-        value: this.formatDate(this.selectedGrant.close_date),
+        value: this.closeDateDisplay,
+        displayMuted: this.closeDateDisplayMuted,
       }, {
         name: 'Grant ID',
         value: this.selectedGrant.grant_id,
@@ -256,6 +265,16 @@ export default {
         value: this.selectedGrant.cost_sharing,
       },
       ];
+    },
+    closeDateDisplay() {
+      // If we have an explainer text instead of a real close date, display that instead
+      if (this.selectedGrant.close_date === FAR_FUTURE_CLOSE_DATE) {
+        return this.selectedGrant.close_date_explanation ?? NOT_AVAILABLE_TEXT;
+      }
+      return this.formatDate(this.selectedGrant.close_date);
+    },
+    closeDateDisplayMuted() {
+      return this.selectedGrant.close_date === FAR_FUTURE_CLOSE_DATE && !this.selectedGrant.close_date_explanation;
     },
     visibleInterestedAgencies() {
       return this.selectedGrant.interested_agencies


### PR DESCRIPTION
### Ticket #2571
## Description
**Note: After a bit more thinking, this PR should be able to deploy in any order with respect to the other steps. It's resilient to even the DB column not existing yet; it'll simply display "Not available" for far-future close dates until we create and backfill the column. That's probably better than showing 2100 anyway, but it'll also only show up behind the grant detail page feature flag. All in all, should be safe to merge whenever!**

Step 4 of introducing close date explanations (for missing close dates) on the Grant Details page. (See https://github.com/usdigitalresponse/usdr-gost/pull/2647 for this step in context of the full plan.) 

Updates the grant detail page frontend to display better information when a grant has a far-future close date. If `close_date_explanation` is available, it'll show that; otherwise, it'll show "Not available" in grayed-out text. 

## Screenshots / Demo Video
<img width="1644" alt="Screenshot 2024-02-21 at 9 40 48 AM" src="https://github.com/usdigitalresponse/usdr-gost/assets/126250/6af510e8-eb33-4490-b1f4-b8e0876e1dcc">
<img width="1644" alt="Screenshot 2024-02-21 at 9 41 07 AM" src="https://github.com/usdigitalresponse/usdr-gost/assets/126250/ab879a89-7910-4859-986c-ae396fa75001">
<img width="1644" alt="Screenshot 2024-02-21 at 9 53 15 AM" src="https://github.com/usdigitalresponse/usdr-gost/assets/126250/05d02da4-08f3-4fa7-b735-88685322b42c">

## Testing
Manually tested behavior across grants in all relevant states

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [ ] Provided ticket and description
- [ ] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers