### PR TITLE
Tweak Terraform code to work when run against blank environment.

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -213,6 +213,7 @@ module "consume_grants" {
   source                   = "./modules/gost_consume_grants"
   namespace                = var.namespace
   permissions_boundary_arn = local.permissions_boundary_arn
+  depends_on               = [aws_ecs_cluster.default]
 
   # Networking
   subnet_ids         = local.private_subnet_ids
@@ -254,6 +255,7 @@ module "arpa_audit_report" {
   source                   = "./modules/sqs_consumer_task"
   namespace                = "${var.namespace}-arpa_audit_report"
   permissions_boundary_arn = local.permissions_boundary_arn
+  depends_on               = [aws_ecs_cluster.default]
 
   # Networking
   subnet_ids         = local.private_subnet_ids
@@ -342,6 +344,7 @@ module "arpa_treasury_report" {
   source                   = "./modules/sqs_consumer_task"
   namespace                = "${var.namespace}-treasury_report"
   permissions_boundary_arn = local.permissions_boundary_arn
+  depends_on               = [aws_ecs_cluster.default]
 
   # Networking
   subnet_ids         = local.private_subnet_ids

--- a/terraform/modules/gost_api/ecs_exec.tf
+++ b/terraform/modules/gost_api/ecs_exec.tf
@@ -3,34 +3,39 @@ module "ecs_exec_policy" {
   version = "2.0.1"
   context = module.this.context
 
-  iam_policy_statements = {
-    AllowExec = {
-      effect = "Allow"
-      actions = [
-        "ssmmessages:CreateControlChannel",
-        "ssmmessages:CreateDataChannel",
-        "ssmmessages:OpenControlChannel",
-        "ssmmessages:OpenDataChannel"
+  iam_policy = [
+    {
+      statements = [
+        {
+          sid    = "AllowExec"
+          effect = "Allow"
+          actions = [
+            "ssmmessages:CreateControlChannel",
+            "ssmmessages:CreateDataChannel",
+            "ssmmessages:OpenControlChannel",
+            "ssmmessages:OpenDataChannel"
+          ]
+          resources = ["*"]
+        },
+        {
+          sid       = "InventoryLogGroupsForExec"
+          effect    = "Allow"
+          actions   = ["logs:DescribeLogGroups"]
+          resources = ["*"]
+        },
+        {
+          sid    = "WriteExecLogs"
+          effect = "Allow"
+          actions = [
+            "logs:CreateLogStream",
+            "logs:DescribeLogStreams",
+            "logs:PutLogEvents",
+          ]
+          resources = [
+            for arn in aws_cloudwatch_log_group.default[*].arn : "${arn}:log-stream:*"
+          ]
+        }
       ]
-      resources = ["*"]
     }
-
-    InventoryLogGroupsForExec = {
-      effect    = "Allow"
-      actions   = ["logs:DescribeLogGroups"]
-      resources = ["*"]
-    }
-
-    WriteExecLogs = {
-      effect = "Allow"
-      actions = [
-        "logs:CreateLogStream",
-        "logs:DescribeLogStreams",
-        "logs:PutLogEvents",
-      ]
-      resources = [
-        for arn in aws_cloudwatch_log_group.default[*].arn : "${arn}:log-stream:*"
-      ]
-    }
-  }
+  ]
 }

--- a/terraform/modules/gost_api/email.tf
+++ b/terraform/modules/gost_api/email.tf
@@ -15,24 +15,29 @@ module "send_emails_policy" {
 
   name = "send-emails"
 
-  iam_policy_statements = {
-    SendEmails = {
-      effect = "Allow"
-      actions = [
-        "SES:SendEmail",
-        "SES:SendRawEmail",
-      ]
-      resources = concat(
-        [data.aws_ses_domain_identity.notifications.arn],
-        values(aws_ses_email_identity.sandbox_mode_recipients)[*].arn,
-      )
-      conditions = [
+  iam_policy = [
+    {
+      statements = [
         {
-          test     = "StringLike"
-          variable = "ses:FromAddress"
-          values   = [var.notifications_email_address]
+          sid    = "SendEmails"
+          effect = "Allow"
+          actions = [
+            "SES:SendEmail",
+            "SES:SendRawEmail",
+          ]
+          resources = concat(
+            [data.aws_ses_domain_identity.notifications.arn],
+            values(aws_ses_email_identity.sandbox_mode_recipients)[*].arn,
+          )
+          conditions = [
+            {
+              test     = "StringLike"
+              variable = "ses:FromAddress"
+              values   = [var.notifications_email_address]
+            }
+          ]
         }
       ]
     }
-  }
+  ]
 }

--- a/terraform/modules/gost_api/logs.tf
+++ b/terraform/modules/gost_api/logs.tf
@@ -12,21 +12,26 @@ module "write_api_logs_policy" {
 
   name = "write-logs"
 
-  iam_policy_statements = {
-    WriteLogs = {
-      effect = "Allow"
-      actions = [
-        "logs:CreateLogStream",
-        "logs:DescribeLogStreams",
-        "logs:PutLogEvents",
+  iam_policy = [
+    {
+      statements = [
+        {
+          sid    = "WriteLogs"
+          effect = "Allow"
+          actions = [
+            "logs:CreateLogStream",
+            "logs:DescribeLogStreams",
+            "logs:PutLogEvents",
+          ]
+          resources = flatten([
+            for arn in aws_cloudwatch_log_group.default[*].arn :
+            [
+              arn,
+              "${arn}:log-stream:*"
+            ]
+          ])
+        }
       ]
-      resources = flatten([
-        for arn in aws_cloudwatch_log_group.default[*].arn :
-        [
-          arn,
-          "${arn}:log-stream:*"
-        ]
-      ])
     }
-  }
+  ]
 }

--- a/terraform/modules/gost_api/postgres.tf
+++ b/terraform/modules/gost_api/postgres.tf
@@ -3,11 +3,16 @@ module "connect_to_postgres_policy" {
   version = "2.0.1"
   context = module.this.context
 
-  iam_policy_statements = {
-    DBAccess = {
-      effect    = "Allow"
-      actions   = ["rds-db:connect"]
-      resources = var.rds_db_connect_resources
+  iam_policy = [
+    {
+      statements = [
+        {
+          sid       = "DBAccess"
+          effect    = "Allow"
+          actions   = ["rds-db:connect"]
+          resources = var.rds_db_connect_resources
+        }
+      ]
     }
-  }
+  ]
 }

--- a/terraform/modules/gost_api/secrets.tf
+++ b/terraform/modules/gost_api/secrets.tf
@@ -48,27 +48,33 @@ module "decrypt_secrets_policy" {
 
   name = "decrypt-secrets"
 
-  iam_policy_statements = {
-    DecryptWithKMS = {
-      effect = "Allow"
-      actions = [
-        "kms:Decrypt",
-      ]
-      resources = [
-        data.aws_kms_key.ssm.arn,
+  iam_policy = [
+    {
+      statements = [
+        {
+          sid    = "DecryptWithKMS"
+          effect = "Allow"
+          actions = [
+            "kms:Decrypt",
+          ]
+          resources = [
+            data.aws_kms_key.ssm.arn,
+          ]
+        },
+        {
+          sid    = "GetSecretParameters"
+          effect = "Allow"
+          actions = [
+            "ssm:GetParameters",
+            "secretsmanager:GetSecretValue",
+          ]
+          resources = compact([
+            join("", data.aws_ssm_parameter.datadog_api_key[*].arn),
+            join("", aws_ssm_parameter.postgres_connection_string[*].arn),
+            join("", aws_ssm_parameter.cookie_secret[*].arn),
+          ])
+        }
       ]
     }
-    GetSecretParameters = {
-      effect = "Allow"
-      actions = [
-        "ssm:GetParameters",
-        "secretsmanager:GetSecretValue",
-      ]
-      resources = compact([
-        join("", data.aws_ssm_parameter.datadog_api_key[*].arn),
-        join("", aws_ssm_parameter.postgres_connection_string[*].arn),
-        join("", aws_ssm_parameter.cookie_secret[*].arn),
-      ])
-    }
-  }
+  ]
 }

--- a/terraform/modules/gost_api/storage.tf
+++ b/terraform/modules/gost_api/storage.tf
@@ -58,14 +58,19 @@ module "access_arpa_reports_bucket_policy" {
 
   name = "access_arpa_reports_bucket"
 
-  iam_policy_statements = {
-    ReadWriteBucketObjects = {
-      effect = "Allow"
-      actions = [
-        "s3:PutObject",
-        "s3:GetObject",
+  iam_policy = [
+    {
+      statements = [
+        {
+          sid    = "ReadWriteBucketObjects"
+          effect = "Allow"
+          actions = [
+            "s3:PutObject",
+            "s3:GetObject",
+          ]
+          resources = ["${module.arpa_audit_reports_bucket.bucket_arn}/*"]
+        }
       ]
-      resources = ["${module.arpa_audit_reports_bucket.bucket_arn}/*"]
     }
-  }
+  ]
 }

--- a/terraform/modules/gost_website/storage.tf
+++ b/terraform/modules/gost_website/storage.tf
@@ -18,33 +18,39 @@ module "cloudfront_to_origin_bucket_access_policy" {
   version = "2.0.1"
   context = module.s3_label.context
 
-  iam_policy_statements = {
-    S3GetObjectForCloudFront = {
-      effect  = "Allow"
-      actions = ["s3:GetObject"]
-      resources = [
-        "${module.origin_bucket.bucket_arn}${var.origin_bucket_dist_path}/*",
-        "${module.origin_bucket.bucket_arn}${var.origin_bucket_config_path}/${var.origin_config_filename}",
-      ]
-      principals = [
+  iam_policy = [
+    {
+      statements = [
         {
-          type        = "AWS"
-          identifiers = [aws_cloudfront_origin_access_identity.default.iam_arn]
+          sid     = "S3GetObjectForCloudFront"
+          effect  = "Allow"
+          actions = ["s3:GetObject"]
+          resources = [
+            "${module.origin_bucket.bucket_arn}${var.origin_bucket_dist_path}/*",
+            "${module.origin_bucket.bucket_arn}${var.origin_bucket_config_path}/${var.origin_config_filename}",
+          ]
+          principals = [
+            {
+              type        = "AWS"
+              identifiers = [aws_cloudfront_origin_access_identity.default.iam_arn]
+            },
+          ]
         },
+        {
+          sid       = "S3ListBucketForCloudFront"
+          effect    = "Allow"
+          actions   = ["s3:ListBucket"]
+          resources = [module.origin_bucket.bucket_arn]
+          principals = [
+            {
+              type        = "AWS"
+              identifiers = [aws_cloudfront_origin_access_identity.default.iam_arn]
+            },
+          ]
+        }
       ]
     }
-    S3ListBucketForCloudFront = {
-      effect    = "Allow"
-      actions   = ["s3:ListBucket"]
-      resources = [module.origin_bucket.bucket_arn]
-      principals = [
-        {
-          type        = "AWS"
-          identifiers = [aws_cloudfront_origin_access_identity.default.iam_arn]
-        },
-      ]
-    }
-  }
+  ]
 }
 
 module "github_deploy_to_origin_bucket_policy" {
@@ -52,21 +58,26 @@ module "github_deploy_to_origin_bucket_policy" {
   version = "2.0.1"
   context = module.s3_label.context
 
-  iam_policy_statements = {
-    S3GetObjectForCloudFront = {
-      effect  = "Allow"
-      actions = ["s3:GetObject"]
-      resources = [
-        "${module.origin_bucket.bucket_arn}${var.origin_bucket_dist_path}/*",
-      ]
-      principals = [
+  iam_policy = [
+    {
+      statements = [
         {
-          type        = "AWS"
-          identifiers = [aws_cloudfront_origin_access_identity.default.iam_arn]
-        },
+          sid     = "S3GetObjectForCloudFront"
+          effect  = "Allow"
+          actions = ["s3:GetObject"]
+          resources = [
+            "${module.origin_bucket.bucket_arn}${var.origin_bucket_dist_path}/*",
+          ]
+          principals = [
+            {
+              type        = "AWS"
+              identifiers = [aws_cloudfront_origin_access_identity.default.iam_arn]
+            },
+          ]
+        }
       ]
     }
-  }
+  ]
 }
 
 module "origin_bucket" {


### PR DESCRIPTION
## Description
While working on #2879 , I've been experimenting with using my own AWS account as a sandbox environment in which to test Terraform code. I [saw in Slack](https://usdigitalresponse.slack.com/archives/C0324KDQSCR/p1699478946709889) that @dysmento had tried this earlier. I've run into a couple of issues that I expect only occur when building the infrastructure from scratch. I don't know that it actually matters that we can build from scratch, but this PR tries to fix them because why not?

**Error 1:**
I received these error messages while running `terraform plan`.

```
│ Error: reading ECS Cluster (gost-sandbox): INACTIVE
│
│   with module.consume_grants.data.aws_ecs_cluster.default,
│   on modules/gost_consume_grants/main.tf line 23, in data "aws_ecs_cluster" "default":
│   23: data "aws_ecs_cluster" "default" {
│
╵
╷
│ Error: reading ECS Cluster (gost-sandbox): INACTIVE
│
│   with module.arpa_treasury_report.data.aws_ecs_cluster.default,
│   on modules/sqs_consumer_task/main.tf line 23, in data "aws_ecs_cluster" "default":
│   23: data "aws_ecs_cluster" "default" {
│
╵
╷
│ Error: reading ECS Cluster (gost-sandbox): INACTIVE
│
│   with module.arpa_audit_report.data.aws_ecs_cluster.default,
│   on modules/sqs_consumer_task/main.tf line 23, in data "aws_ecs_cluster" "default":
│   23: data "aws_ecs_cluster" "default" {
│
```

These were fixed by adding `depends_on  = [aws_ecs_cluster.default]` to the definitions of these 3 modules.

**Error 2:**
I also saw multiple instances of the error reported by @dysmento .

```
│ Error: Invalid count argument
│
│   on .terraform/modules/api.access_arpa_reports_bucket_policy/main.tf line 24, in data "aws_iam_policy_document" "policy":
│   24:   count = local.enabled ? length(local.policy) : 0
│
│ The "count" value depends on resource attributes that cannot be determined until apply, so Terraform cannot predict how many instances will be created. To work around
│ this, use the -target argument to first apply only the resources that the count depends on.

```

These errors occur wherever:

1. The `2.0.1` version of the module `cloudposse/iam-policy/aws` is used AND
2. The code in `iam_policy_statements` refers to some resource that is to be built by Terraform

So for instance:
```
module "access_arpa_reports_bucket_policy" {
  source  = "cloudposse/iam-policy/aws"
  version = "2.0.1"
  context = module.s3_label.context

  name = "access_arpa_reports_bucket"

  iam_policy_statements = {
    ReadWriteBucketObjects = {
      effect = "Allow"
      actions = [
        "s3:PutObject",
        "s3:GetObject",
      ]
      resources = ["${module.arpa_audit_reports_bucket.bucket_arn}/*"]
    }
  }
}
```

It turns out that the `iam_policy_statements` input [was deprecated](https://github.com/cloudposse/terraform-aws-iam-policy?tab=readme-ov-file#input_iam_policy_statements) in version 2.0.1 of this module, in favor of a new `iam_policy` input. The deprecation is not entirely backwards compatible - the module now tries to compute a `count` that requires evaluating the `iam_policy_statements` block and thus generates this error. The fix is to update all the places where we use version 2.0.1 to use the new `iam_policy` input instead.

## Screenshots / Demo Video
N/A

## Testing
With these changes, I got `terraform plan` working in my AWS account but `terraform apply` is a different matter. Ultimately, this will need to be tested on staging.

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [ ] Provided ticket and description
- [ ] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers