### PR TITLE
Add user avatar to grant details page

### DIFF
--- a/packages/client/src/components/Layout.vue
+++ b/packages/client/src/components/Layout.vue
@@ -14,7 +14,7 @@
             <!-- Using 'button-content' slot -->
             <template v-if="myProfileEnabled" #button-content>
               <div class="d-inline-flex justify-content-start align-items-center" style="width: 242px">
-                <UserAvatar size="2.5rem"/>
+                <UserAvatar :user-name="loggedInUser.name" :color="loggedInUser.avatar_color" size="2.5rem"/>
                 <div class="ml-2 mr-5 text-black">
                   <p class="m-0 font-weight-bold">{{ loggedInUser.name }}</p>
                   <p class="m-0">{{ selectedTeam ? selectedTeam.name : '' }}</p>

--- a/packages/client/src/components/Modals/EditUser.vue
+++ b/packages/client/src/components/Modals/EditUser.vue
@@ -11,15 +11,21 @@
     :ok-disabled="$v.formData.$invalid"
     >
     <div class="text-center my-3">
-      <UserAvatar editable @changeColor="handleChangeColor" :userName="formData.name"/>
+      <UserAvatar :userName="formData.name" :color="formData.avatarColor" />
     </div>
     <b-form>
-       <b-form-group
-          :state="!$v.formData.name.$invalid"
-          label="Name"
-          label-for="name-input"
-          invalid-feedback="Please enter your preferred first and last name"
-        >
+      <b-form-group label="Avatar color" label-for="avatar-color">
+        <b-form-radio-group id="avatar-color" class="color-picker" v-model="formData.avatarColor" buttons>
+          <b-form-radio v-for="color in avatarColors" :key="color" :value="color" button :style="{ backgroundColor: color}" />
+        </b-form-radio-group>
+      </b-form-group>
+
+      <b-form-group
+        :state="!$v.formData.name.$invalid"
+        label="Name"
+        label-for="name-input"
+        invalid-feedback="Please enter your preferred first and last name"
+      >
         <b-form-input
           type="text"
           id="name-input"
@@ -28,7 +34,7 @@
           required
           trim
           autofocus
-        ></b-form-input>
+        />
       </b-form-group>
     </b-form>
   </b-modal>
@@ -37,7 +43,8 @@
 <script>
 import { mapGetters, mapActions } from 'vuex';
 import { required, minLength } from 'vuelidate/lib/validators';
-import UserAvatar from '../UserAvatar.vue';
+import { avatarColors } from '@/helpers/constants';
+import UserAvatar from '@/components/UserAvatar.vue';
 
 export default {
   components: {
@@ -45,6 +52,7 @@ export default {
   },
   data() {
     return {
+      avatarColors: Object.keys(avatarColors),
       formData: {
         name: null,
         avatarColor: null,
@@ -110,8 +118,19 @@ export default {
     font-size: 20px;
     font-weight: 700;
   }
-
   .footer {
     border: none;
+  }
+  #avatar-color {
+    display: grid;
+    grid-template-columns: repeat(9, 1fr);
+    justify-items: center;
+    row-gap: 10px;
+  }
+  #avatar-color .btn {
+    border: none;
+    border-radius: 5px;
+    height: 35px;
+    width: 35px;
   }
 </style>

--- a/packages/client/src/components/UserAvatar.vue
+++ b/packages/client/src/components/UserAvatar.vue
@@ -1,87 +1,30 @@
 <template>
-  <div>
-   <!-- Default avatar w/o badge: style attribute is bound to computed
-    property fixedAvatarStyles which is derived from user session data.
-    -->
-    <b-avatar v-if="!editable" :text="initials" :size="avatarSize" v-bind:style="fixedAvatarStyles" badge-variant="light">
-    </b-avatar>
-
-    <div v-if="editable">
-      <!-- Editable avatar:style attribute is bound to editableAvatarStyles
-        so changes from the color picker will be reflected -->
-      <b-avatar :text="toInitials(userName)" :size="avatarSize" v-bind:style="editableAvatarStyles" badge-variant="light">
-      </b-avatar>
-      <div class="my-4">
-        <p class="text-left">Avatar color</p>
-        <div class="color-picker">
-          <b-button v-for="(color, index) in allColors" :key="index" :style="{ backgroundColor: color }" @click="handleColorSelection(color)"></b-button>
-        </div>
-      </div>
-    </div>
-  </div>
+  <b-avatar :text="initials" :size="size" :style="colorStyles" />
 </template>
 
 <script>
-import { mapGetters } from 'vuex';
 import { avatarColors } from '@/helpers/constants';
 
 export default {
   props: {
-    size: {
-      type: String,
-      default: '5rem',
-    },
-    editable: {
-      type: Boolean,
-      default: false,
-    },
     userName: {
       type: String,
       default: '',
     },
-  },
-  data() {
-    return {
-      allColors: Object.keys(avatarColors),
-      editableAvatarStyles: null,
-    };
+    color: {
+      type: String,
+      default: Object.keys(avatarColors)[0],
+    },
+    size: {
+      type: String,
+      default: '5rem',
+    },
   },
   computed: {
-    ...mapGetters({
-      loggedInUser: 'users/loggedInUser',
-    }),
     initials() {
-      return this.toInitials(this.loggedInUser.name);
-    },
-    avatarSize() {
-      return this.size;
-    },
-    fixedAvatarStyles() {
-      return {
-        backgroundColor: this.loggedInUser.avatar_color,
-        color: avatarColors[this.loggedInUser.avatar_color],
-      };
-    },
-  },
-  created() {
-    this.editableAvatarStyles = {
-      backgroundColor: this.loggedInUser.avatar_color,
-      color: avatarColors[this.loggedInUser.avatar_color],
-    };
-  },
-  methods: {
-    handleColorSelection(bgColor) {
-      this.editableAvatarStyles = {
-        backgroundColor: bgColor,
-        color: avatarColors[bgColor],
-      };
+      if (!this.userName) return '';
 
-      this.$emit('changeColor', bgColor); // passes background color to EditUser form
-    },
-    toInitials(name) {
-      if (!name) return '';
-
-      const fullNameArr = name.split(' ');
+      const fullNameArr = this.userName.split(' ');
 
       if (fullNameArr.length < 2) return fullNameArr[0][0].toUpperCase();
 
@@ -89,22 +32,12 @@ export default {
       const lastName = fullNameArr.at(-1);
       return (firstName[0] + lastName[0]).toUpperCase();
     },
+    colorStyles() {
+      return {
+        backgroundColor: this.color,
+        color: avatarColors[this.color],
+      };
+    },
   },
 };
 </script>
-
-<style>
-.color-picker {
-  display: grid;
-  grid-template-columns: repeat(9, 1fr);
-  justify-items: center;
-  row-gap: 10px;
-}
-
-.color-picker button {
-  border: none;
-  border-radius: 5px;
-  height: 35px;
-  width: 35px;
-}
-</style>

--- a/packages/client/src/helpers/constants.js
+++ b/packages/client/src/helpers/constants.js
@@ -34,6 +34,7 @@ const billOptions = [
   'Social Security Administration',
 ];
 
+// Mapping of available avatar background colors to foreground text colors
 const avatarColors = {
   '#44337A': '#FFF',
   '#086F83': '#FFF',

--- a/packages/client/src/views/GrantDetails.vue
+++ b/packages/client/src/views/GrantDetails.vue
@@ -124,8 +124,8 @@
                 </b-button>
               </div>
               <div v-for="agency in visibleInterestedAgencies" :key="agency.id" class="d-flex justify-content-between align-items-start my-3">
-                <!-- TODO: adopt updated design for what to show on each line item here -->
-                <div>
+                <UserAvatar :user-name="agency.user_name" :color="agency.user_avatar_color" size="2.5rem" />
+                <div class="mx-3">
                   <p class="m-0">
                     <strong>{{ agency.user_name }}</strong> updated
                     <strong>{{ agency.agency_name }}</strong> team status to
@@ -153,6 +153,7 @@ import { datadogRum } from '@datadog/browser-rum';
 import { debounce } from 'lodash';
 import { newTerminologyEnabled } from '@/helpers/featureFlags';
 import { DateTime } from 'luxon';
+import UserAvatar from '@/components/UserAvatar.vue';
 
 const HEADER = '__HEADER__';
 const FAR_FUTURE_CLOSE_DATE = '2100-01-01';
@@ -161,6 +162,9 @@ const NOT_AVAILABLE_TEXT = 'Not available';
 export default {
   props: {
     selectedGrant: Object,
+  },
+  components: {
+    UserAvatar,
   },
   data() {
     return {
@@ -334,7 +338,6 @@ export default {
       getGrantAssignedAgencies: 'grants/getGrantAssignedAgencies',
       assignAgenciesToGrantAction: 'grants/assignAgenciesToGrant',
       unassignAgenciesToGrantAction: 'grants/unassignAgenciesToGrant',
-      fetchUsers: 'users/fetchUsers',
       fetchAgencies: 'agencies/fetchAgencies',
       fetchGrantDetails: 'grants/fetchGrantDetails',
     }),

--- a/packages/client/src/views/MyProfile.vue
+++ b/packages/client/src/views/MyProfile.vue
@@ -6,12 +6,12 @@
       <section style="margin-top: 4rem;">
         <b-row>
           <b-col>
-            <UserAvatar />
+            <UserAvatar :user-name="loggedInUser.name" :color="loggedInUser.avatar_color" />
           </b-col>
           <b-col cols="7">
-            <p class="mb-2 h6"><b>{{ name }}</b></p>
-            <p class="mb-2">{{ email }}</p>
-            <p class="mb-2">{{ agency }}</p>
+            <p class="mb-2 h6"><b>{{ loggedInUser.name }}</b></p>
+            <p class="mb-2">{{ loggedInUser.email }}</p>
+            <p class="mb-2">{{ loggedInUser.agency_name }}</p>
           </b-col>
           <b-col class="text-end">
             <b-button variant="primary" size="md" @click="$bvModal.show('edit-user-modal')">
@@ -78,18 +78,6 @@ export default {
     ...mapGetters({
       loggedInUser: 'users/loggedInUser',
     }),
-    name() {
-      return this.loggedInUser.name;
-    },
-    email() {
-      return this.loggedInUser.email;
-    },
-    agency() {
-      return this.loggedInUser.agency_name;
-    },
-    emailPreferences() {
-      return this.loggedInUser.emailPreferences;
-    },
   },
   methods: {
     ...mapActions({
@@ -97,7 +85,7 @@ export default {
     }),
     onUpdateEmailPreference(pref) {
       const updatedPreferences = {
-        ...this.emailPreferences,
+        ...this.loggedInUser.emailPreferences,
         [pref.key]: pref.checked ? 'SUBSCRIBED' : 'UNSUBSCRIBED',
       };
       this.updateEmailSubscriptionPreferences({
@@ -108,7 +96,7 @@ export default {
   beforeMount() {
     this.prefs.forEach((pref) => {
       // eslint-disable-next-line no-param-reassign
-      pref.checked = this.emailPreferences[pref.key] === 'SUBSCRIBED';
+      pref.checked = this.loggedInUser.emailPreferences[pref.key] === 'SUBSCRIBED';
     });
   },
 };

--- a/packages/server/src/db/index.js
+++ b/packages/server/src/db/index.js
@@ -1150,7 +1150,7 @@ async function getInterestedAgencies({ grantIds, tenantId }) {
 
     const result = await query.select(`${TABLES.grants_interested}.grant_id`, `${TABLES.grants_interested}.agency_id`,
         `${TABLES.agencies}.name as agency_name`, `${TABLES.agencies}.abbreviation as agency_abbreviation`,
-        `${TABLES.users}.id as user_id`, `${TABLES.users}.email as user_email`, `${TABLES.users}.name as user_name`,
+        `${TABLES.users}.id as user_id`, `${TABLES.users}.email as user_email`, `${TABLES.users}.name as user_name`, `${TABLES.users}.avatar_color as user_avatar_color`,
         `${TABLES.interested_codes}.id as interested_code_id`, `${TABLES.interested_codes}.name as interested_code_name`, `${TABLES.interested_codes}.status_code as interested_status_code`);
 
     return result;


### PR DESCRIPTION
### Ticket #2619 
## Description
Adds the user avatar alongside the interested grant listings on the grant details page. In order to achieve this, the PR also does some refactoring/cleanup of the `UserAvatar` component and usage sites: 

- Remove the editable flag and color picker input from the `UserAvatar` component, and instead make that part of the EditUser modal component. (This is a better separation of concerns, and also helps decouple the current logged in user from the user displayed in `UserAvatar`.)
- Update the existing "call sites" using `UserAvatar` (`Layout` for the page header, and `MyProfile` where it shows your current user settings) to pass in the `loggedInUser` data to display. 
- Add `avatar_color` to the properties queried and returned by the API for interested agencies, so it gets returned alongside their name and email. 
- Finally, update the Grant Details Page to display the `UserAvatar` of the relevant user for interested agencies

## Screenshots / Demo Video
<img width="1657" alt="Screenshot 2024-02-28 at 11 47 21 AM" src="https://github.com/usdigitalresponse/usdr-gost/assets/126250/670353a7-bdb6-4630-aca7-2f0a1ef9732d">
<img width="1657" alt="image" src="https://github.com/usdigitalresponse/usdr-gost/assets/126250/9b4ade7f-f8e2-459a-b9a9-7a991f2c09de">
<img width="1657" alt="image" src="https://github.com/usdigitalresponse/usdr-gost/assets/126250/330d75d7-f06c-4e5d-8b65-c47464193590">

## Testing
- Manually tested editing avatar details on the my profile page
- Verified relevant avatars get updated
- Verified avatars of other users are returned and displayed on grant detail page

### Automated and Unit Tests
- [ ] Added Unit tests


### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [ ] Provided ticket and description
- [ ] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers