### PR TITLE
fix: #2944 - updated contractor uei validation

### DIFF
--- a/packages/server/__tests__/arpa_reporter/server/services/validate-upload.spec.js
+++ b/packages/server/__tests__/arpa_reporter/server/services/validate-upload.spec.js
@@ -216,7 +216,7 @@ describe('findRecipientInDatabase', () => {
 
 describe('validateIdentifier', () => {
     const validateIdentifier = validateUploadModule.__get__('validateIdentifier');
-    it('should return an error if recipient is a new subrecipient or contractor and has no UEI', () => {
+    it('should return an error if recipient is a new subrecipient and has no UEI', () => {
         const recipient = {
             Entity_Type_2__c: 'Subrecipient',
             Unique_Entity_Identifier__c: null,
@@ -226,8 +226,40 @@ describe('validateIdentifier', () => {
         const errors = validateIdentifier(recipient, recipientExists);
         assert.deepStrictEqual(errors, [
             new ValidationError(
-                'UEI is required for all new subrecipients and contractors',
+                'UEI is required for all new subrecipients',
                 { col: 'C', severity: 'err' },
+            ),
+        ]);
+    });
+
+    it('should return an error if recipient is a new contractor and has no UEI or TIN', () => {
+        const recipient = {
+            Entity_Type_2__c: 'Contractor',
+            Unique_Entity_Identifier__c: null,
+            EIN__c: null,
+        };
+        const recipientExists = false;
+        const errors = validateIdentifier(recipient, recipientExists);
+        assert.deepStrictEqual(errors, [
+            new ValidationError(
+                'At least one of UEI or TIN/EIN must be set, but both are missing',
+                { col: 'CD', severity: 'err' },
+            ),
+        ]);
+    });
+
+    it('should return an error if recipient is a new beneficiary and has no UEI or TIN', () => {
+        const recipient = {
+            Entity_Type_2__c: 'Beneficiary',
+            Unique_Entity_Identifier__c: null,
+            EIN__c: null,
+        };
+        const recipientExists = false;
+        const errors = validateIdentifier(recipient, recipientExists);
+        assert.deepStrictEqual(errors, [
+            new ValidationError(
+                'At least one of UEI or TIN/EIN must be set, but both are missing',
+                { col: 'CD', severity: 'err' },
             ),
         ]);
     });
@@ -253,6 +285,39 @@ describe('validateIdentifier', () => {
             Entity_Type_2__c: 'Subrecipient',
             Unique_Entity_Identifier__c: '0123456789ABCDEF',
             EIN__c: null,
+        };
+        const recipientExists = false;
+        const errors = validateIdentifier(recipient, recipientExists);
+        assert.deepStrictEqual(errors, []);
+    });
+
+    it('should not return an error if recipient is a new contractor and has a UEI', () => {
+        const recipient = {
+            Entity_Type_2__c: 'Contractor',
+            Unique_Entity_Identifier__c: '0123456789ABCDEF',
+            EIN__c: null,
+        };
+        const recipientExists = false;
+        const errors = validateIdentifier(recipient, recipientExists);
+        assert.deepStrictEqual(errors, []);
+    });
+
+    it('should not return an error if recipient is a new contractor and has a TIN', () => {
+        const recipient = {
+            Entity_Type_2__c: 'Contractor',
+            Unique_Entity_Identifier__c: null,
+            EIN__c: '123345678',
+        };
+        const recipientExists = false;
+        const errors = validateIdentifier(recipient, recipientExists);
+        assert.deepStrictEqual(errors, []);
+    });
+
+    it('should not return an error if recipient is a new contractor and has a TIN and UEI', () => {
+        const recipient = {
+            Entity_Type_2__c: 'Contractor',
+            Unique_Entity_Identifier__c: '133456789ASDFG',
+            EIN__c: '123345678',
         };
         const recipientExists = false;
         const errors = validateIdentifier(recipient, recipientExists);

--- a/packages/server/__tests__/arpa_reporter/server/services/validate-upload.spec.js
+++ b/packages/server/__tests__/arpa_reporter/server/services/validate-upload.spec.js
@@ -243,7 +243,7 @@ describe('validateIdentifier', () => {
         assert.deepStrictEqual(errors, [
             new ValidationError(
                 'At least one of UEI or TIN/EIN must be set, but both are missing',
-                { col: 'CD', severity: 'err' },
+                { col: 'C, D', severity: 'err' },
             ),
         ]);
     });
@@ -259,7 +259,7 @@ describe('validateIdentifier', () => {
         assert.deepStrictEqual(errors, [
             new ValidationError(
                 'At least one of UEI or TIN/EIN must be set, but both are missing',
-                { col: 'CD', severity: 'err' },
+                { col: 'C, D', severity: 'err' },
             ),
         ]);
     });
@@ -274,7 +274,7 @@ describe('validateIdentifier', () => {
         const errors = validateIdentifier(recipient, recipientExists);
         assert.deepStrictEqual(errors, [
             new ValidationError(
-                'UEI is required for all new subrecipients and contractors',
+                'UEI is required for all new subrecipients',
                 { col: 'C', severity: 'err' },
             ),
         ]);
@@ -481,7 +481,7 @@ describe('validateSubrecipientRecord', () => {
         });
         assert.deepStrictEqual(errors, [
             new ValidationError(
-                'UEI is required for all new subrecipients and contractors',
+                'UEI is required for all new subrecipients',
                 { col: 'C', severity: 'err' },
             ),
         ]);

--- a/packages/server/src/arpa_reporter/services/validate-upload.js
+++ b/packages/server/src/arpa_reporter/services/validate-upload.js
@@ -157,13 +157,14 @@ function validateIdentifier(recipient, recipientExists) {
     const hasTIN = Boolean(recipient.EIN__c);
     const entityType = recipient.Entity_Type_2__c;
     const isContractorOrBeneficiary = (entityType.includes('Contractor') || entityType.includes('Beneficiary'));
+    const isSubrecipient = entityType.includes('Subrecipient');
 
-    if (entityType === 'Subrecipient' && !recipientExists && !hasUEI) {
+    if (isSubrecipient && !recipientExists && !hasUEI) {
         errors.push(new ValidationError(
             'UEI is required for all new subrecipients',
             { col: 'C', severity: 'err' },
         ));
-    } else if (isContractorOrBeneficiary && !recipientExists && !hasUEI && !hasTIN) {
+    } else if (isContractorOrBeneficiary && !hasUEI && !hasTIN) {
         errors.push(new ValidationError(
             'At least one of UEI or TIN/EIN must be set, but both are missing',
             { col: 'C, D', severity: 'err' },

--- a/packages/server/src/arpa_reporter/services/validate-upload.js
+++ b/packages/server/src/arpa_reporter/services/validate-upload.js
@@ -160,7 +160,7 @@ function validateIdentifier(recipient, recipientExists) {
 
     if (entityType === 'Subrecipient' && !recipientExists && !hasUEI) {
         errors.push(new ValidationError(
-            'UEI is required for all new subrecipients and contractors',
+            'UEI is required for all new subrecipients',
             { col: 'C', severity: 'err' },
         ));
     } else if (isContractorOrBeneficiary && !recipientExists && !hasUEI && !hasTIN) {


### PR DESCRIPTION
### Ticket #2944 
## Description
* updated validation rules as per ticket 2944 for contractor / beneficienary / subrecipient
* exact logic is in the original ticket

## Screenshots / Demo Video

## Testing
Uploaded sample file and checked for validation breaks

### Automated and Unit Tests
- [x] Added Unit tests

### Manual tests for Reviewer
- [x] Added steps to test feature/functionality manually

## Checklist
- [x] Provided ticket and description
- [x] Provided screenshots/demo
- [x] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [x] Added PR reviewers