### PR TITLE
Replace lodash-checkit usage with vuelidate

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -26,7 +26,6 @@
     "core-js": "^3.21.1",
     "jquery": "3.6.0",
     "lodash": "^4.17.21",
-    "lodash-checkit": "^2.3.3",
     "luxon": "^3.4.3",
     "moment": "^2.29.2",
     "numeral": "^2.0.6",

--- a/packages/client/src/arpa_reporter/views/LoginView.vue
+++ b/packages/client/src/arpa_reporter/views/LoginView.vue
@@ -23,54 +23,62 @@
       </div>
     </form>
     <div
-      v-if="message"
-      :class="messageClass"
+      v-if="serverResponse"
+      :class="{
+        'alert alert-success': serverResponse.success,
+        'alert alert-danger': !serverResponse.success,
+      }"
     >
-      {{ message }}
+      {{ serverResponse.message }}
+    </div>
+    <div
+      v-for="error of v$.$errors"
+      :key="error.$uid"
+      class="alert alert-danger"
+    >
+      {{ error.$message }}
     </div>
   </div>
 </template>
 
 <script>
-import _ from 'lodash-checkit';
 import { apiURL } from '@/helpers/fetchApi';
+import { useVuelidate } from '@vuelidate/core';
+import { required, email, helpers } from '@vuelidate/validators';
 
 export default {
   name: 'LoginView',
+  setup() {
+    return { v$: useVuelidate() };
+  },
   data() {
-    const message = _.get(this, '$route.query.message', null);
-    const messageClass = message ? 'alert alert-danger' : '';
+    const serverResponse = this.$route.query.message && {
+      message: this.$route.query.message,
+      success: false, // If message is present in the URL, it's because of an error (e.g., invalid token)
+    };
     return {
       email: '',
-      message,
-      messageClass,
+      serverResponse,
     };
   },
+  validations: {
+    email: {
+      required: helpers.withMessage('Please enter an email address', required),
+      email: helpers.withMessage('Please enter a valid email address', email),
+    },
+  },
   methods: {
-    login(event) {
+    async login(event) {
       event.preventDefault();
-      if (!this.email) {
-        this.message = 'Email cannot be blank';
-        this.messageClass = 'alert alert-danger';
+      this.serverResponse = null;
+      if (!(await this.v$.$validate())) {
         return;
       }
-      if (!_.isEmail(this.email)) {
-        this.message = `'${this.email}' is not a valid email address`;
-        this.messageClass = 'alert alert-danger';
-        return;
-      }
-
-      const redirectTo = (
-        // If we got to the login page via a redirect, a post-login redirect URL will already be specified
-        this.$route.query.redirect_to
-        // If we went to the login page directly, we default to redirecting to the homepage.
-        // This gets a full relative URL including any VueRouter base prefix, if configured (such as in GOST)
-        || this.$router.resolve('/').href
-      );
+      this.v$.$reset();
 
       const body = JSON.stringify({
         email: this.email,
-        redirect_to: redirectTo,
+        redirect_to: this.$route.query.redirect_to || this.$router.resolve('/').href,
       });
       const headers = {
         'Content-Type': 'application/json',
@@ -82,16 +90,18 @@ export default {
         })
         .then((r) => r.json())
         .then((r) => {
-          this.email = '';
-          this.message = r.message;
-          this.messageClass = r.success
-            ? 'alert alert-success'
-            : 'alert alert-danger';
+          this.serverResponse = {
+            message: r.message,
+            success: r.success,
+          };
         })
         .catch((error) => {
           console.log('error:', error.message);
-          this.message = error.message;
-          this.messageClass = 'alert alert-danger';
+          this.serverResponse = {
+            message: error.message
+              || 'There was a problem at USDR. Try again in a minute or two, and if you still receive the same error, contact the USDR team.',
+            success: false,
+          };
         });
     },
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -10722,7 +10722,7 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
-lodash-checkit@^2.3.3, lodash-checkit@^2.4.1:
+lodash-checkit@^2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/lodash-checkit/-/lodash-checkit-2.4.1.tgz#8b09c6b359a5d4de86f752ff9c231f1db5d23fd4"
   integrity sha512-OAg5CqY04/dnsO8izxXqlleuj7z/dOk6yV0pm0TVtRaUwG5v2PGw4XWSIG/dLK0UWYk7g0/TCk8OCf50oVwv6w==


### PR DESCRIPTION
### Ticket #<Enter Number Here To Auto-Link>
## Description
Both login pages (Grants and ARPA) did ad-hoc validation of the login email field using the `lodash-checkit` library. This was undesirable for a couple reasons: 

1. The `checkit` library is intended to run in node environments, not browser environments, and it relies on e.g. `global` for some functions, which isn't present in the browser. Specifically, this becomes a blocker for switching to vite, in addition to being a bit dangerous in case someone eventually reaches for whatever checkit method actually references `global`. 
2. Ideally, it'd be great to eventually remove the lodash dependency from the frontend code to improve the bundle size, anyway. 

Since we're already pretty reliant on vuelidate for form validation, it seemed appropriate to migrate these forms to use that library for form validation instead. Also tidied up the login logic a bit. 

## Screenshots / Demo Video
<img width="1888" alt="Screenshot 2024-04-26 at 9 45 13 AM" src="https://github.com/usdigitalresponse/usdr-gost/assets/126250/62a55e53-80b6-4d0a-81fe-eb229e3ce43f">
<img width="944" alt="Screenshot 2024-04-26 at 9 47 11 AM" src="https://github.com/usdigitalresponse/usdr-gost/assets/126250/5ce27cfd-5c61-428d-b9a9-965e5fddfcea">
<img width="970" alt="Screenshot 2024-04-26 at 9 47 23 AM" src="https://github.com/usdigitalresponse/usdr-gost/assets/126250/33333c29-0ac3-429f-9e5f-a857ee575d27">
<img width="1714" alt="Screenshot 2024-04-26 at 9 48 26 AM" src="https://github.com/usdigitalresponse/usdr-gost/assets/126250/df6e0506-2552-4198-887e-a895ebfbd6cc">
<img width="1714" alt="Screenshot 2024-04-26 at 9 48 35 AM" src="https://github.com/usdigitalresponse/usdr-gost/assets/126250/0ad1dc77-aeb1-48f1-8945-c65b56f88ed8">

## Testing
Manually verified login behavior continues to work across both login forms (see screenshots), including: 
- Missing email address gets a useful error message
- Invalid email address gets a useful error message
- Valid login server response results in a green success alert, notifying the user to check their email
- Invalid login server response results in a red error alert with the returned message
- Query string messages are displayed upon arrival to the page as an error (e.g., if the user tries to log in with a bad token, they get redirected)
- Redirect-to query string parameter properly redirects

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [ ] Provided ticket and description
- [ ] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers