### PR TITLE
Delete code for the old grants digest.

### DIFF
--- a/packages/server/__tests__/api/agencies.test.js
+++ b/packages/server/__tests__/api/agencies.test.js
@@ -2,7 +2,6 @@ const { expect } = require('chai');
 const sinon = require('sinon');
 const { getSessionCookie, makeTestServer } = require('./utils');
 const emailService = require('../../src/lib/email/service-email');
-const email = require('../../src/lib/email');
 const {
     createAgency, createUser, deleteUser, deleteAgency,
 } = require('../../src/db');
@@ -175,23 +174,6 @@ describe('`/api/organizations/:organizationId/agencies` endpoint', () => {
             console.log(JSON.stringify(subAgency));
             const response = await deleteRequest(subAgency);
             expect(response.status).to.equal(200);
-        });
-    });
-
-    context('GET organizations/:organizationId/agencies/sendDigestEmail', () => {
-        it('kicks off the digest email for usdr admin users', async () => {
-            const sendFake = sinon.fake.returns('foo');
-            sinon.replace(email, 'sendGrantDigest', sendFake);
-            const response = await fetchApi('/agencies/sendDigestEmail', agencies.admin.own, fetchOptions.admin);
-            expect(response.statusText).to.equal('OK');
-            expect(sendFake.getCalls()[0].firstArg.name).to.equal('USDR');
-            expect(sendFake.calledOnce).to.equal(true);
-        });
-        it('is forbidden for non-usdr admin users', async () => {
-            const sendFake = sinon.fake.returns('foo');
-            sinon.replace(email, 'sendGrantDigest', sendFake);
-            const response = await fetchApi('/agencies/sendDigestEmail', agencies.admin.own, fetchOptions.nonUSDRAdmin);
-            expect(response.statusText).to.equal('Forbidden');
         });
     });
 

--- a/packages/server/__tests__/db/db.test.js
+++ b/packages/server/__tests__/db/db.test.js
@@ -797,53 +797,6 @@ describe('db', () => {
         });
     });
 
-    context('getAgenciesSubscribedToDigest', () => {
-        beforeEach(() => {
-            this.clockFn = (date) => sinon.useFakeTimers(new Date(date));
-            this.clock = this.clockFn('2021-08-06');
-        });
-        afterEach(() => {
-            this.clock.restore();
-        });
-        it('returns agencies with keywords and eligibility codes setup with explicit subscriptions setup', async () => {
-            /* ensure that admin user is subscribed to all notifications */
-            await db.setUserEmailSubscriptionPreference(fixtures.users.adminUser.id, fixtures.users.adminUser.agency_id);
-
-            /* ensure that staff user is not subscribed to any notifications */
-            const emailUnsubscribePreference = Object.assign(
-                ...Object.values(emailConstants.notificationType).map(
-                    (k) => ({ [k]: emailConstants.emailSubscriptionStatus.unsubscribed }),
-                ),
-            );
-            await db.setUserEmailSubscriptionPreference(fixtures.users.staffUser.id, fixtures.users.staffUser.agency_id, emailUnsubscribePreference);
-
-            const result = await db.getAgenciesSubscribedToDigest();
-            expect(result.length).to.equal(1);
-            expect(result[0].name).to.equal('State Board of Accountancy');
-            expect(result[0].recipients.length).to.equal(1);
-            expect(result[0].recipients[0]).to.equal(fixtures.users.adminUser.email);
-
-            await knex('email_subscriptions').del();
-        });
-        it('returns agencies with keywords and eligibility codes setup with default subscribed', async () => {
-            /* ensure that staff user is not subscribed to any notifications */
-            const emailUnsubscribePreference = Object.assign(
-                ...Object.values(emailConstants.notificationType).map(
-                    (k) => ({ [k]: emailConstants.emailSubscriptionStatus.unsubscribed }),
-                ),
-            );
-            await db.setUserEmailSubscriptionPreference(fixtures.users.staffUser.id, fixtures.users.staffUser.agency_id, emailUnsubscribePreference);
-
-            const result = await db.getAgenciesSubscribedToDigest();
-            expect(result.length).to.equal(1);
-            expect(result[0].name).to.equal('State Board of Accountancy');
-            expect(result[0].recipients.length).to.equal(1);
-            expect(result[0].recipients[0]).to.equal(fixtures.users.adminUser.email);
-
-            await knex('email_subscriptions').del();
-        });
-    });
-
     context('getNewGrantsForAgency', () => {
         beforeEach(() => {
             this.clockFn = (date) => sinon.useFakeTimers(new Date(date));

--- a/packages/server/__tests__/email/email.test.js
+++ b/packages/server/__tests__/email/email.test.js
@@ -10,7 +10,6 @@ const fixtures = require('../db/seeds/fixtures');
 const db = require('../../src/db');
 const awsTransport = require('../../src/lib/gost-aws');
 const emailConstants = require('../../src/lib/email/constants');
-const knex = require('../../src/db/connection');
 
 const {
     TEST_EMAIL_RECIPIENT,
@@ -316,28 +315,6 @@ describe('Email sender', () => {
             expect(sendFake.firstCall.firstArg.emailHTML).contains(body);
         });
     });
-    context('saved search grant digest email', () => {
-        beforeEach(async () => {
-            this.clockFn = (date) => sinon.useFakeTimers(new Date(date));
-            this.clock = this.clockFn('2021-08-06');
-        });
-        afterEach(async () => {
-            this.clock.restore();
-        });
-        it('buildAndSendGrantDigest sends grants for all subscribed agencies', async () => {
-            const sendFake = sinon.fake.returns('foo');
-            sinon.replace(email, 'sendGrantDigest', sendFake);
-
-            /* ensure that admin user is subscribed to all notifications */
-            await db.setUserEmailSubscriptionPreference(fixtures.users.adminUser.id, fixtures.users.adminUser.agency_id);
-
-            await email.buildAndSendGrantDigest();
-
-            /* only fixtures.agency.accountancy has eligibility-codes, keywords, and users that match an existing grant */
-            expect(sendFake.calledOnce).to.equal(true);
-            await knex('email_subscriptions').del();
-        });
-    });
     context('grant digest email', () => {
         beforeEach(async () => {
             this.clockFn = (date) => sinon.useFakeTimers(new Date(date));
@@ -345,19 +322,6 @@ describe('Email sender', () => {
         });
         afterEach(async () => {
             this.clock.restore();
-        });
-        it('buildAndSendGrantDigest sends grants for all subscribed agencies', async () => {
-            const sendFake = sinon.fake.returns('foo');
-            sinon.replace(email, 'sendGrantDigest', sendFake);
-
-            /* ensure that admin user is subscribed to all notifications */
-            await db.setUserEmailSubscriptionPreference(fixtures.users.adminUser.id, fixtures.users.adminUser.agency_id);
-
-            await email.buildAndSendGrantDigest();
-
-            /* only fixtures.agency.accountancy has eligibility-codes, keywords, and users that match an existing grant */
-            expect(sendFake.calledOnce).to.equal(true);
-            await knex('email_subscriptions').del();
         });
         it('sendGrantDigest sends no email when there are no grants to send', async () => {
             const sendFake = sinon.fake.returns('foo');

--- a/packages/server/__tests__/scripts/sendGrantDigestEmail.test.js
+++ b/packages/server/__tests__/scripts/sendGrantDigestEmail.test.js
@@ -5,15 +5,11 @@ const sendGrantDigestEmail = require('../../src/scripts/sendGrantDigestEmail').m
 
 describe('sendGrantDigestEmail script', () => {
     const sandbox = sinon.createSandbox();
-    let buildAndSendGrantDigestFake;
     let buildAndSendUserSavedSearchGrantDigestFake;
 
     beforeEach(() => {
         process.env.ENABLE_GRANT_DIGEST_SCHEDULED_TASK = 'true';
-        process.env.ENABLE_GRANTS_DIGEST = 'true';
         process.env.ENABLE_SAVED_SEARCH_GRANTS_DIGEST = 'true';
-        buildAndSendGrantDigestFake = sandbox.fake();
-        sandbox.replace(email, 'buildAndSendGrantDigest', buildAndSendGrantDigestFake);
         buildAndSendUserSavedSearchGrantDigestFake = sandbox.fake();
         sandbox.replace(email, 'buildAndSendUserSavedSearchGrantDigest', buildAndSendUserSavedSearchGrantDigestFake);
     });
@@ -24,28 +20,18 @@ describe('sendGrantDigestEmail script', () => {
 
     it('triggers sending digest emails when flags are on', async () => {
         await sendGrantDigestEmail();
-        expect(buildAndSendGrantDigestFake.called).to.equal(true);
         expect(buildAndSendUserSavedSearchGrantDigestFake.called).to.equal(true);
     });
 
     it('triggers no emails when scheduled task flag is off', async () => {
         process.env.ENABLE_GRANT_DIGEST_SCHEDULED_TASK = 'false';
         await sendGrantDigestEmail();
-        expect(buildAndSendGrantDigestFake.called).to.equal(false);
         expect(buildAndSendUserSavedSearchGrantDigestFake.called).to.equal(false);
-    });
-
-    it('skips buildAndSendGrantDigest when that email flag is off', async () => {
-        process.env.ENABLE_GRANTS_DIGEST = 'false';
-        await sendGrantDigestEmail();
-        expect(buildAndSendGrantDigestFake.called).to.equal(false);
-        expect(buildAndSendUserSavedSearchGrantDigestFake.called).to.equal(true);
     });
 
     it('skips buildAndSendUserSavedSearchGrantDigest when that email flag is off', async () => {
         process.env.ENABLE_SAVED_SEARCH_GRANTS_DIGEST = 'false';
         await sendGrantDigestEmail();
-        expect(buildAndSendGrantDigestFake.called).to.equal(true);
         expect(buildAndSendUserSavedSearchGrantDigestFake.called).to.equal(false);
     });
 });

--- a/packages/server/src/index.js
+++ b/packages/server/src/index.js
@@ -26,14 +26,6 @@ if (process.env.ENABLE_GRANTS_SCRAPER === 'true') {
     job.start();
 }
 
-if (process.env.ENABLE_GRANTS_DIGEST === 'true' && process.env.ENABLE_GRANT_DIGEST_SCHEDULED_TASK !== 'true') {
-    const generateGrantDigestCron = new CronJob(
-        // once per day at 12:00 UTC
-        '0 0 12 * * *', emailService.buildAndSendGrantDigest,
-    );
-    generateGrantDigestCron.start();
-}
-
 if (process.env.ENABLE_SAVED_SEARCH_GRANTS_DIGEST === 'true' && process.env.ENABLE_GRANT_DIGEST_SCHEDULED_TASK !== 'true') {
     const generateSavedSearchGrantDigestCron = new CronJob(
         // once per day at 13:00 UTC

--- a/packages/server/src/lib/email.js
+++ b/packages/server/src/lib/email.js
@@ -439,28 +439,6 @@ async function buildAndSendUserSavedSearchGrantDigest(userId, openDate) {
     console.log(`Successfully built and sent grants digest emails for ${inputs.length} saved searches on ${openDate}`);
 }
 
-async function buildAndSendGrantDigest() {
-    const openDate = moment().subtract(1, 'day').format('YYYY-MM-DD');
-    console.log(`Building and sending Grants Digest email for all agencies on ${openDate}`);
-    /*
-    1. get all agencies with notificaiton turned on (temporarily get all agencies with a custom keyword)
-    2. for each agency
-        call sendGrantDigest
-    */
-    const agencies = await db.getAgenciesSubscribedToDigest(openDate);
-    const inputs = [];
-    agencies.forEach((agency) => inputs.push({
-        name: agency.name,
-        matchedGrants: agency.matched_grants,
-        matchedGrantsTotal: agency.matched_grants.length,
-        recipients: agency.recipients,
-        openDate,
-    }));
-    await asyncBatch(inputs, module.exports.sendGrantDigest, 2);
-
-    console.log(`Successfully built and sent grants digest emails for ${openDate}`);
-}
-
 async function sendAsyncReportEmail(recipient, signedUrl, reportType) {
     const formattedBodyTemplate = fileSystem.readFileSync(path.join(__dirname, '../static/email_templates/_formatted_body.html'));
 
@@ -495,7 +473,6 @@ module.exports = {
     buildGrantDetail,
     sendGrantAssignedNotficationForAgency,
     buildAndSendUserSavedSearchGrantDigest,
-    buildAndSendGrantDigest,
     getAndSendGrantForSavedSearch,
     sendGrantDigest,
     getGrantDetail,

--- a/packages/server/src/routes/agencies.js
+++ b/packages/server/src/routes/agencies.js
@@ -10,7 +10,6 @@ const {
     requireAdminUser,
     requireUser,
     isUserAuthorized,
-    requireUSDRSuperAdminUser,
 } = require('../lib/access-helpers');
 const {
     getAgency,
@@ -26,30 +25,11 @@ const {
     getAgencyTree,
 } = require('../db');
 const AgencyImporter = require('../lib/agencyImporter');
-const email = require('../lib/email');
 
 router.get('/', requireUser, async (req, res) => {
     const { user } = req.session;
     const response = await getTenantAgencies(user.tenant_id);
     res.json(response);
-});
-
-router.get('/sendDigestEmail', requireUSDRSuperAdminUser, async (req, res) => {
-    const { user } = req.session;
-    const agency = await getAgency(parseInt(req.params.organizationId, 10));
-    try {
-        await email.sendGrantDigest({
-            name: agency[0].name,
-            matchedGrants: agency[0].matched_grants,
-            matchedGrantsTotal: agency[0].matched_grants?.length,
-            recipients: agency[0].recipients,
-        });
-    } catch (e) {
-        console.error(`Unable to kick-off digest email for ${req.params.organizationId} by user ${user.id} due to error ${e}}`);
-        res.sendStatus(500).json({ message: 'Something went wrong while kicking off the digest email. Please investigate the server logs.' });
-    }
-
-    res.sendStatus(200);
 });
 
 router.put('/:agency', requireAdminUser, async (req, res) => {

--- a/packages/server/src/scripts/sendGrantDigestEmail.js
+++ b/packages/server/src/scripts/sendGrantDigestEmail.js
@@ -17,10 +17,6 @@ exports.main = async function main() {
     }
 
     await tracer.trace('arpaTreasuryReport', async () => {
-        if (process.env.ENABLE_GRANTS_DIGEST === 'true') {
-            log.info('Sending grant digest emails');
-            await email.buildAndSendGrantDigest();
-        }
         if (process.env.ENABLE_SAVED_SEARCH_GRANTS_DIGEST === 'true') {
             log.info('Sending saved search grant digest emails');
             await email.buildAndSendUserSavedSearchGrantDigest();

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -175,7 +175,6 @@ module "api" {
   autoscaling_desired_count_minimum  = var.api_minumum_task_count
   autoscaling_desired_count_maximum  = var.api_maximum_task_count
   enable_grants_scraper              = var.api_enable_grants_scraper
-  enable_grants_digest               = var.api_enable_grants_digest
   enable_new_team_terminology        = var.api_enable_new_team_terminology
   enable_my_profile                  = var.api_enable_my_profile
   enable_saved_search_grants_digest  = var.api_enable_saved_search_grants_digest

--- a/terraform/modules/gost_api/task.tf
+++ b/terraform/modules/gost_api/task.tf
@@ -47,7 +47,6 @@ module "api_container_definition" {
       API_DOMAIN                         = "https://${var.domain_name}"
       AUDIT_REPORT_BUCKET                = module.arpa_audit_reports_bucket.bucket_id
       DATA_DIR                           = "/var/data"
-      ENABLE_GRANTS_DIGEST               = var.enable_grants_digest ? "true" : "false"
       ENABLE_SAVED_SEARCH_GRANTS_DIGEST  = var.enable_saved_search_grants_digest ? "true" : "false"
       ENABLE_GRANT_DIGEST_SCHEDULED_TASK = var.enable_grant_digest_scheduled_task ? "true" : "false"
       ENABLE_GRANTS_SCRAPER              = "false"

--- a/terraform/modules/gost_api/variables.tf
+++ b/terraform/modules/gost_api/variables.tf
@@ -162,12 +162,6 @@ variable "enable_grants_scraper" {
   default     = false
 }
 
-variable "enable_grants_digest" {
-  description = "When true, sets the ENABLE_GRANTS_DIGEST environment variable to true in the API container."
-  type        = bool
-  default     = false
-}
-
 variable "enable_new_team_terminology" {
   description = "When true, sets the ENABLE_NEW_TEAM_TERMINOLOGY environment variable to true in the API container."
   type        = bool

--- a/terraform/modules/gost_consume_grants/compute.tf
+++ b/terraform/modules/gost_consume_grants/compute.tf
@@ -57,7 +57,6 @@ module "consumer_container_definition" {
 
   map_environment = merge(
     {
-      ENABLE_GRANTS_DIGEST           = "false"
       ENABLE_GRANTS_SCRAPER          = "false"
       GRANTS_INGEST_EVENTS_QUEUE_URL = module.sqs_queue.queue_url
       NODE_OPTIONS                   = "--max_old_space_size=200"

--- a/terraform/modules/sqs_consumer_task/compute.tf
+++ b/terraform/modules/sqs_consumer_task/compute.tf
@@ -61,7 +61,6 @@ module "consumer_container_definition" {
 
   map_environment = merge(
     {
-      ENABLE_GRANTS_DIGEST  = "false"
       ENABLE_GRANTS_SCRAPER = "false"
       NODE_OPTIONS          = "--max_old_space_size=200"
       PGSSLROOTCERT         = "rds-combined-ca-bundle.pem"

--- a/terraform/prod.tfvars
+++ b/terraform/prod.tfvars
@@ -64,7 +64,6 @@ api_default_desired_task_count         = 3
 api_minumum_task_count                 = 2
 api_maximum_task_count                 = 5
 api_enable_grants_scraper              = false
-api_enable_grants_digest               = false
 api_enable_new_team_terminology        = true
 api_enable_my_profile                  = true
 api_enable_saved_search_grants_digest  = true

--- a/terraform/sandbox.tfvars
+++ b/terraform/sandbox.tfvars
@@ -29,7 +29,6 @@ api_default_desired_task_count         = 1
 api_minumum_task_count                 = 1
 api_maximum_task_count                 = 5
 api_enable_grants_scraper              = false
-api_enable_grants_digest               = false
 api_enable_new_team_terminology        = false
 api_enable_my_profile                  = true
 api_enable_saved_search_grants_digest  = false

--- a/terraform/staging.tfvars
+++ b/terraform/staging.tfvars
@@ -61,7 +61,6 @@ api_default_desired_task_count         = 1
 api_minumum_task_count                 = 1
 api_maximum_task_count                 = 5
 api_enable_grants_scraper              = false
-api_enable_grants_digest               = false
 api_enable_new_team_terminology        = true
 api_enable_my_profile                  = true
 api_enable_saved_search_grants_digest  = true

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -186,10 +186,6 @@ variable "api_enable_grants_scraper" {
   type = bool
 }
 
-variable "api_enable_grants_digest" {
-  type = bool
-}
-
 variable "api_enable_new_team_terminology" {
   type = bool
 }


### PR DESCRIPTION
## Description
Grant Finder introduced user managed saved searches in https://github.com/usdigitalresponse/usdr-gost/issues/1370. Once this feature was in place, we started sending users grant digest emails based on their individual saved searches. Prior to this feature, Grant Finder was sending a different type of grant digest email, based on keywords and criteria set at the agency/team level. These agency-level digest emails are controlled by the `ENABLE_GRANTS_DIGEST` flag and have been disabled since Sept 2023. This PR deletes the feature flag and cleans up its backing code.

## Screenshots / Demo Video
N/A

## Testing
Check that sending grant digest emails still works:
1. In `packages/server/.env`, add
```
ENABLE_GRANT_DIGEST_SCHEDULED_TASK=true
ENABLE_SAVED_SEARCH_GRANTS_DIGEST=true
```
2. Do `docker compose up -d`.
3. Execute `docker compose exec app node packages/server/src/scripts/sendGrantDigestEmail.js` and check that it runs.

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [ ] Provided ticket and description
- [ ] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers