### PR TITLE
Add email user link to grant detail page

### DIFF
--- a/packages/client/src/views/GrantDetails.vue
+++ b/packages/client/src/views/GrantDetails.vue
@@ -131,6 +131,11 @@
                     <strong>{{ agency.agency_name }}</strong> team status to
                     <strong>{{ agency.interested_code_name }}</strong>
                   </p>
+                  <p v-if="agency.user_email">
+                    <a :href="`mailto:${ agency.user_email }`" class="text-muted">
+                      <small><b-icon icon="envelope-fill"></b-icon> {{ agency.user_email }}</small>
+                    </a>
+                  </p>
                 </div>
                 <b-button-close
                   @click="unmarkGrantAsInterested(agency)"


### PR DESCRIPTION
### Ticket #2645 
## Description
Adds an email link for interested agency listings on the grant details page. 

## Screenshots / Demo Video
<img width="1657" alt="image" src="https://github.com/usdigitalresponse/usdr-gost/assets/126250/4221fb85-f412-49b3-88b8-1ea116758411">

## Testing
Manually tested link shows up for assigned agencies, and that clicking opens an email compose in your default email client. 

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [ ] Provided ticket and description
- [ ] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers