### PR TITLE
Fix email from names

### DIFF
--- a/packages/server/src/lib/email.js
+++ b/packages/server/src/lib/email.js
@@ -16,8 +16,9 @@ const ASYNC_REPORT_TYPES = {
     treasury: 'treasury',
 };
 const HELPDESK_EMAIL = 'grants-helpdesk@usdigitalresponse.org';
+const GENERIC_FROM_NAME = 'USDR Grants';
 const GRANT_FINDER_EMAIL_FROM_NAME = 'USDR Federal Grant Finder';
-const ARPA_EMAIL_FROM_NAME = 'UDSR ARPA Reporter';
+const ARPA_EMAIL_FROM_NAME = 'USDR ARPA Reporter';
 
 async function deliverEmail({
     fromName,
@@ -130,7 +131,7 @@ async function sendPassCode(email, passcode, httpOrigin, redirectTo) {
         console.log(`${BLUE}${'-'.repeat(message.length)}`);
     }
     await module.exports.deliverEmail({
-        fromName: GRANT_FINDER_EMAIL_FROM_NAME,
+        fromName: GENERIC_FROM_NAME,
         toAddress: email,
         emailHTML,
         emailPlain: `Your link to access USDR's Grants tool is ${href}. It expires in ${expiryMinutes} minutes`,
@@ -192,7 +193,7 @@ function sendWelcomeEmail(email, httpOrigin) {
     );
 
     return module.exports.deliverEmail({
-        fromName: GRANT_FINDER_EMAIL_FROM_NAME,
+        fromName: GENERIC_FROM_NAME,
         toAddress: email,
         emailHTML,
         emailPlain: `Visit USDR's Grants Tool at: ${httpOrigin}.`,


### PR DESCRIPTION
### Ticket [#2353](https://github.com/usdigitalresponse/usdr-gost/issues/2353)
## Description
Fixes a few remaining issues with email "from" names: 

1. Typo of "USDR"
2. Welcome and login emails need a more generic "from" name

## Screenshots / Demo Video
<img width="1282" alt="Screenshot 2024-04-23 at 9 53 30 AM" src="https://github.com/usdigitalresponse/usdr-gost/assets/126250/83394928-70b4-4315-bf4e-35bd0eae4df5">

## Testing
- Sent all emails via the `send-debug-email` tool and verified their from names in mailpit (see screenshot above)
- We'll want to verify again in the staging environment, since emails follow a different send path in staging

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [ ] Provided ticket and description
- [ ] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers