### PR TITLE
audit report: source project metadata from most recent record

### DIFF
--- a/packages/server/src/arpa_reporter/lib/audit-report.js
+++ b/packages/server/src/arpa_reporter/lib/audit-report.js
@@ -308,11 +308,12 @@ async function createReportsGroupedByProject(periodId, tenantId, dateFormat = RE
         projectLogger.debug('populating row from records in project');
 
         // set values for columns that are common across all records of projectId
+        const lastProjectRecord = projectRecords[projectRecords.length - 1];
         const row = {
             'Project ID': projectId,
-            'Project Description': projectRecords[0].content.Project_Description__c,
-            'Project Expenditure Category Group': ec(projectRecords[0].type),
-            'Project Expenditure Category': projectRecords[0].subcategory,
+            'Project Description': lastProjectRecord.content.Project_Description__c,
+            'Project Expenditure Category Group': ec(lastProjectRecord.type),
+            'Project Expenditure Category': lastProjectRecord.subcategory,
             'Capital Expenditure Amount': 0,
         };
 


### PR DESCRIPTION
### Ticket #2817
## Description

The audit report should source metadata for each project from the most recent project record, not the oldest project record.

## Screenshots / Demo Video

## Testing

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [x] Provided ticket and description
- [ ] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [x] Added PR reviewers