### PR TITLE
Update grant details page overall layout

### DIFF
--- a/packages/client/src/views/GrantDetails.vue
+++ b/packages/client/src/views/GrantDetails.vue
@@ -1,149 +1,149 @@
 <template>
-  <section class="grants-details-container m-5">
-      <div v-if="loading">
-        Loading...
-      </div>
-      <div v-if="!selectedGrant && !loading">
-        No grant found
-      </div>
-      <b-container fluid v-if="selectedGrant && !loading">
-        <b-row>
+  <section>
+    <div v-if="loading">
+      Loading...
+    </div>
+    <div v-if="!selectedGrant && !loading">
+      No grant found
+    </div>
+    <b-container fluid v-if="selectedGrant && !loading">
+      <div class="grant-details-container">
 
-          <!-- Left page column: title, table data, and grant description -->
-          <b-col>
-            <h2 class="mb-5">{{ selectedGrant.title }}</h2>
-            <b-table
-              class="grant-details-table mb-5"
-              :items="tableData"
-              :fields="[
-                {key: 'name', class: 'color-gray grants-details-table-fit-content'},
-                {key: 'value', class: 'font-weight-bold'},
-              ]"
-              thead-class="d-none"
-              borderless
-              hover
+        <!-- Left page column: headline -->
+        <h2 class="grant-details-headline m-0">{{ selectedGrant.title }}</h2>
+
+        <!-- Left page column: table data, and grant description -->
+        <div class="grant-details-content">
+          <b-table
+            class="grant-details-table mb-5"
+            :items="tableData"
+            :fields="[
+              {key: 'name', class: 'color-gray grants-details-table-fit-content'},
+              {key: 'value', class: 'font-weight-bold'},
+            ]"
+            thead-class="d-none"
+            borderless
+            hover
+          >
+            <template #cell()="data">
+              <span :class="{'text-muted font-weight-normal': data.item.displayMuted}">
+                {{ data.value }}
+              </span>
+            </template>
+          </b-table>
+          <h3 class="mb-3">Description</h3>
+          <!-- TODO: spike on removing v-html usage https://github.com/usdigitalresponse/usdr-gost/issues/2572 -->
+          <div style="white-space: pre-line" v-html="selectedGrant.description"></div>
+        </div>
+
+        <!-- Right page column: main print/copy/grants.gov buttons -->
+        <div class="grant-details-main-actions print-d-none">
+          <b-button
+            variant="primary"
+            block
+            class="mb-3"
+            :href="`https://www.grants.gov/search-results-detail/${selectedGrant.grant_id}`"
+            target="_blank"
+            rel="noopener noreferrer"
+            data-dd-action-name="view on grants.gov"
+          >
+            <b-icon icon="box-arrow-up-right" aria-hidden="true" class="mr-2" />
+            Apply on Grants.gov
+          </b-button>
+          <div class="d-flex">
+            <b-button
+              class="w-50 flex-shrink-1 mr-3"
+              variant="outline-primary"
+              @click="printPage"
             >
-              <template #cell()="data">
-                <span :class="{'text-muted font-weight-normal': data.item.displayMuted}">
-                  {{ data.value }}
-                </span>
-              </template>
-            </b-table>
-            <h3 class="mb-3">Description</h3>
-            <!-- TODO: spike on removing v-html usage https://github.com/usdigitalresponse/usdr-gost/issues/2572 -->
-            <div style="white-space: pre-line" v-html="selectedGrant.description"></div>
-          </b-col>
+              <b-icon icon="printer-fill" aria-hidden="true" class="mr-2" />
+              Print
+            </b-button>
+            <b-button
+              class="w-50 flex-shrink-1"
+              :variant="copyUrlSuccessTimeout === null ? 'outline-primary' : 'outline-success'"
+              @click="copyUrl"
+            >
+              <b-icon :icon="copyUrlSuccessTimeout === null ? 'files' : 'check2'" aria-hidden="true" class="mr-2" />
+              <span v-if="copyUrlSuccessTimeout === null">Copy Link</span>
+              <span v-else>Link Copied</span>
+            </b-button>
+          </div>
+        </div>
 
-          <!-- Right page column: apply, assign, and status actions -->
-          <b-col class="grants-details-sidebar">
-
-            <!-- Main action buttons section -->
-            <div class="mb-5 print-d-none">
-              <b-button
-                variant="primary"
-                block
-                class="mb-3"
-                :href="`https://www.grants.gov/search-results-detail/${selectedGrant.grant_id}`"
-                target="_blank"
-                rel="noopener noreferrer"
-                data-dd-action-name="view on grants.gov"
-              >
-                <b-icon icon="box-arrow-up-right" aria-hidden="true" class="mr-2" />
-                Apply on Grants.gov
+        <!-- Right page column: secondary assign grant section -->
+        <div class="grant-details-secondary-actions">
+          <!-- Assign grant section -->
+          <div class="mb-5">
+            <h3 class="mb-3">Assign Grant</h3>
+            <div class="d-flex print-d-none">
+              <v-select
+                class="flex-grow-1 mr-3"
+                v-model="selectedAgencyToAssign"
+                :options="unassignedAgencies"
+                label="name"
+                track-by="id"
+                :placeholder="`Choose ${newTerminologyEnabled ? 'team': 'agency'}`"
+                :clearable="false"
+                data-dd-action-name="select team for grant assignment"
+              />
+              <b-button variant="outline-primary" @click="assignAgenciesToGrant" :disabled="!selectedAgencyToAssign" data-dd-action-name="assign team">
+                Submit
               </b-button>
-              <div class="d-flex">
-                <b-button
-                  class="w-50 flex-shrink-1 mr-3"
-                  variant="outline-primary"
-                  @click="printPage"
-                >
-                  <b-icon icon="printer-fill" aria-hidden="true" class="mr-2" />
-                  Print
-                </b-button>
-                <b-button
-                  class="w-50 flex-shrink-1"
-                  :variant="copyUrlSuccessTimeout === null ? 'outline-primary' : 'outline-success'"
-                  @click="copyUrl"
-                >
-                  <b-icon :icon="copyUrlSuccessTimeout === null ? 'files' : 'check2'" aria-hidden="true" class="mr-2" />
-                  <span v-if="copyUrlSuccessTimeout === null">Copy Link</span>
-                  <span v-else>Link Copied</span>
-                </b-button>
-              </div>
             </div>
-
-            <!-- Assign grant section -->
-            <div class="mb-5">
-              <h3 class="mb-3">Assign Grant</h3>
-              <div class="d-flex print-d-none">
-                <v-select
-                  class="flex-grow-1 mr-3"
-                  v-model="selectedAgencyToAssign"
-                  :options="unassignedAgencies"
-                  label="name"
-                  track-by="id"
-                  :placeholder="`Choose ${newTerminologyEnabled ? 'team': 'agency'}`"
-                  :clearable="false"
-                  data-dd-action-name="select team for grant assignment"
-                />
-                <b-button variant="outline-primary" @click="assignAgenciesToGrant" :disabled="!selectedAgencyToAssign" data-dd-action-name="assign team">
-                  Submit
-                </b-button>
+            <div v-for="agency in assignedAgencies" :key="agency.id" class="d-flex justify-content-between align-items-start my-3">
+              <div class="mr-3">
+                <p class="m-0">{{ agency.name }}</p>
+                <p class="m-0 text-muted"><small>{{ formatDateTime(agency.created_at) }}</small></p>
               </div>
-              <div v-for="agency in assignedAgencies" :key="agency.id" class="d-flex justify-content-between align-items-start my-3">
-                <div class="mr-3">
-                  <p class="m-0">{{ agency.name }}</p>
-                  <p class="m-0 text-muted"><small>{{ formatDateTime(agency.created_at) }}</small></p>
-                </div>
-                <b-button-close
-                  @click="unassignAgenciesToGrant(agency)"
-                  data-dd-action-name="remove team assignment"
-                  class="print-d-none"
-                />
-              </div>
+              <b-button-close
+                @click="unassignAgenciesToGrant(agency)"
+                data-dd-action-name="remove team assignment"
+                class="print-d-none"
+              />
             </div>
+          </div>
 
-            <!-- Team status section -->
-            <div class="mb-5">
-              <h3 class="mb-3">{{newTerminologyEnabled ? 'Team': 'Agency'}} Status</h3>
-              <div class="d-flex print-d-none">
-                <v-select
-                  class="flex-grow-1 mr-3"
-                  v-model="selectedInterestedCode"
-                  :reduce="(option) => option.id"
-                  :options="interestedOptions"
-                  label="name"
-                  track-by="id"
-                  placeholder="Choose status"
-                  :selectable="selectableOption"
-                  :clearable="false"
-                  data-dd-action-name="select team status"
-                />
-                <b-button variant="outline-primary" @click="markGrantAsInterested" :disabled="!selectedInterestedCode" data-dd-action-name="submit team status">
-                  Submit
-                </b-button>
-              </div>
-              <div v-for="agency in visibleInterestedAgencies" :key="agency.id" class="d-flex justify-content-between align-items-start my-3">
-                <!-- TODO: adopt updated design for what to show on each line item here -->
-                <div>
-                  <p class="m-0">
-                    <strong>{{ agency.user_name }}</strong> updated
-                    <strong>{{ agency.agency_name }}</strong> team status to
-                    <strong>{{ agency.interested_code_name }}</strong>
-                  </p>
-                </div>
-                <b-button-close
-                  @click="unmarkGrantAsInterested(agency)"
-                  data-dd-action-name="remove team status"
-                  class="print-d-none"
-                />
-              </div>
+          <!-- Team status section -->
+          <div class="mb-5">
+            <h3 class="mb-3">{{newTerminologyEnabled ? 'Team': 'Agency'}} Status</h3>
+            <div class="d-flex print-d-none">
+              <v-select
+                class="flex-grow-1 mr-3"
+                v-model="selectedInterestedCode"
+                :reduce="(option) => option.id"
+                :options="interestedOptions"
+                label="name"
+                track-by="id"
+                placeholder="Choose status"
+                :selectable="selectableOption"
+                :clearable="false"
+                data-dd-action-name="select team status"
+              />
+              <b-button variant="outline-primary" @click="markGrantAsInterested" :disabled="!selectedInterestedCode" data-dd-action-name="submit team status">
+                Submit
+              </b-button>
             </div>
+            <div v-for="agency in visibleInterestedAgencies" :key="agency.id" class="d-flex justify-content-between align-items-start my-3">
+              <!-- TODO: adopt updated design for what to show on each line item here -->
+              <div>
+                <p class="m-0">
+                  <strong>{{ agency.user_name }}</strong> updated
+                  <strong>{{ agency.agency_name }}</strong> team status to
+                  <strong>{{ agency.interested_code_name }}</strong>
+                </p>
+              </div>
+              <b-button-close
+                @click="unmarkGrantAsInterested(agency)"
+                data-dd-action-name="remove team status"
+                class="print-d-none"
+              />
+            </div>
+          </div>
+        </div>
 
-          </b-col>
-
-        </b-row>
-      </b-container>
+      </div>
+    </b-container>
   </section>
 </template>
 
@@ -431,10 +431,31 @@ export default {
 </script>
 
 <style lang="css">
-.grants-details-sidebar {
-  flex-basis: 437px;
-  flex-grow: 0;
+.grant-details-container {
+  margin: 80px;
+  display: grid;
+  grid-template-columns: 1fr 437px;
+  grid-template-rows: auto;
+  grid-template-areas:
+    "headline  main-actions"
+    "content   secondary-actions";
+  column-gap: 90px;
+  row-gap: 48px;
 }
+.grant-details-headline {
+  grid-area: headline;
+  align-self: end;
+}
+.grant-details-content {
+  grid-area: content;
+}
+.grant-details-main-actions {
+  grid-area: main-actions;
+}
+.grant-details-secondary-actions {
+  grid-area: secondary-actions;
+}
+
 .grant-details-table tr:nth-of-type(odd) {
   /* Design color differs from default bootstrap, so making our own striped background here */
   background-color: #F9F9F9;


### PR DESCRIPTION
### Ticket #2675 
## Description

Updates the Grant Detail page overall layout so page components align as described in the figma: https://www.figma.com/file/yQx55VTr5awPYClHIJCz8y/Grant-Details?type=design&node-id=2017-27875&mode=design&t=T7gArjh1H06DndRw-4

**Review note:** The diff appears larger than the real change here. If you [ignore whitespace changes](https://github.blog/2018-05-01-ignore-white-space-in-code-review/) it should make the diff more readable. 

## Screenshots / Demo Video
<img width="1657" alt="Screenshot 2024-02-27 at 11 06 55 AM" src="https://github.com/usdigitalresponse/usdr-gost/assets/126250/8a4bcb20-bad1-46d4-9f46-d36f3abcdc00">

## Testing

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [ ] Provided ticket and description
- [ ] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers