### PR TITLE
Sort `matching_event_types` array to prevent perma-diffs

### DIFF
--- a/terraform/email.tf
+++ b/terraform/email.tf
@@ -33,7 +33,7 @@ resource "aws_sesv2_configuration_set_event_destination" "default" {
       topic_arn = join("", data.aws_sns_topic.datadog_forwarder[*].arn)
     }
     enabled = true
-    matching_event_types = [
+    matching_event_types = sort([
       "SEND",
       "REJECT",
       "BOUNCE",
@@ -43,7 +43,7 @@ resource "aws_sesv2_configuration_set_event_destination" "default" {
       "CLICK",
       "RENDERING_FAILURE",
       "DELIVERY_DELAY",
-      "SUBSCRIPTION"
-    ]
+      "SUBSCRIPTION",
+    ])
   }
 }


### PR DESCRIPTION
### Ticket #2789 
## Description

This PR is a quick follow-up to https://github.com/usdigitalresponse/usdr-gost/pull/2924. It has no real impact to users or infrastructure state, but is intended to resolve a "perma-diff" issue that only became apparent after #2924 was merged.

If you look at any Terraform plans generated after that PR was merged, you'll see that they include planned updates due to this detected "change":
<details>
<summary>Expand for plan output snippet</summary>

```diff
  # aws_sesv2_configuration_set_event_destination.default[0] will be updated in-place
  ~ resource "aws_sesv2_configuration_set_event_destination" "default" {
        id                     = "gost-staging-default|DatadogForwarderSNSTopic"
        # (2 unchanged attributes hidden)

      ~ event_destination {
          ~ matching_event_types = [
              + "SEND",
              + "REJECT",
                "BOUNCE",
              - "CLICK",
                "COMPLAINT",
                "DELIVERY",
              - "DELIVERY_DELAY",
                "OPEN",
              - "REJECT",
              + "CLICK",
                "RENDERING_FAILURE",
              - "SEND",
              + "DELIVERY_DELAY",
                "SUBSCRIPTION",
            ]
            # (1 unchanged attribute hidden)

            # (1 unchanged block hidden)
        }
    }
```

</details>

A close look shows that the order of the array items defined in Terraform don't match what Terraform sees as the current state in AWS, which includes all the same items but is ordered alphabetically. This sometimes happens when arbitrarily-sorted collections in Terraform are represented in AWS configuration in a different (usually alphabetical) order. The mismatch means that Terraform will always detect a deviation in state, even if the planned change is ultimately a no-op. The solution is to wrap the Terraform array definition in a `sort()` call (or manually sort the items in source code), which should ensure that what Terraform compares in source code is sorted in the same way as what AWS returns.

Our Terraform plans usually have a fair number of perma-diffs (even if you discount the S3 objects for client-side build artifacts), so this isn't entirely a new problem. I just happened to spot this relatively soon after the new code from #2924 was deployed, so it seemed worth fixing as a one-off.

## Testing

It should be sufficient to observe that Terraform plans generated for this PR do not include the changes to `aws_sesv2_configuration_set_event_destination.default[0]` shown in the above example.


### Manual tests for Reviewer
- [x] Added steps to test feature/functionality manually

## Checklist
- [x] Provided ticket and description
- [x] Provided testing information
- [x] Added PR reviewers