### PR TITLE
Drop the column grants.raw_body.

### DIFF
--- a/packages/server/migrations/20240308203616_drop_grants_raw_body_column.js
+++ b/packages/server/migrations/20240308203616_drop_grants_raw_body_column.js
@@ -1,0 +1,20 @@
+/**
+ * The text column `raw_body` was replaced with a jsonb column `raw_body_json` in a previous migration.
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function (knex) {
+    return knex.schema.table('grants', (table) => {
+        table.dropColumn('raw_body');
+    });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function (knex) {
+    return knex.schema.table('grants', (table) => {
+        table.text('raw_body');
+    });
+};

--- a/packages/server/migrations/20240308203616_drop_grants_raw_body_column.js
+++ b/packages/server/migrations/20240308203616_drop_grants_raw_body_column.js
@@ -16,5 +16,9 @@ exports.up = function (knex) {
 exports.down = function (knex) {
     return knex.schema.table('grants', (table) => {
         table.text('raw_body');
-    });
+    }).raw(`
+        UPDATE grants 
+          SET raw_body = raw_body_json::text 
+        WHERE raw_body_json IS NOT NULL;
+    `);
 };


### PR DESCRIPTION
## Description
This is a code clean-up PR. It contains a migration to drop the now redundant column `grants.raw_body`.

In https://github.com/usdigitalresponse/usdr-gost/pull/2435, we added a jsonb column grants.raw_body_json and populated it from the text column grants.raw_body. In https://github.com/usdigitalresponse/usdr-gost/pull/2454, we updated the grant ingestor to write to raw_body_json instead of to raw_body. In https://github.com/usdigitalresponse/usdr-gost/pull/2720, we deleted all code references to raw_body. It should be safe to drop the column now.

## Screenshots / Demo Video
N/A

## Testing
Run the migration, start up the app, click around and check that nothing is broken.

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [x] Provided ticket and description
- [ ] Provided screenshots/demo
- [x] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers