### PR TITLE
Flag DB migrations in release notes

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -28,6 +28,10 @@ categories:
     collapse-after: 10
     labels:
       - bug
+  - title: 🗂️ Database Changes
+    collapse-after: 1
+    labels:
+      - database-changes
   - title: 📖 Documentation improvements
     collapse-after: 10
     labels:


### PR DESCRIPTION
## Description

This PR updates the auto-generated release notes config so that PRs with the https://github.com/usdigitalresponse/usdr-gost/labels/database-changes label are grouped under a common heading. This should make it easier for releasers to check whether any Knex migrations are part of a release, which is necessary until we have an automated migration process.

## Screenshots / Demo Video

Sneak preview ahead of #2750:
![image](https://github.com/usdigitalresponse/usdr-gost/assets/1851017/e76dd0a2-744b-4271-8c4a-b4a564b7ece1)