### PR TITLE
Add GA4 property configuration for non-Production environments

### DIFF
--- a/packages/client/public/deploy-config.js
+++ b/packages/client/public/deploy-config.js
@@ -29,3 +29,7 @@ window.APP_CONFIG.featureFlags = {
 //  Empty for the dev configuration by default.
 //  Set to 'G-D5DFR7BN0N' to enable Google Analytics in dev environments.
 window.APP_CONFIG.GOOGLE_TAG_ID = '';
+
+// This only takes effect if GOOGLE_TAG_ID is non-empty and can generally be ignored.
+// See https://support.google.com/analytics/answer/7201382 for usage information.
+window.APP_CONFIG.GOOGLE_ANALYTICS_DEBUG = true;

--- a/packages/client/public/deploy-config.js
+++ b/packages/client/public/deploy-config.js
@@ -26,5 +26,6 @@ window.APP_CONFIG.featureFlags = {
 };
 
 // Setting a GOOGLE_TAG_ID enables Google Analytics.
-// Empty for the dev configuration since there is not yet a Google Analytics property for dev.
+// Empty for the dev configuration by default.
+// Set to 'G-D5DFR7BN0N' to enable Google Analytics in dev environments.
 window.APP_CONFIG.GOOGLE_TAG_ID = '';

--- a/packages/client/public/deploy-config.js
+++ b/packages/client/public/deploy-config.js
@@ -31,5 +31,5 @@ window.APP_CONFIG.featureFlags = {
 window.APP_CONFIG.GOOGLE_TAG_ID = '';
 
 // This only takes effect if GOOGLE_TAG_ID is non-empty and can generally be ignored.
-// See https://support.google.com/analytics/answer/7201382 for usage information.
+//  See https://support.google.com/analytics/answer/7201382 for usage information.
 window.APP_CONFIG.GOOGLE_ANALYTICS_DEBUG = true;

--- a/packages/client/public/deploy-config.js
+++ b/packages/client/public/deploy-config.js
@@ -26,6 +26,6 @@ window.APP_CONFIG.featureFlags = {
 };
 
 // Setting a GOOGLE_TAG_ID enables Google Analytics.
-// Empty for the dev configuration by default.
-// Set to 'G-D5DFR7BN0N' to enable Google Analytics in dev environments.
+//  Empty for the dev configuration by default.
+//  Set to 'G-D5DFR7BN0N' to enable Google Analytics in dev environments.
 window.APP_CONFIG.GOOGLE_TAG_ID = '';

--- a/packages/client/src/helpers/gtag.js
+++ b/packages/client/src/helpers/gtag.js
@@ -14,7 +14,10 @@
 export function gtagConfig(config) {
   // See index.html for the definition of the gtag function.
   if (typeof window.gtag === 'function' && window.APP_CONFIG?.GOOGLE_TAG_ID) {
-    window.gtag('config', window.APP_CONFIG.GOOGLE_TAG_ID, config);
+    window.gtag('config', window.APP_CONFIG.GOOGLE_TAG_ID, {
+      ...(window.APP_CONFIG?.GOOGLE_ANALYTICS_DEBUG ? { debug_mode: true } : {}),
+      ...config,
+    });
   }
 }
 

--- a/packages/client/tests/unit/helpers/gtag.spec.js
+++ b/packages/client/tests/unit/helpers/gtag.spec.js
@@ -51,5 +51,15 @@ describe('gtag', () => {
       expect(() => setUserForGoogleAnalytics(user)).to.not.throw();
       expect(observedGtagArgs).to.be.null;
     });
+    it('enables GA debug mode when instructed via APP_CONFIG', () => {
+      window.APP_CONFIG.GOOGLE_ANALYTICS_DEBUG = true;
+      setUserForGoogleAnalytics(user);
+      expect(observedGtagArgs[2]).to.have.property('debug_mode', true);
+    });
+    it('disables GA debug mode when not instructed via APP_CONFIG', () => {
+      window.APP_CONFIG.GOOGLE_ANALYTICS_DEBUG = undefined;
+      setUserForGoogleAnalytics(user);
+      expect(observedGtagArgs[2]).to.not.have.property('debug_mode');
+    });
   });
 });

--- a/terraform/prod.tfvars
+++ b/terraform/prod.tfvars
@@ -52,7 +52,7 @@ website_feature_flags = {
   newGrantsDetailPageEnabled = false,
 }
 
-// Google Analytics Account ID: 233192355, Property ID: 321194851
+// Google Analytics Account ID: 233192355, Property ID: 321194851, Stream ID: 3802896350
 website_google_tag_id = "G-WCDTMFM6RG"
 
 // ECS Cluster

--- a/terraform/staging.tfvars
+++ b/terraform/staging.tfvars
@@ -49,6 +49,9 @@ website_feature_flags = {
   newGrantsDetailPageEnabled = false,
 }
 
+// Google Analytics Account ID: 233192355, Property ID: 429910307, Stream ID: 7590745080
+website_google_tag_id = "G-D5DFR7BN0N"
+
 // ECS Cluster
 cluster_container_insights_enabled = true
 


### PR DESCRIPTION
### Ticket #2480 (prerequisite to #2589)
## Description

This PR accompanies the creation of a new Google Analytics property dedicated for non-Production usage. The motivation (wisely suggested by @sanason) is to provide a safe default for development use, which will hopefully discourage folks from using the Production property in non-Production environments (which would risk skewing its data).

## Screenshots / Demo Video

Not much to see here.

## Testing

1. Update `packages/client/public/deploy-config.js` so that `window.APP_CONFIG.GOOGLE_TAG_ID` is set to the property ID provided by the preceding line's comment.
2. You may also need to enable third-party cookies in your browser (or use a private/incognito browsing window).
3. Navigate to the Grant Finder client app in your browser and perform some actions.
4. Observe that network requests are being made to https://www.google-analytics.com/g/collect.

If using Chrome, you may optionally install [this extension](https://chromewebstore.google.com/detail/tag-assistant-companion/jmekfmbnaedfebfnmakmokmlfpblbfdm) for richer debugging information.

### Automated and Unit Tests
- [x] Added Unit tests

### Manual tests for Reviewer
- [x] Added steps to test feature/functionality manually

## Checklist
- [x] Provided ticket and description
- [ ] Provided screenshots/demo
- [x] Provided testing information
- [x] Provided adequate test coverage for all new code
- [x] Added PR reviewers