### PR TITLE
Make it easier to enable Postgres persistence in dev.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,3 +122,6 @@ volume/
 
 # Terraform
 terraform/.terraform/
+
+# Local overrides for docker compose
+docker-compose.override.yml

--- a/docker/README.md
+++ b/docker/README.md
@@ -162,11 +162,19 @@ development environments (e.g. you can nuke everything and start fresh). However
 like to persist the state of your databases across rebuilds, you can mount a local directory
 from your workstation at the `/bitnami/postgresql` path within the container. For your convenience,
 this repository contains a directory at `docker/postgres/persistence` to use for this purpose;
-any files within this directory will be ignored by git. Simply update the `postgres` service
-definition in the `docker-compose.yml` file to mount this volume – you can do so
-by adding/uncommenting the corresponding `services.postgres.volumes` item in that file so that
-the `./docker/postgres/persistence:/bitnami/postgresql` volume mount is enabled.
+any files within this directory will be ignored by git.
 
+#### How to enable persistence - Quick and dirty method
+Uncomment the line `# - ./docker/postgres/persistence:/bitnami/postgresql` in our root level `docker-compose.yml` file.
+
+#### How to enable persistence - Long-tem method
+Create a file `docker-compose.override.yml` in the root of the project and add the following content. Note that this file is ignored by git.
+```yaml
+ services:
+   postgres:
+     volumes:
+       - ./docker/postgres/persistence:/bitnami/postgresql 
+```
 
 ### Create SQS queues in localstack
 SQS queues should automatically be setup from the `localstack/entrypoint/init-aws.sh` script.


### PR DESCRIPTION
### Ticket #<Enter Number Here To Auto-Link>
## Description

Instructions for using docker compose override for anyone who wants to permanently enable db persistence in their dev environment.

## Screenshots / Demo Video

## Testing

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [ ] Provided ticket and description
- [ ] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers