### PR TITLE
Migrate client code entirely to ES6 import style

### DIFF
--- a/packages/client/.eslintrc.js
+++ b/packages/client/.eslintrc.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/no-commonjs */
 module.exports = {
   root: true,
   env: {
@@ -28,6 +29,7 @@ module.exports = {
     'no-restricted-syntax': 'off',
 
     'import/prefer-default-export': 'off',
+    'import/no-commonjs': 'error',
     'import-alias/import-alias': [
       'error',
       {

--- a/packages/client/babel.config.js
+++ b/packages/client/babel.config.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/no-commonjs */
 module.exports = {
   presets: [
     '@vue/cli-plugin-babel/preset',

--- a/packages/client/src/arpa_reporter/views/ReportingPeriodsView.vue
+++ b/packages/client/src/arpa_reporter/views/ReportingPeriodsView.vue
@@ -117,10 +117,9 @@
 </template>
 
 <script>
+import _ from 'lodash';
+import moment from 'moment';
 import { post } from '@/arpa_reporter/store';
-
-const moment = require('moment');
-const _ = require('lodash');
 
 export default {
   data() {

--- a/packages/client/src/components/RecordUploader.vue
+++ b/packages/client/src/components/RecordUploader.vue
@@ -40,6 +40,7 @@
 </template>
 
 <script>
+import { mapGetters } from 'vuex';
 import { apiURL } from '@/helpers/fetchApi';
 
 export default {
@@ -58,6 +59,9 @@ export default {
     };
   },
   computed: {
+    ...mapGetters({
+      organizationId: 'users/selectedAgencyId',
+    }),
     uploadButtonLabel() {
       return this.uploading ? 'Uploading...' : 'Upload';
     },
@@ -80,7 +84,7 @@ export default {
       const formData = new FormData();
       formData.append('spreadsheet', file);
       try {
-        const url = apiURL(`/api/organizations/:organizationId/${this.uploadRecordType}/import`);
+        const url = apiURL(`/api/organizations/${this.organizationId}/${this.uploadRecordType}/import`);
         const options = {
           method: 'POST',
           credentials: 'include',

--- a/packages/client/src/helpers/constants.js
+++ b/packages/client/src/helpers/constants.js
@@ -1,4 +1,4 @@
-const billOptions = [
+export const billOptions = [
   'All Bills',
   'Bipartisan Safer Communities Act',
   'Consumer Product Safety Commission',
@@ -35,7 +35,7 @@ const billOptions = [
 ];
 
 // Mapping of available avatar background colors to foreground text colors
-const avatarColors = {
+export const avatarColors = {
   '#44337A': '#FFF',
   '#086F83': '#FFF',
   '#234E52': '#FFF',
@@ -56,13 +56,7 @@ const avatarColors = {
   '#FCD663': '#000',
 };
 
-const defaultCloseDateThresholds = {
+export const defaultCloseDateThresholds = {
   warning: 30,
   danger: 15,
-};
-
-module.exports = {
-  billOptions,
-  avatarColors,
-  defaultCloseDateThresholds,
 };

--- a/packages/client/src/helpers/fetchApi.js
+++ b/packages/client/src/helpers/fetchApi.js
@@ -1,4 +1,3 @@
-import store from '@/store';
 import urlJoin from 'url-join';
 
 export function apiURL(endpointPath) {
@@ -12,16 +11,12 @@ function getDefaultHeaders() {
   return headers;
 }
 
-export function addOrganizationId(url) {
-  return url.replace(':organizationId', store.getters['users/selectedAgencyId']);
-}
-
 export function get(url) {
   const options = {
     credentials: 'include',
     headers: getDefaultHeaders(),
   };
-  return fetch(addOrganizationId(apiURL(url)), options).then((r) => {
+  return fetch(apiURL(url), options).then((r) => {
     if (r.ok) {
       return r.json();
     }
@@ -38,7 +33,7 @@ export function deleteRequest(url, body) {
     headers: getDefaultHeaders(),
     body: JSON.stringify(body),
   };
-  return fetch(addOrganizationId(apiURL(url)), options)
+  return fetch(apiURL(url), options)
     .then((r) => {
       if (r.ok) {
         return r.json();
@@ -56,7 +51,7 @@ export function post(url, body) {
     headers: getDefaultHeaders(),
     body: JSON.stringify(body),
   };
-  return fetch(addOrganizationId(apiURL(url)), options)
+  return fetch(apiURL(url), options)
     .then((r) => {
       if (r.ok) {
         return r.json();
@@ -74,7 +69,7 @@ export function put(url, body) {
     headers: getDefaultHeaders(),
     body: JSON.stringify(body),
   };
-  return fetch(addOrganizationId(apiURL(url)), options)
+  return fetch(apiURL(url), options)
     .then((r) => {
       if (r.ok) {
         return r.json();
@@ -92,7 +87,7 @@ export function patch(url, body) {
     headers: getDefaultHeaders(),
     body: JSON.stringify(body),
   };
-  return fetch(addOrganizationId(apiURL(url)), options)
+  return fetch(apiURL(url), options)
     .then((r) => {
       if (r.ok) {
         return r.json();

--- a/packages/client/src/main.js
+++ b/packages/client/src/main.js
@@ -15,10 +15,9 @@ import { setUserForGoogleAnalytics } from '@/helpers/gtag';
 import App from '@/App.vue';
 import router from '@/router';
 import store from '@/store';
+import * as fetchApi from '@/helpers/fetchApi';
 import '@/assets/fix-sticky-headers.css';
 import '@/assets/adjust-vue-select.css';
-
-const fetchApi = require('@/helpers/fetchApi');
 
 if (window.APP_CONFIG?.GOOGLE_TAG_ID) {
   store.watch((state) => state.users.loggedInUser, (newUser) => setUserForGoogleAnalytics(newUser));

--- a/packages/client/src/mixin/resizableTable.js
+++ b/packages/client/src/mixin/resizableTable.js
@@ -1,5 +1,5 @@
 // https://github.com/bootstrap-vue/bootstrap-vue/issues/1496
-module.exports = {
+export default {
   data() {
     return {
       gripElement: null,

--- a/packages/client/src/store/modules/agencies.js
+++ b/packages/client/src/store/modules/agencies.js
@@ -13,17 +13,17 @@ export default {
     agencies: (state) => state.agencies,
   },
   actions: {
-    fetchAgencies({ commit }) {
-      fetchApi.get('/api/organizations/:organizationId/agencies').then((data) => commit('SET_AGENCIES', data));
+    fetchAgencies({ commit, rootGetters }) {
+      fetchApi.get(`/api/organizations/${rootGetters['users/selectedAgencyId']}/agencies`).then((data) => commit('SET_AGENCIES', data));
     },
-    async createAgency({ dispatch }, body) {
-      await fetchApi.post('/api/organizations/:organizationId/agencies/', body);
+    async createAgency({ dispatch, rootGetters }, body) {
+      await fetchApi.post(`/api/organizations/${rootGetters['users/selectedAgencyId']}/agencies/`, body);
       dispatch('fetchAgencies');
     },
-    async deleteAgency({ dispatch }, {
+    async deleteAgency({ dispatch, rootGetters }, {
       agencyId, parent, name, abbreviation, warningThreshold, dangerThreshold,
     }) {
-      await fetchApi.deleteRequest(`/api/organizations/:organizationId/agencies/del/${agencyId}`, {
+      await fetchApi.deleteRequest(`/api/organizations/${rootGetters['users/selectedAgencyId']}/agencies/del/${agencyId}`, {
         parent,
         name,
         abbreviation,
@@ -32,34 +32,34 @@ export default {
       });
       dispatch('fetchAgencies');
     },
-    async updateThresholds({ dispatch }, { agencyId, warningThreshold, dangerThreshold }) {
-      await fetchApi.put(`/api/organizations/:organizationId/agencies/${agencyId}`, {
+    async updateThresholds({ dispatch, rootGetters }, { agencyId, warningThreshold, dangerThreshold }) {
+      await fetchApi.put(`/api/organizations/${rootGetters['users/selectedAgencyId']}/agencies/${agencyId}`, {
         // Currently, agencies are seeded into db; only thresholds are mutable.
         warningThreshold,
         dangerThreshold,
       });
       dispatch('fetchAgencies');
     },
-    async updateAgencyName({ dispatch }, { agencyId, name }) {
-      await fetchApi.put(`/api/organizations/:organizationId/agencies/name/${agencyId}`, {
+    async updateAgencyName({ dispatch, rootGetters }, { agencyId, name }) {
+      await fetchApi.put(`/api/organizations/${rootGetters['users/selectedAgencyId']}/agencies/name/${agencyId}`, {
         name,
       });
       dispatch('fetchAgencies');
     },
-    async updateAgencyAbbr({ dispatch }, { agencyId, abbreviation }) {
-      await fetchApi.put(`/api/organizations/:organizationId/agencies/abbr/${agencyId}`, {
+    async updateAgencyAbbr({ dispatch, rootGetters }, { agencyId, abbreviation }) {
+      await fetchApi.put(`/api/organizations/${rootGetters['users/selectedAgencyId']}/agencies/abbr/${agencyId}`, {
         abbreviation,
       });
       dispatch('fetchAgencies');
     },
-    async updateAgencyCode({ dispatch }, { agencyId, code }) {
-      await fetchApi.put(`/api/organizations/:organizationId/agencies/code/${agencyId}`, {
+    async updateAgencyCode({ dispatch, rootGetters }, { agencyId, code }) {
+      await fetchApi.put(`/api/organizations/${rootGetters['users/selectedAgencyId']}/agencies/code/${agencyId}`, {
         code,
       });
       dispatch('fetchAgencies');
     },
-    async updateAgencyParent({ dispatch }, { agencyId, parentId }) {
-      await fetchApi.put(`/api/organizations/:organizationId/agencies/parent/${agencyId}`, {
+    async updateAgencyParent({ dispatch, rootGetters }, { agencyId, parentId }) {
+      await fetchApi.put(`/api/organizations/${rootGetters['users/selectedAgencyId']}/agencies/parent/${agencyId}`, {
         parentId,
       });
       dispatch('fetchAgencies');

--- a/packages/client/src/store/modules/agencies.js
+++ b/packages/client/src/store/modules/agencies.js
@@ -1,4 +1,4 @@
-const fetchApi = require('@/helpers/fetchApi');
+import * as fetchApi from '@/helpers/fetchApi';
 
 function initialState() {
   return {

--- a/packages/client/src/store/modules/dashboard.js
+++ b/packages/client/src/store/modules/dashboard.js
@@ -31,10 +31,10 @@ export default {
     totalInterestedGrantsByAgencies: (state) => state.totalInterestedGrantsByAgencies,
   },
   actions: {
-    async fetchDashboard({ commit }) {
+    async fetchDashboard({ commit, rootGetters }) {
       const twentyFourHoursAgo = new Date(Date.now() - 24 * 60 * 60 * 1000);
       const timestampQueryString = twentyFourHoursAgo.toISOString();
-      const result = await fetchApi.get(`/api/organizations/:organizationId/dashboard?totalGrants=true&totalViewedGrants=true&totalInterestedGrants=true&grantsCreatedFromTs=${timestampQueryString}&grantsUpdatedFromTs=${timestampQueryString}&totalInterestedGrantsByAgencies=true`);
+      const result = await fetchApi.get(`/api/organizations/${rootGetters['users/selectedAgencyId']}/dashboard?totalGrants=true&totalViewedGrants=true&totalInterestedGrants=true&grantsCreatedFromTs=${timestampQueryString}&grantsUpdatedFromTs=${timestampQueryString}&totalInterestedGrantsByAgencies=true`);
       if (result.totalGrants) {
         commit('SET_TOTAL_GRANTS', result.totalGrants);
       }

--- a/packages/client/src/store/modules/dashboard.js
+++ b/packages/client/src/store/modules/dashboard.js
@@ -1,4 +1,4 @@
-const fetchApi = require('@/helpers/fetchApi');
+import * as fetchApi from '@/helpers/fetchApi';
 
 function initialState() {
   return {

--- a/packages/client/src/store/modules/grants.js
+++ b/packages/client/src/store/modules/grants.js
@@ -121,7 +121,7 @@ export default {
     displaySavedSearchPanel: (state) => state.tableMode === tableModes.MANAGE,
   },
   actions: {
-    fetchGrants({ commit }, {
+    fetchGrants({ commit, rootGetters }, {
       currentPage, perPage, orderBy, orderDesc, searchTerm, interestedByMe,
       assignedToAgency, aging, positiveInterest, result, rejected, interestedByAgency,
       opportunityStatuses, opportunityCategories, costSharing,
@@ -134,10 +134,10 @@ export default {
         .filter(([key, value]) => value || typeof value === 'number')
         .map(([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(value)}`)
         .join('&');
-      return fetchApi.get(`/api/organizations/:organizationId/grants?${query}`)
+      return fetchApi.get(`/api/organizations/${rootGetters['users/selectedAgencyId']}/grants?${query}`)
         .then((data) => commit('SET_GRANTS', data));
     },
-    fetchGrantsNext({ commit }, {
+    fetchGrantsNext({ commit, rootGetters }, {
       currentPage, perPage, orderBy, orderDesc,
     }) {
       const pagination = { currentPage, perPage };
@@ -145,77 +145,77 @@ export default {
       const filters = { ...this.state.grants.searchFormFilters };
       const { criteriaQuery, paginationQuery, orderingQuery } = buildGrantsNextQuery({ filters, ordering, pagination });
 
-      return fetchApi.get(`/api/organizations/:organizationId/grants/next?${paginationQuery}&${orderingQuery}&${criteriaQuery}`)
+      return fetchApi.get(`/api/organizations/${rootGetters['users/selectedAgencyId']}/grants/next?${paginationQuery}&${orderingQuery}&${criteriaQuery}`)
         .then((data) => commit('SET_GRANTS', data));
     },
     // Retrieves grants that the user's team (or any subteam) has interacted with (either by setting status or assigning to a user).
     // Sorted in descending order by the date on which the interaction occurred (recently interacted with are first).
-    fetchGrantsInterested({ commit }, { perPage, currentPage }) {
-      return fetchApi.get(`/api/organizations/:organizationId/grants/grantsInterested/${perPage}/${currentPage}`)
+    fetchGrantsInterested({ commit, rootGetters }, { perPage, currentPage }) {
+      return fetchApi.get(`/api/organizations/${rootGetters['users/selectedAgencyId']}/grants/grantsInterested/${perPage}/${currentPage}`)
         .then((data) => commit('SET_GRANTS_INTERESTED', data));
     },
     // Retrieves grants that the user's team (or any subteam) is interested in and that have closing dates in the future.
     // Sorted in ascending order by the closing date (grants that close soonest are first).
-    fetchClosestGrants({ commit }, { perPage, currentPage }) {
-      return fetchApi.get(`/api/organizations/:organizationId/grants/closestGrants/${perPage}/${currentPage}`)
+    fetchClosestGrants({ commit, rootGetters }, { perPage, currentPage }) {
+      return fetchApi.get(`/api/organizations/${rootGetters['users/selectedAgencyId']}/grants/closestGrants/${perPage}/${currentPage}`)
         .then((data) => commit('SET_CLOSEST_GRANTS', data));
     },
-    fetchGrantDetails({ commit }, { grantId }) {
-      return fetchApi.get(`/api/organizations/:organizationId/grants/${grantId}/grantDetails`)
+    fetchGrantDetails({ commit, rootGetters }, { grantId }) {
+      return fetchApi.get(`/api/organizations/${rootGetters['users/selectedAgencyId']}/grants/${grantId}/grantDetails`)
         .then((data) => commit('SET_GRANT_CURRENT', data));
     },
-    markGrantAsViewed(context, { grantId, agencyId }) {
-      return fetchApi.put(`/api/organizations/:organizationId/grants/${grantId}/view/${agencyId}`);
+    markGrantAsViewed({ rootGetters }, { grantId, agencyId }) {
+      return fetchApi.put(`/api/organizations/${rootGetters['users/selectedAgencyId']}/grants/${grantId}/view/${agencyId}`);
     },
-    getGrantAssignedAgencies(context, { grantId }) {
-      return fetchApi.get(`/api/organizations/:organizationId/grants/${grantId}/assign/agencies`);
+    getGrantAssignedAgencies({ rootGetters }, { grantId }) {
+      return fetchApi.get(`/api/organizations/${rootGetters['users/selectedAgencyId']}/grants/${grantId}/assign/agencies`);
     },
-    getInterestedAgencies(context, { grantId }) {
-      return fetchApi.get(`/api/organizations/:organizationId/grants/${grantId}/interested`);
+    getInterestedAgencies({ rootGetters }, { grantId }) {
+      return fetchApi.get(`/api/organizations/${rootGetters['users/selectedAgencyId']}/grants/${grantId}/interested`);
     },
-    assignAgenciesToGrant(context, { grantId, agencyIds }) {
-      return fetchApi.put(`/api/organizations/:organizationId/grants/${grantId}/assign/agencies`, {
+    assignAgenciesToGrant({ rootGetters }, { grantId, agencyIds }) {
+      return fetchApi.put(`/api/organizations/${rootGetters['users/selectedAgencyId']}/grants/${grantId}/assign/agencies`, {
         agencyIds,
       });
     },
-    unassignAgenciesToGrant(context, { grantId, agencyIds }) {
-      return fetchApi.deleteRequest(`/api/organizations/:organizationId/grants/${grantId}/assign/agencies`, {
+    unassignAgenciesToGrant({ rootGetters }, { grantId, agencyIds }) {
+      return fetchApi.deleteRequest(`/api/organizations/${rootGetters['users/selectedAgencyId']}/grants/${grantId}/assign/agencies`, {
         agencyIds,
       });
     },
-    unmarkGrantAsInterested(context, {
+    unmarkGrantAsInterested({ rootGetters }, {
       grantId, agencyIds, interestedCode, agencyId,
     }) {
-      return fetchApi.deleteRequest(`/api/organizations/:organizationId/grants/${grantId}/interested/${agencyId}`, {
+      return fetchApi.deleteRequest(`/api/organizations/${rootGetters['users/selectedAgencyId']}/grants/${grantId}/interested/${agencyId}`, {
         agencyIds,
         interestedCode,
       });
     },
-    fetchInterestedAgencies(context, { grantId }) {
-      return fetchApi.get(`/api/organizations/:organizationId/grants/${grantId}/interested`);
+    fetchInterestedAgencies({ rootGetters }, { grantId }) {
+      return fetchApi.get(`/api/organizations/${rootGetters['users/selectedAgencyId']}/grants/${grantId}/interested`);
     },
-    async markGrantAsInterested({ commit }, { grantId, agencyId, interestedCode }) {
-      const interestedAgencies = await fetchApi.put(`/api/organizations/:organizationId/grants/${grantId}/interested/${agencyId}`, {
+    async markGrantAsInterested({ commit, rootGetters }, { grantId, agencyId, interestedCode }) {
+      const interestedAgencies = await fetchApi.put(`/api/organizations/${rootGetters['users/selectedAgencyId']}/grants/${grantId}/interested/${agencyId}`, {
         interestedCode,
       });
       commit('UPDATE_GRANT', { grantId, data: { interested_agencies: interestedAgencies } });
     },
-    fetchEligibilityCodes({ commit }) {
-      fetchApi.get('/api/organizations/:organizationId/eligibility-codes')
+    fetchEligibilityCodes({ commit, rootGetters }) {
+      fetchApi.get(`/api/organizations/${rootGetters['users/selectedAgencyId']}/eligibility-codes`)
         .then((data) => commit('SET_ELIGIBILITY_CODES', data));
     },
-    fetchSearchConfig({ commit }) {
-      fetchApi.get('/api/organizations/:organizationId/search-config')
+    fetchSearchConfig({ commit, rootGetters }) {
+      fetchApi.get(`/api/organizations/${rootGetters['users/selectedAgencyId']}/search-config`)
         .then((data) => commit('SET_SEARCH_CONFIG', data));
     },
-    fetchInterestedCodes({ commit }) {
-      fetchApi.get('/api/organizations/:organizationId/interested-codes')
+    fetchInterestedCodes({ commit, rootGetters }) {
+      fetchApi.get(`/api/organizations/${rootGetters['users/selectedAgencyId']}/interested-codes`)
         .then((data) => commit('SET_INTERESTED_CODES', data));
     },
-    async setEligibilityCodeEnabled(context, { code, enabled }) {
-      await fetchApi.put(`/api/organizations/:organizationId/eligibility-codes/${code}/enable/${enabled}`);
+    async setEligibilityCodeEnabled({ rootGetters }, { code, enabled }) {
+      await fetchApi.put(`/api/organizations/${rootGetters['users/selectedAgencyId']}/eligibility-codes/${code}/enable/${enabled}`);
     },
-    async fetchSavedSearches({ commit }, {
+    async fetchSavedSearches({ commit, rootGetters }, {
       currentPage, perPage,
     }) {
       // TODO: Add pagination URL parameters.
@@ -225,17 +225,17 @@ export default {
         .filter(([key, value]) => value || typeof value === 'number')
         .map(([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(value)}`)
         .join('&');
-      const data = await fetchApi.get(`/api/organizations/:organizationId/grants-saved-search?${paginationQuery}`);
+      const data = await fetchApi.get(`/api/organizations/${rootGetters['users/selectedAgencyId']}/grants-saved-search?${paginationQuery}`);
       commit('SET_SAVED_SEARCHES', data);
     },
-    async createSavedSearch(context, { searchInfo }) {
-      return fetchApi.post('/api/organizations/:organizationId/grants-saved-search', searchInfo);
+    async createSavedSearch({ rootGetters }, { searchInfo }) {
+      return fetchApi.post(`/api/organizations/${rootGetters['users/selectedAgencyId']}/grants-saved-search`, searchInfo);
     },
-    async updateSavedSearch(context, { searchId, searchInfo }) {
-      await fetchApi.put(`/api/organizations/:organizationId/grants-saved-search/${searchId}`, searchInfo);
+    async updateSavedSearch({ rootGetters }, { searchId, searchInfo }) {
+      await fetchApi.put(`/api/organizations/${rootGetters['users/selectedAgencyId']}/grants-saved-search/${searchId}`, searchInfo);
     },
-    async deleteSavedSearch(context, { searchId }) {
-      await fetchApi.deleteRequest(`/api/organizations/:organizationId/grants-saved-search/${searchId}`);
+    async deleteSavedSearch({ rootGetters }, { searchId }) {
+      await fetchApi.deleteRequest(`/api/organizations/${rootGetters['users/selectedAgencyId']}/grants-saved-search/${searchId}`);
     },
     changeSelectedSearchId({ commit }, searchId) {
       commit('SET_SELECTED_SEARCH_ID', searchId);
@@ -243,20 +243,20 @@ export default {
     changeEditingSearchId({ commit }, searchId) {
       commit('SET_EDITING_SEARCH_ID', searchId);
     },
-    exportCSV({
+    exportCSV({ rootGetters }, {
       currentPage, perPage, orderBy, orderDesc,
     }) {
       const pagination = { currentPage, perPage };
       const ordering = { orderBy, orderDesc };
       const filters = { ...this.state.grants.searchFormFilters };
       const { criteriaQuery, paginationQuery, orderingQuery } = buildGrantsNextQuery({ filters, ordering, pagination });
-      const navUrl = fetchApi.apiURL(fetchApi.addOrganizationId(
-        `/api/organizations/:organizationId/grants/exportCSVNew?${paginationQuery}&${orderingQuery}&${criteriaQuery}`,
-      ));
+      const navUrl = fetchApi.apiURL(
+        `/api/organizations/${rootGetters['users/selectedAgencyId']}/grants/exportCSVNew?${paginationQuery}&${orderingQuery}&${criteriaQuery}`,
+      );
       window.location = navUrl;
     },
-    exportCSVRecentActivities() {
-      window.location = fetchApi.apiURL(fetchApi.addOrganizationId('/api/organizations/:organizationId/grants/exportCSVRecentActivities'));
+    exportCSVRecentActivities({ rootGetters }) {
+      window.location = fetchApi.apiURL(`/api/organizations/${rootGetters['users/selectedAgencyId']}/grants/exportCSVRecentActivities`);
     },
     applyFilters(context, filters) {
       context.commit('APPLY_FILTERS', filters);

--- a/packages/client/src/store/modules/grants.js
+++ b/packages/client/src/store/modules/grants.js
@@ -1,6 +1,5 @@
-const fetchApi = require('@/helpers/fetchApi');
-
-const { formatFilterDisplay } = require('@/helpers/filters');
+import * as fetchApi from '@/helpers/fetchApi';
+import { formatFilterDisplay } from '@/helpers/filters';
 
 const tableModes = {
   VIEW: 'view',

--- a/packages/client/src/store/modules/roles.js
+++ b/packages/client/src/store/modules/roles.js
@@ -13,8 +13,8 @@ export default {
     roles: (state) => state.roles,
   },
   actions: {
-    fetchRoles({ commit }) {
-      fetchApi.get('/api/organizations/:organizationId/roles').then((data) => commit('SET_ROLES', data));
+    fetchRoles({ commit, rootGetters }) {
+      fetchApi.get(`/api/organizations/${rootGetters['users/selectedAgencyId']}/roles`).then((data) => commit('SET_ROLES', data));
     },
   },
   mutations: {

--- a/packages/client/src/store/modules/roles.js
+++ b/packages/client/src/store/modules/roles.js
@@ -1,4 +1,4 @@
-const fetchApi = require('@/helpers/fetchApi');
+import * as fetchApi from '@/helpers/fetchApi';
 
 function initialState() {
   return {

--- a/packages/client/src/store/modules/tenants.js
+++ b/packages/client/src/store/modules/tenants.js
@@ -13,15 +13,15 @@ export default {
     tenants: (state) => state.tenants,
   },
   actions: {
-    fetchTenants({ commit }) {
-      fetchApi.get('/api/organizations/:organizationId/tenants').then((data) => commit('SET_TENANTS', data));
+    fetchTenants({ commit, rootGetters }) {
+      fetchApi.get(`/api/organizations/${rootGetters['users/selectedAgencyId']}/tenants`).then((data) => commit('SET_TENANTS', data));
     },
-    async createTenant({ dispatch }, options) {
-      await fetchApi.post('/api/organizations/:organizationId/tenants/', options);
+    async createTenant({ dispatch, rootGetters }, options) {
+      await fetchApi.post(`/api/organizations/${rootGetters['users/selectedAgencyId']}/tenants/`, options);
       dispatch('fetchTenants');
     },
-    async updateDisplayName({ dispatch }, { tenantId, displayName }) {
-      await fetchApi.put(`/api/organizations/:organizationId/tenants/${tenantId}`, {
+    async updateDisplayName({ dispatch, rootGetters }, { tenantId, displayName }) {
+      await fetchApi.put(`/api/organizations/${rootGetters['users/selectedAgencyId']}/tenants/${tenantId}`, {
         displayName,
       });
       dispatch('fetchTenants');

--- a/packages/client/src/store/modules/tenants.js
+++ b/packages/client/src/store/modules/tenants.js
@@ -1,4 +1,4 @@
-const fetchApi = require('@/helpers/fetchApi');
+import * as fetchApi from '@/helpers/fetchApi';
 
 function initialState() {
   return {

--- a/packages/client/src/store/modules/users.js
+++ b/packages/client/src/store/modules/users.js
@@ -53,23 +53,23 @@ export default {
       commit('SET_SELECTED_AGENCY', agencyId);
       localStorage.setItem('selectedAgencyId', agencyId);
     },
-    fetchUsers({ commit }) {
-      return fetchApi.get('/api/organizations/:organizationId/users')
+    fetchUsers({ commit, rootGetters }) {
+      return fetchApi.get(`/api/organizations/${rootGetters['users/selectedAgencyId']}/users`)
         .then((data) => commit('SET_USERS', data));
     },
-    async createUser({ dispatch }, user) {
-      await fetchApi.post('/api/organizations/:organizationId/users', user);
+    async createUser({ dispatch, rootGetters }, user) {
+      await fetchApi.post(`/api/organizations/${rootGetters['users/selectedAgencyId']}/users`, user);
       await dispatch('fetchUsers');
     },
-    async updateUser({ commit }, user) {
+    async updateUser({ commit, rootGetters }, user) {
       const { id, name, avatarColor } = user;
-      const data = await fetchApi.patch(`/api/organizations/:organizationId/users/${id}`, { name, avatar_color: avatarColor });
+      const data = await fetchApi.patch(`/api/organizations/${rootGetters['users/selectedAgencyId']}/users/${id}`, { name, avatar_color: avatarColor });
       commit('SET_LOGGED_IN_USER', data.user);
     },
-    async deleteUser({ dispatch, commit }, userId) {
+    async deleteUser({ dispatch, commit, rootGetters }, userId) {
       try {
         await fetchApi.deleteRequest(
-          `/api/organizations/:organizationId/users/${userId}`,
+          `/api/organizations/${rootGetters['users/selectedAgencyId']}/users/${userId}`,
         );
       } catch (error) {
         commit('alerts/addAlert', {
@@ -79,9 +79,9 @@ export default {
       }
       await dispatch('fetchUsers');
     },
-    async updateEmailSubscriptionPreferencesForLoggedInUser({ commit, getters }, { preferences }) {
+    async updateEmailSubscriptionPreferencesForLoggedInUser({ commit, getters, rootGetters }, { preferences }) {
       const data = await fetchApi.put(
-        `/api/organizations/:organizationId/users/${getters.loggedInUser.id}/email_subscription`,
+        `/api/organizations/${rootGetters['users/selectedAgencyId']}/users/${getters.loggedInUser.id}/email_subscription`,
         {
           preferences,
         },

--- a/packages/client/src/store/modules/users.js
+++ b/packages/client/src/store/modules/users.js
@@ -1,4 +1,4 @@
-const fetchApi = require('@/helpers/fetchApi');
+import * as fetchApi from '@/helpers/fetchApi';
 
 function initialState() {
   return {

--- a/packages/client/vue.config.js
+++ b/packages/client/vue.config.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/no-commonjs */
 // This will be used to branch behaviors in ARPA Reporter code based on running
 // in GOST environment.
 process.env.VUE_APP_IS_GOST = true;


### PR DESCRIPTION
### Ticket #<Enter Number Here To Auto-Link>
## Description
Migrates client codebase the final bit from CommonJS (`require(...)` and `module.exports`) to ES6 (`import` and `export`) style, and enforces this going forward in eslint. 

**Steps taken:**

1. Add a lint rule to disallow CJS style (and add ignore comments to project root config files that get executed in a CJS environment).
2. Replace remaining `require` and `module.exports` references with `import`/`export`.
3. Fix a circular dependency between `fetchApi` and `store` code. 

**Details on the circular dependency:**

Many of our store modules understandably rely on `fetchApi` to pull data from the server; meanwhile, the `fetchApi` code had a helper that automatically replaced `:organizationId` with the appropriate value from the store, based on the logged-in user. This caused a circular import between the `fetchApi` module and the various `store/...` modules. 

Interestingly, eslint didn't flag the circular import when it was via CJS `require` statements because by default the `eslint-plugin-import` plugin [only flags circular imports on ES6 imports](https://github.com/import-js/eslint-plugin-import/blob/HEAD/docs/rules/no-cycle.md). 

This obviously wasn't causing any bugs today (possibly because the code happened to be loading in the correct order, or only executing async, or was managed gracefully by webpack, I'm not certain), but it has the possibility to cause an unexpected bug down the road. Additionally, circular imports can be confusing and additional cognitive load for developers. So it seemed worth fixing rather than adding eslint ignore comments. 

To fix the issue, we grab `rootGetters` from the context for the actions that need to insert organization ID into a URL, and insert it directly in the actions. This really isn't much more verbose than `:organizationId` was, and it's more clear and less "magic" than the hidden helper was previously. So to me, this change is an overall improvement in clarity even aside from the cyclic dependency. 

(Also note that `RecordUploader` was actually never hitting the codepath to replace `:organizationId` with the ID, but [the server code](https://github.com/usdigitalresponse/usdr-gost/blob/7ac21928a8be1de8d072b85a3b62fa1f8dab1610/packages/server/src/lib/access-helpers.js#L69-L77) ended up seeing literally the string `:organizationId`, determining it's not a number, and ignoring it in favor of the user's agency.)

## Screenshots / Demo Video

## Testing
- I've tested a number of the endpoints explicitly by visiting the relevant page and performing the action to trigger it. (Particularly, things like the uploader that required some special attention.)
- Overall, the site seems to continue working fine on my devbox. 
- Unit tests continue to pass.
- We'll want to diligently test all the core functionality on staging, since this diff is pretty wide-ranging.

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [ ] Provided ticket and description
- [ ] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers