### PR TITLE
Flip grant detail page flag on in development

### DIFF
--- a/packages/client/public/deploy-config.js
+++ b/packages/client/public/deploy-config.js
@@ -22,7 +22,7 @@ window.APP_CONFIG.overrideFeatureFlag = (flagName, overrideValue) => {
 window.APP_CONFIG.featureFlags = {
   myProfileEnabled: true,
   newTerminologyEnabled: true,
-  newGrantsDetailPageEnabled: false,
+  newGrantsDetailPageEnabled: true,
 };
 
 // Setting a GOOGLE_TAG_ID enables Google Analytics.


### PR DESCRIPTION
### Ticket #<Enter Number Here To Auto-Link>
## Description
Given the new Grant Details page is nearly feature-complete and developers predominantly want the flag on in development (per discussion in this week's planning meeting), this PR flips the flag (in development only) to be on by default. 

## Screenshots / Demo Video

## Testing
Manually tested "Browse Grants" and "My Grants" grant tables all point to the new detail page. 

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [ ] Provided ticket and description
- [ ] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers