### PR TITLE
Align eslint rules across environments

### DIFF
--- a/packages/client/.eslintrc.js
+++ b/packages/client/.eslintrc.js
@@ -12,13 +12,10 @@ module.exports = {
     parser: 'babel-eslint',
   },
   rules: {
-    'max-len': process.env.NODE_ENV === 'production' ? 'warn' : 'off',
-    // ['warn', {
-    //   // eslint-disable-next-line max-len
-    //   code: 120, comments: 120, tabWidth: 4, ignoreStrings: true, ignoreTemplateLiterals: true, ignoreRegExpLiterals: true,
-    // }],
-    'no-console': process.env.NODE_ENV === 'production' ? 'warn' : 'off',
-    'no-debugger': process.env.NODE_ENV === 'production' ? 'warn' : 'off',
+    // TODO: enable these lint rules over time
+    'max-len': 'off',
+    'no-console': 'off',
+    'no-debugger': 'off',
     'func-names': 'off',
 
     // Modern browsers have much greater support for ES6+ features than they did


### PR DESCRIPTION
### Ticket #<Enter Number Here To Auto-Link>
## Description
Github PRs show outstanding check failures on every single PR's diff page, even though the failures are global and unrelated to the change. This is added noise that devs shouldn't have to think about. 

This PR should eliminate the eslint-based warning noise by aligning the eslint rules across all environments. (Previously, `yarn lint` and `yarn pre-commit` would run eslint with the "development" env, whereas `yarn build` would run eslint with the "production" env. This caused the warnings in CI that Github would display on PRs, even though they're not displayed in the course of the standard development workflow.)

Example of eslint warnings from a different PR: 

<img width="1438" alt="image" src="https://github.com/usdigitalresponse/usdr-gost/assets/126250/ea3e1592-372a-4011-b83f-05a93c5c8ceb">

## Screenshots / Demo Video

Screenshot of the warnings from this PR after CI ran — note it's only tflint warnings, but eslint warnings have been eliminated:

<img width="1438" alt="image" src="https://github.com/usdigitalresponse/usdr-gost/assets/126250/41b8e3b0-c0f3-44d1-9835-444d524e396d">


## Testing
- Ran `yarn lint` in the client package locally, and it still passes
- Once this PR is created, CI will run, and we should be able to verify the diff page no longer shows eslint warnings

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [ ] Provided ticket and description
- [ ] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers