### PR TITLE
Upgrade vuelidate

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -19,6 +19,8 @@
   "dependencies": {
     "@braid/vue-formulate": "^2.5.3",
     "@datadog/browser-rum": "^5.5.0",
+    "@vuelidate/core": "^2.0.3",
+    "@vuelidate/validators": "^2.0.4",
     "bootstrap": "^4.6.1",
     "bootstrap-vue": "^2.19.0",
     "core-js": "^3.21.1",
@@ -36,7 +38,6 @@
     "vue-router": "^3.5.2",
     "vue-select": "^3.16.0",
     "vue2-filters": "^0.14.0",
-    "vuelidate": "^0.7.6",
     "vuex": "^3.6.2"
   },
   "devDependencies": {

--- a/packages/client/src/components/Modals/AddOrganization.vue
+++ b/packages/client/src/components/Modals/AddOrganization.vue
@@ -4,7 +4,7 @@
       id="add-tenant-modal"
       ref="modal"
       :title="newTerminologyEnabled ? 'Add Organization' : 'Add Tenant'"
-      :ok-disabled="$v.formData.$invalid"
+      :ok-disabled="v$.formData.$invalid"
       @show="resetModal"
       @hidden="resetModal"
       @ok="handleOk"
@@ -14,7 +14,7 @@
         @submit.stop.prevent="handleSubmit"
       >
         <b-form-group
-          :state="!$v.formData.tenantName.$invalid"
+          :state="!v$.formData.tenantName.$invalid"
           :label="newTerminologyEnabled ? 'Organization Name' : 'Tenant Name'"
           label-for="tenantName-input"
           :invalid-feedback="newTerminologyEnabled ? 'Organization name is invalid' : 'Tenant name is invalid'"
@@ -22,12 +22,12 @@
           <b-form-input
             id="tenantName-input"
             v-model="formData.tenantName"
-            :state="!$v.formData.tenantName.$invalid"
+            :state="!v$.formData.tenantName.$invalid"
             required
           />
         </b-form-group>
         <b-form-group
-          :state="!$v.formData.agencyName.$invalid"
+          :state="!v$.formData.agencyName.$invalid"
           :label="newTerminologyEnabled ? 'Team Name' : 'Agency Name'"
           label-for="agencyName-input"
           :invalid-feedback="newTerminologyEnabled ? 'Team name is invalid' : 'Agency name is invalid'"
@@ -35,12 +35,12 @@
           <b-form-input
             id="agencyName-input"
             v-model="formData.agencyName"
-            :state="!$v.formData.agencyName.$invalid"
+            :state="!v$.formData.agencyName.$invalid"
             required
           />
         </b-form-group>
         <b-form-group
-          :state="!$v.formData.agencyAbbreviation"
+          :state="!v$.formData.agencyAbbreviation"
           :label="newTerminologyEnabled ? 'Team Abbreviation' : 'Agency Abbreviation'"
           label-for="agencyAbbreviation-input"
           :invalid-feedback="newTerminologyEnabled ? 'Team abbreviation is invalid' : 'Agency abbreviation is invalid'"
@@ -48,11 +48,11 @@
           <b-form-input
             id="agencyAbbreviation-input"
             v-model="formData.agencyAbbreviation"
-            :state="!$v.formData.agencyAbbreviation"
+            :state="!v$.formData.agencyAbbreviation"
           />
         </b-form-group>
         <b-form-group
-          :state="!$v.formData.agencyCode.$invalid"
+          :state="!v$.formData.agencyCode.$invalid"
           label="Agency Code"
           label-for="agencyCode-input"
           invalid-feedback="Agency code is invalid"
@@ -60,12 +60,12 @@
           <b-form-input
             id="agencyCode-input"
             v-model="formData.agencyCode"
-            :state="!$v.formData.agencyCode.$invalid"
+            :state="!v$.formData.agencyCode.$invalid"
             required
           />
         </b-form-group>
         <b-form-group
-          :state="!$v.formData.adminUserEmail.$invalid"
+          :state="!v$.formData.adminUserEmail.$invalid"
           label="Admin User Email"
           label-for="adminUserEmail-input"
           invalid-feedback="Please enter a valid admin user email address"
@@ -73,11 +73,11 @@
           <b-form-input
             id="adminUserEmail-input"
             v-model="formData.adminUserEmail"
-            :state="!$v.formData.adminUserEmail.$invalid"
+            :state="!v$.formData.adminUserEmail.$invalid"
           />
         </b-form-group>
         <b-form-group
-          :state="!$v.formData.adminUserName.$invalid"
+          :state="!v$.formData.adminUserName.$invalid"
           label="Admin User Name"
           label-for="adminUserName-input"
           invalid-feedback="Admin user name is invalid"
@@ -85,7 +85,7 @@
           <b-form-input
             id="adminUserName-input"
             v-model="formData.adminUserName"
-            :state="!$v.formData.adminUserName.$invalid"
+            :state="!v$.formData.adminUserName.$invalid"
           />
         </b-form-group>
       </form>
@@ -95,12 +95,16 @@
 
 <script>
 import { mapActions } from 'vuex';
-import { required, email } from 'vuelidate/lib/validators';
+import { useVuelidate } from '@vuelidate/core';
+import { required, email } from '@vuelidate/validators';
 import { newTerminologyEnabled } from '@/helpers/featureFlags';
 
 export default {
   props: {
     showModal: Boolean,
+  },
+  setup() {
+    return { v$: useVuelidate() };
   },
   data() {
     return {
@@ -151,7 +155,7 @@ export default {
     resetModal() {
       this.formData = {};
       this.$emit('update:showModal', false);
-      this.$v.$reset();
+      this.v$.$reset();
     },
     handleOk(bvModalEvt) {
       // Prevent modal from closing
@@ -161,7 +165,7 @@ export default {
     },
     async handleSubmit() {
       // Exit when the form isn't valid
-      if (this.$v.formData.$invalid) {
+      if (this.v$.formData.$invalid) {
         return;
       }
       await this.createTenant(this.formData);

--- a/packages/client/src/components/Modals/AddTeam.vue
+++ b/packages/client/src/components/Modals/AddTeam.vue
@@ -5,7 +5,7 @@
     ref="modal"
     v-model="modalVisible"
     :title="newTerminologyEnabled ? 'Add Team' : 'Add Agency'"
-    :ok-disabled="$v.formData.$invalid"
+    :ok-disabled="v$.formData.$invalid"
     @ok="handleOk"
   >
     <form
@@ -13,7 +13,7 @@
       @submit.stop.prevent="handleSubmit"
     >
       <b-form-group
-        :state="!$v.formData.name.$invalid"
+        :state="!v$.formData.name.$invalid"
         label-for="name-input"
         invalid-feedback="Required"
       >
@@ -29,7 +29,7 @@
         />
       </b-form-group>
       <b-form-group
-        :state="!$v.formData.abbreviation.$invalid"
+        :state="!v$.formData.abbreviation.$invalid"
         label-for="abbreviation-input"
         invalid-feedback="Required"
       >
@@ -49,7 +49,7 @@
         />
       </b-form-group>
       <b-form-group
-        :state="!$v.formData.code.$invalid"
+        :state="!v$.formData.code.$invalid"
         label-for="code-input"
         invalid-feedback="Required"
       >
@@ -69,7 +69,7 @@
         />
       </b-form-group>
       <b-form-group
-        :state="!$v.formData.parentAgency.$invalid"
+        :state="!v$.formData.parentAgency.$invalid"
         label-for="agency-input"
         :invalid-feedback="newTerminologyEnabled ? 'Must select a parent team' : 'Must select a parent agency'"
       >
@@ -93,7 +93,7 @@
         </v-select>
       </b-form-group>
       <b-form-group
-        :state="!$v.formData.warningThreshold.$invalid"
+        :state="!v$.formData.warningThreshold.$invalid"
         label-for="warningThreshold-input"
         invalid-feedback="Warning Threshold must be 2 or greater"
       >
@@ -112,7 +112,7 @@
         />
       </b-form-group>
       <b-form-group
-        :state="!$v.formData.dangerThreshold.$invalid"
+        :state="!v$.formData.dangerThreshold.$invalid"
         label-for="dangerThreshold-input"
         invalid-feedback="Danger Threshold must be greater than 0 and less than Warning Threshold"
       >
@@ -136,17 +136,21 @@
 
 <script>
 import { mapActions, mapGetters } from 'vuex';
+import { useVuelidate } from '@vuelidate/core';
 import {
   required,
   requiredUnless,
   numeric,
   minValue,
-} from 'vuelidate/lib/validators';
+} from '@vuelidate/validators';
 import { newTerminologyEnabled } from '@/helpers/featureFlags';
 
 export default {
   props: {
     show: Boolean,
+  },
+  setup() {
+    return { v$: useVuelidate() };
   },
   data() {
     return {
@@ -221,7 +225,7 @@ export default {
       this.handleSubmit();
     },
     async handleSubmit() {
-      if (this.$v.formData.$invalid) {
+      if (this.v$.formData.$invalid) {
         return;
       }
       const body = {

--- a/packages/client/src/components/Modals/AddUser.vue
+++ b/packages/client/src/components/Modals/AddUser.vue
@@ -5,7 +5,7 @@
       ref="modal"
       v-model="modalVisible"
       title="Add User"
-      :ok-disabled="$v.formData.$invalid"
+      :ok-disabled="v$.formData.$invalid"
       @ok="handleOk"
     >
       <form
@@ -13,7 +13,7 @@
         @submit.stop.prevent="handleSubmit"
       >
         <b-form-group
-          :state="!$v.formData.email.$invalid"
+          :state="!v$.formData.email.$invalid"
           label="Email"
           label-for="email-input"
           invalid-feedback="Please enter a valid email address"
@@ -25,7 +25,7 @@
           />
         </b-form-group>
         <b-form-group
-          :state="!$v.formData.name.$invalid"
+          :state="!v$.formData.name.$invalid"
           label="Name"
           label-for="name-input"
           invalid-feedback="Please enter your preferred first and last name"
@@ -37,7 +37,7 @@
           />
         </b-form-group>
         <b-form-group
-          :state="!$v.formData.role.$invalid"
+          :state="!v$.formData.role.$invalid"
           label="Role"
           label-for="role-select"
           invalid-feedback="Please select your role"
@@ -49,7 +49,7 @@
           />
         </b-form-group>
         <b-form-group
-          :state="!$v.formData.agency.$invalid"
+          :state="!v$.formData.agency.$invalid"
           :label="newTerminologyEnabled ? 'Team' : 'Agency'"
           label-for="agency-select"
           :invalid-feedback="`Please select your ${newTerminologyEnabled ? 'team' : 'agency'}`"
@@ -67,12 +67,16 @@
 
 <script>
 import { mapActions, mapGetters } from 'vuex';
-import { required, minLength, email } from 'vuelidate/lib/validators';
+import { useVuelidate } from '@vuelidate/core';
+import { required, minLength, email } from '@vuelidate/validators';
 import { newTerminologyEnabled } from '@/helpers/featureFlags';
 
 export default {
   props: {
     show: Boolean,
+  },
+  setup() {
+    return { v$: useVuelidate() };
   },
   data() {
     return {
@@ -154,7 +158,7 @@ export default {
     },
     async handleSubmit() {
       // Exit when the form isn't valid
-      if (this.$v.formData.$invalid) {
+      if (this.v$.formData.$invalid) {
         return;
       }
       try {

--- a/packages/client/src/components/Modals/EditTeam.vue
+++ b/packages/client/src/components/Modals/EditTeam.vue
@@ -5,7 +5,7 @@
     ref="modal"
     v-model="modalVisible"
     :title="newTerminologyEnabled ? 'Edit Team' : 'Edit Agency'"
-    :ok-disabled="$v.formData.$invalid"
+    :ok-disabled="v$.formData.$invalid"
     @ok="handleOk"
   >
     <h3>{{ agency && agency.name }}</h3>
@@ -85,7 +85,7 @@
         </v-select>
       </b-form-group>
       <b-form-group
-        :state="!$v.formData.warningThreshold.$invalid"
+        :state="!v$.formData.warningThreshold.$invalid"
         label-for="warningThreshold-input"
         invalid-feedback="Warning Threshold must be 2 or greater"
       >
@@ -101,7 +101,7 @@
           autofocus
           type="number"
           min="2"
-          :state="!$v.formData.warningThreshold.$invalid"
+          :state="!v$.formData.warningThreshold.$invalid"
           required
         />
       </b-form-group>
@@ -120,7 +120,7 @@
           v-model="formData.dangerThreshold"
           type="number"
           min="1"
-          :state="!$v.formData.dangerThreshold.$invalid"
+          :state="!v$.formData.dangerThreshold.$invalid"
           required
         />
       </b-form-group>
@@ -153,9 +153,8 @@
 
 <script>
 import { mapActions, mapGetters } from 'vuex';
-import {
-  required, numeric, minValue,
-} from 'vuelidate/lib/validators';
+import { useVuelidate } from '@vuelidate/core';
+import { required, numeric, minValue } from '@vuelidate/validators';
 import { newTerminologyEnabled } from '@/helpers/featureFlags';
 
 export default {
@@ -165,6 +164,9 @@ export default {
       type: Object,
       default: null,
     },
+  },
+  setup() {
+    return { v$: useVuelidate() };
   },
   data() {
     return {
@@ -234,7 +236,7 @@ export default {
       this.handleSubmit();
     },
     async handleDelete() {
-      if (this.$v.formData.$invalid) {
+      if (this.v$.formData.$invalid) {
         return;
       }
       const msgBoxConfirmResult = await this.$bvModal.msgBoxConfirm(
@@ -265,7 +267,7 @@ export default {
       }
     },
     async handleSubmit() {
-      if (this.$v.formData.$invalid) {
+      if (this.v$.formData.$invalid) {
         return;
       }
       // TODO(mbroussard): This feels kinda screwy that we do multiple requests (always, since we

--- a/packages/client/src/components/Modals/EditUser.vue
+++ b/packages/client/src/components/Modals/EditUser.vue
@@ -5,7 +5,7 @@
     header-class="heading"
     footer-class="footer"
     ok-title="Save"
-    :ok-disabled="$v.formData.$invalid"
+    :ok-disabled="v$.formData.$invalid"
     @show="resetModal"
     @hidden="resetModal"
     @ok="handleOk"
@@ -38,7 +38,7 @@
       </b-form-group>
 
       <b-form-group
-        :state="!$v.formData.name.$invalid"
+        :state="!v$.formData.name.$invalid"
         label="Name"
         label-for="name-input"
         invalid-feedback="Please enter your preferred first and last name"
@@ -59,13 +59,17 @@
 
 <script>
 import { mapGetters, mapActions } from 'vuex';
-import { required, minLength } from 'vuelidate/lib/validators';
+import { useVuelidate } from '@vuelidate/core';
+import { required, minLength } from '@vuelidate/validators';
 import { avatarColors } from '@/helpers/constants';
 import UserAvatar from '@/components/UserAvatar.vue';
 
 export default {
   components: {
     UserAvatar,
+  },
+  setup() {
+    return { v$: useVuelidate() };
   },
   data() {
     return {
@@ -108,7 +112,7 @@ export default {
     async handleSubmit() {
       this.formData.id = this.loggedInUser.id;
       // Exit when the form isn't valid
-      if (this.$v.formData.$invalid) {
+      if (this.v$.formData.$invalid) {
         return;
       }
       try {

--- a/packages/client/src/components/Modals/SavedSearchPanel.vue
+++ b/packages/client/src/components/Modals/SavedSearchPanel.vue
@@ -150,7 +150,6 @@ export default {
       savedSearchFields: [{ key: 'searchinfo', label: 'Saved Search' }],
     };
   },
-  validations: {},
   computed: {
     ...mapGetters({
       savedSearches: 'grants/savedSearches',

--- a/packages/client/src/components/Modals/SearchPanel.vue
+++ b/packages/client/src/components/Modals/SearchPanel.vue
@@ -323,9 +323,6 @@ export default {
       ],
     };
   },
-  validations: {
-    formData: {},
-  },
   computed: {
     ...mapGetters({
       eligibilityCodes: 'grants/eligibilityCodes',

--- a/packages/client/src/main.js
+++ b/packages/client/src/main.js
@@ -10,7 +10,6 @@ import Vue from 'vue';
 import VueRouter from 'vue-router';
 import { BootstrapVue, IconsPlugin } from 'bootstrap-vue';
 import vSelect from 'vue-select';
-import Vuelidate from 'vuelidate';
 import { setUserForGoogleAnalytics } from '@/helpers/gtag';
 import App from '@/App.vue';
 import router from '@/router';
@@ -32,7 +31,6 @@ store.watch((state) => state.users.loggedInUser, (newUser) => datadogRum.setUser
 Vue.use(BootstrapVue);
 // Optionally install the BootstrapVue icon components plugin
 Vue.use(IconsPlugin);
-Vue.use(Vuelidate);
 Vue.use(VueRouter);
 Vue.component('VSelect', vSelect);
 

--- a/packages/client/tests/unit/components/Modals/AddOrganization.spec.js
+++ b/packages/client/tests/unit/components/Modals/AddOrganization.spec.js
@@ -2,11 +2,9 @@ import { expect } from 'chai';
 import { createLocalVue, shallowMount } from '@vue/test-utils';
 import Vuex from 'vuex';
 import AddOrganization from '@/components/Modals/AddOrganization.vue';
-import Vuelidate from 'vuelidate';
 
 const localVue = createLocalVue();
 localVue.use(Vuex);
-localVue.use(Vuelidate);
 
 let wrapper;
 const stubs = ['b-modal', 'b-form-group', 'b-form-input'];

--- a/packages/client/tests/unit/components/Modals/AddTeam.spec.js
+++ b/packages/client/tests/unit/components/Modals/AddTeam.spec.js
@@ -1,12 +1,10 @@
 import { expect } from 'chai';
 import { createLocalVue, shallowMount } from '@vue/test-utils';
 import Vuex from 'vuex';
-import Vuelidate from 'vuelidate';
 import AddTeam from '@/components/Modals/AddTeam.vue';
 
 const localVue = createLocalVue();
 localVue.use(Vuex);
-localVue.use(Vuelidate);
 
 let store;
 let wrapper;

--- a/packages/client/tests/unit/components/Modals/EditOrganization.spec.js
+++ b/packages/client/tests/unit/components/Modals/EditOrganization.spec.js
@@ -1,12 +1,10 @@
 import { expect } from 'chai';
 import { createLocalVue, shallowMount } from '@vue/test-utils';
 import Vuex from 'vuex';
-import Vuelidate from 'vuelidate';
 import EditOrganization from '@/components/Modals/EditOrganization.vue';
 
 const localVue = createLocalVue();
 localVue.use(Vuex);
-localVue.use(Vuelidate);
 
 let wrapper;
 const stubs = ['b-modal', 'b-form-group', 'b-form-input'];

--- a/packages/client/tests/unit/components/Modals/EditTeam.spec.js
+++ b/packages/client/tests/unit/components/Modals/EditTeam.spec.js
@@ -1,12 +1,10 @@
 import { expect } from 'chai';
 import { createLocalVue, shallowMount } from '@vue/test-utils';
 import Vuex from 'vuex';
-import Vuelidate from 'vuelidate';
 import EditTeam from '@/components/Modals/EditTeam.vue';
 
 const localVue = createLocalVue();
 localVue.use(Vuex);
-localVue.use(Vuelidate);
 
 let store;
 let wrapper;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4325,6 +4325,20 @@
   resolved "https://registry.yarnpkg.com/@vue/web-component-wrapper/-/web-component-wrapper-1.3.0.tgz#b6b40a7625429d2bd7c2281ddba601ed05dc7f1a"
   integrity sha512-Iu8Tbg3f+emIIMmI2ycSI8QcEuAUgPTgHwesDU1eKMLE4YC/c/sFbGc70QgMq31ijRftV0R7vCm9co6rldCeOA==
 
+"@vuelidate/core@^2.0.3":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@vuelidate/core/-/core-2.0.3.tgz#40468c5ed15b72bde880a026b0699c2f0f1ecede"
+  integrity sha512-AN6l7KF7+mEfyWG0doT96z+47ljwPpZfi9/JrNMkOGLFv27XVZvKzRLXlmDPQjPl/wOB1GNnHuc54jlCLRNqGA==
+  dependencies:
+    vue-demi "^0.13.11"
+
+"@vuelidate/validators@^2.0.4":
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/@vuelidate/validators/-/validators-2.0.4.tgz#0a88a7b2b18f15fd9c384095593f369a6f7384e9"
+  integrity sha512-odTxtUZ2JpwwiQ10t0QWYJkkYrfd0SyFYhdHH44QQ1jDatlZgTh/KRzrWVmn/ib9Gq7H4hFD4e8ahoo5YlUlDw==
+  dependencies:
+    vue-demi "^0.13.11"
+
 "@webassemblyjs/ast@1.12.1", "@webassemblyjs/ast@^1.12.1":
   version "1.12.1"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.12.1.tgz#bb16a0e8b1914f979f45864c23819cc3e3f0d4bb"
@@ -15295,6 +15309,11 @@ vue-codemod@^0.0.5:
     source-map "^0.6.1"
     yargs "^16.2.0"
 
+vue-demi@^0.13.11:
+  version "0.13.11"
+  resolved "https://registry.yarnpkg.com/vue-demi/-/vue-demi-0.13.11.tgz#7d90369bdae8974d87b1973564ad390182410d99"
+  integrity sha512-IR8HoEEGM65YY3ZJYAjMlKygDQn25D5ajNFNoKh9RSDMQtlzCxtfQjdQgv9jjK+m3377SsJXY8ysq8kLCZL25A==
+
 vue-eslint-parser@^8.0.1:
   version "8.3.0"
   resolved "https://registry.yarnpkg.com/vue-eslint-parser/-/vue-eslint-parser-8.3.0.tgz#5d31129a1b3dd89c0069ca0a1c88f970c360bd0d"
@@ -15383,11 +15402,6 @@ vue@^2.6.14, vue@^2.7.12:
   dependencies:
     "@vue/compiler-sfc" "2.7.14"
     csstype "^3.1.0"
-
-vuelidate@^0.7.6:
-  version "0.7.7"
-  resolved "https://registry.yarnpkg.com/vuelidate/-/vuelidate-0.7.7.tgz#5df3930a63ddecf56fde7bdacea9dbaf0c9bf899"
-  integrity sha512-pT/U2lDI67wkIqI4tum7cMSIfGcAMfB+Phtqh2ttdXURwvHRBJEAQ0tVbUsW9Upg83Q5QH59bnCoXI7A9JDGnA==
 
 vuex@^3.6.2:
   version "3.6.2"


### PR DESCRIPTION
### Ticket #<Enter Number Here To Auto-Link>
## Description
Upgrades Vuelidate from 0.x to 2.x. This upgrade unlocks vite and/or vue3 upgrades, in addition to just plain keeping up with package upgrades. There should be no behavior changes introduced by this PR, but follows the [Vuelidate migration guide](https://vuelidate-next.netlify.app/migration_guide.html) to update our integration: 

1. Updates the installed packages
2. Removes vuelidate as a `Vue.use(...)` global plugin (it's now applied on a per-component basis)
3. Updates components to new usage patterns: 
   - Each component has a `setup()` method to call `useVuelidate()`, which applies vuelidate behavior to the component.
   - Vuelidate core and Vuelidate's built-in validators are now separate packages, so we update the imports accordingly. 
   - We now call the vuelidate helper object `v$` (instead of the global `$v` installed by `Vue.use(Vuelidate)`) because Vue3 reserves variables starting with `$` for internal use. We could call this anything now, but `v$` follows the convention in the Vuelidate docs.
   - Note that the `validations: {...}` hash that defines the actual validation logic does not change at all.

## Screenshots / Demo Video
<img width="1888" alt="Screenshot 2024-04-26 at 9 07 36 AM" src="https://github.com/usdigitalresponse/usdr-gost/assets/126250/dd729d51-1546-404d-8348-c3825a71b06a">
<img width="1888" alt="Screenshot 2024-04-26 at 9 08 02 AM" src="https://github.com/usdigitalresponse/usdr-gost/assets/126250/c3ca0224-b859-4bac-bb50-7741755ee25f">
<img width="1888" alt="Screenshot 2024-04-26 at 9 08 17 AM" src="https://github.com/usdigitalresponse/usdr-gost/assets/126250/259bbf16-1fa8-4674-b9bb-095aac3b8ff4">
<img width="1888" alt="Screenshot 2024-04-26 at 9 08 26 AM" src="https://github.com/usdigitalresponse/usdr-gost/assets/126250/03adfe29-ad6b-4933-9210-ca5dac2391ec">
<img width="1888" alt="Screenshot 2024-04-26 at 9 08 39 AM" src="https://github.com/usdigitalresponse/usdr-gost/assets/126250/35fb9205-e390-4232-b29a-43ec53a6c1c3">
<img width="1888" alt="Screenshot 2024-04-26 at 9 08 51 AM" src="https://github.com/usdigitalresponse/usdr-gost/assets/126250/c51350d9-e099-4d97-9151-5c0d24976f0d">

## Testing
- Unit tests remain passing
- Manually verified behavior of the 3 add and 3 edit forms that rely on vuelidate (see screenshots)

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [ ] Provided ticket and description
- [ ] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers