### PR TITLE
fix: #1801 - revert frontend change

### DIFF
--- a/packages/client/src/assets/adjust-vue-select.css
+++ b/packages/client/src/assets/adjust-vue-select.css
@@ -9,3 +9,15 @@
 .vs__open-indicator {
   cursor: pointer;
 }
+
+.vs__search::placeholder {
+  color: #878787;
+}
+
+.vs__dropdown-option--disabled {
+  text-transform: uppercase;
+  font-size: 12px;
+}
+.vs__dropdown-option--disabled:not(:first-child) {
+  margin-top: 12px;
+}

--- a/packages/client/tests/unit/arpa_reporter/views/Home.spec.js
+++ b/packages/client/tests/unit/arpa_reporter/views/Home.spec.js
@@ -39,10 +39,6 @@ describe('Home.vue', () => {
         const reportingPeriodClosed = wrapper.get('#closedReportingPeriodMessage');
         expect(reportingPeriodClosed.text()).to.include('This reporting period is closed.');
       });
-      it('should not show a download button', () => {
-        const sendTreasuryReportButton = wrapper.find('#sendTreasuryReportButton');
-        expect(sendTreasuryReportButton.exists()).to.not.true;
-      });
     });
     describe('during the reporting period', () => {
       beforeEach(() => {
@@ -112,9 +108,9 @@ describe('Home.vue', () => {
           mocks: { $route: route },
         });
       });
-      it('should show the Send Treasury Report button', () => {
-        const sendTreasuryReportButton = wrapper.get('#sendTreasuryReportButton');
-        expect(sendTreasuryReportButton.text()).to.include('Send Treasury Report by Email');
+      it('should show the Download Treasury Report button', () => {
+        const downloadButton = wrapper.getComponent({ name: 'DownloadButton' });
+        expect(downloadButton.text()).to.include('Download Treasury Report');
       });
     });
     describe('with the sync_audit_download param', () => {
@@ -133,40 +129,9 @@ describe('Home.vue', () => {
           mocks: { $route: route },
         });
       });
-      it('should show the Send Treasury Report button', () => {
-        const sendTreasuryReportButton = wrapper.get('#sendTreasuryReportButton');
-        expect(sendTreasuryReportButton.text()).to.include('Send Treasury Report by Email');
-      });
-    });
-  });
-  describe('when an admin loads the home page outside the reporting period', () => {
-    describe('without query params', () => {
-      beforeEach(() => {
-        store = new Vuex.Store({
-          state: { },
-          getters: {
-            user: () => ({ role: { name: 'admin' } }),
-            viewPeriodIsCurrent: () => false,
-          },
-        });
-        route = { query: { } };
-        wrapper = shallowMount(Home, {
-          store,
-          localVue,
-          mocks: { $route: route },
-        });
-      });
-      it('should not show the submit workbook button', () => {
-        const submitWorkbookButton = wrapper.find('#submitWorkbookButton');
-        expect(submitWorkbookButton.exists()).to.not.true;
-      });
-      it('should show the Send Treasury Report by Email Button', () => {
-        const sendTreasuryReportButton = wrapper.get('#sendTreasuryReportButton');
-        expect(sendTreasuryReportButton.text()).to.include('Send Treasury Report by Email');
-      });
-      it('should show the reporting period as closed', () => {
-        const reportingPeriodClosed = wrapper.get('#closedReportingPeriodMessage');
-        expect(reportingPeriodClosed.text()).to.include('This reporting period is closed.');
+      it('should show the Download Treasury Report button', () => {
+        const downloadAuditButton = wrapper.getComponent({ name: 'DownloadButton' });
+        expect(downloadAuditButton.text()).to.include('Download Audit Report');
       });
     });
   });


### PR DESCRIPTION
### Ticket #1801
## Description
this reverts the frontend change for 1801, but leaves the backend alone. we need more info for the purpose of 1801, so for now we are rolling back the frontend changes that let's the user action on it.

## Screenshots / Demo Video

## Testing

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [ ] Provided ticket and description
- [ ] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers