### PR TITLE
Send emails via SES using a configuration set.

### DIFF
--- a/packages/server/__tests__/email/email.test.js
+++ b/packages/server/__tests__/email/email.test.js
@@ -19,6 +19,7 @@ const {
     AWS_DEFAULT_REGION,
     AWS_REGION,
     NOTIFICATIONS_EMAIL,
+    SES_CONFIGURATION_SET_DEFAULT,
 
     NODEMAILER_HOST,
     NODEMAILER_PORT,
@@ -41,6 +42,7 @@ describe('Email module', () => {
         process.env.AWS_DEFAULT_REGION = AWS_DEFAULT_REGION;
         process.env.AWS_REGION = AWS_REGION;
         process.env.NOTIFICATIONS_EMAIL = NOTIFICATIONS_EMAIL;
+        process.env.SES_CONFIGURATION_SET_DEFAULT = SES_CONFIGURATION_SET_DEFAULT;
         process.env.NODEMAILER_HOST = NODEMAILER_HOST;
         process.env.NODEMAILER_PORT = NODEMAILER_PORT;
         process.env.NODEMAILER_EMAIL = NODEMAILER_EMAIL;
@@ -60,6 +62,7 @@ describe('Email module', () => {
         delete process.env.AWS_REGION;
         delete process.env.AWS_DEFAULT_REGION;
         delete process.env.NOTIFICATIONS_EMAIL;
+        delete process.env.SES_CONFIGURATION_SET_DEFAULT;
     }
 
     const sandbox = sinon.createSandbox();
@@ -86,6 +89,7 @@ describe('Email module', () => {
             process.env.AWS_DEFAULT_REGION = 'us-west-2';
             process.env.AWS_REGION = 'us-west-2';
             process.env.NOTIFICATIONS_EMAIL = 'fake@example.org';
+            process.env.SES_CONFIGURATION_SET_DEFAULT = 'default-configuration-set';
         });
 
         it('Fails when NOTIFICATIONS_EMAIL is missing', async () => {
@@ -101,6 +105,22 @@ describe('Email module', () => {
             expect(err.message).to.be.a('string').and.satisfy(
                 (msg) => msg.startsWith('NOTIFICATIONS_EMAIL is not set'),
             );
+        });
+
+        it('sends configuration set name if SES_CONFIGURATION_SET_DEFAULT is set', async () => {
+            const sendSpy = sandbox.spy();
+            sandbox.stub(awsTransport, 'getSESClient').returns({ send: sendSpy });
+            await awsTransport.sendEmail(testEmail);
+            expect(sendSpy.called).is.true;
+            expect(sendSpy.args[0][0].input.ConfigurationSetName).to.equal('default-configuration-set');
+        });
+        it('does not require a configuration set name', async () => {
+            delete process.env.SES_CONFIGURATION_SET_DEFAULT;
+            const sendSpy = sandbox.spy();
+            sandbox.stub(awsTransport, 'getSESClient').returns({ send: sendSpy });
+            await awsTransport.sendEmail(testEmail);
+            expect(sendSpy.called).is.true;
+            expect(sendSpy.args[0][0].input).to.not.have.property('ConfigurationSetName');
         });
 
         it('correctly formats from email without name', async () => {

--- a/packages/server/src/lib/gost-aws.js
+++ b/packages/server/src/lib/gost-aws.js
@@ -103,6 +103,9 @@ async function sendEmail(message) {
     if (message.ccAddress) {
         params.Destination.CcAddresses = [message.ccAddress];
     }
+    if (process.env.SES_CONFIGURATION_SET_DEFAULT) {
+        params.ConfigurationSetName = process.env.SES_CONFIGURATION_SET_DEFAULT;
+    }
     const command = new SendEmailCommand(params);
     try {
         const data = await transport.send(command);

--- a/terraform/email.tf
+++ b/terraform/email.tf
@@ -19,12 +19,12 @@ resource "aws_sesv2_configuration_set" "default" {
 }
 
 data "aws_sns_topic" "datadog_forwarder" {
-  count = var.ses_datadog_events_enabled ? 1 : 0
+  count = var.email_enable_tracking && var.ses_datadog_events_enabled ? 1 : 0
   name  = "datadog-forwarder"
 }
 
 resource "aws_sesv2_configuration_set_event_destination" "default" {
-  count                  = var.ses_datadog_events_enabled ? 1 : 0
+  count                  = var.email_enable_tracking && var.ses_datadog_events_enabled ? 1 : 0
   event_destination_name = "DatadogForwarderSNSTopic"
   configuration_set_name = aws_sesv2_configuration_set.default.configuration_set_name
 

--- a/terraform/prod.tfvars
+++ b/terraform/prod.tfvars
@@ -86,3 +86,6 @@ consume_grants_source_event_bus_name = "default"
 consume_grants_datadog_environment_variables = {
   DD_PROFILING_ENABLED = true,
 }
+
+// Email
+email_enable_tracking = false

--- a/terraform/sandbox.tfvars
+++ b/terraform/sandbox.tfvars
@@ -41,3 +41,6 @@ postgres_apply_changes_immediately = true
 
 // Consume Grants
 consume_grants_source_event_bus_name = "default"
+
+// Email
+email_enable_tracking = false

--- a/terraform/staging.tfvars
+++ b/terraform/staging.tfvars
@@ -84,3 +84,6 @@ consume_grants_source_event_bus_name = "default"
 consume_grants_datadog_environment_variables = {
   DD_PROFILING_ENABLED = true,
 }
+
+// Email
+email_enable_tracking = false

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -247,3 +247,9 @@ variable "consume_grants_datadog_environment_variables" {
   type    = map(string)
   default = {}
 }
+
+# Email
+variable "email_enable_tracking" {
+  description = "Feature flag for email tracking. When false, disables link rewriting for click tracking in emails."
+  type        = bool
+}


### PR DESCRIPTION
### Ticket #2880 
## Description
This PR does as the ticket describes. However, since we haven't fixed the problem noted in #2996 yet, this PR also adds a feature flag that disables all of the email tracking functionality that the configuration set is supposed to bring us. My plan is:
1. Merge this PR which should not break anything.
2. Enable email tracking in staging in the PR for #2996 and use staging to test that all of our emails still work correctly and that we are receiving email events in Datadog.
3. Enable email tracking in prod in a separate PR.

In [this PR comment thread](https://github.com/usdigitalresponse/usdr-gost/pull/2924#discussion_r1573065817), we discussed a different way of setting the configuration set used to send emails. My main takeaway from that conversation was that the different way was not an approach that I could code up myself as a volunteer. So, in the interest of getting to the point where we can start having email metrics, I'm taking the originally proposed approach, which seems perfectly fine too.

## Screenshots / Demo Video
N/A


## Testing
Not testable in dev since it depends on AWS infrastructure.

Since `enable_email_tracking` is disabled in staging, there won't be new functionality to test there. We should do some regression testing, namely:

1. Have a login passcode email sent from staging. Check that it was sent and that you received it.
4. Hover over the link in the email and check that the URL still looks like `https://api.staging.grants.usdr.dev/api/sessions?passcode=some_passcode`. Click on the link and make sure it works.

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [ ] Provided ticket and description
- [ ] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers