### PR TITLE
Stop setting configuration set when sending emails.

### DIFF
--- a/packages/server/__tests__/email/email.test.js
+++ b/packages/server/__tests__/email/email.test.js
@@ -19,7 +19,6 @@ const {
     AWS_DEFAULT_REGION,
     AWS_REGION,
     NOTIFICATIONS_EMAIL,
-    SES_CONFIGURATION_SET_DEFAULT,
 
     NODEMAILER_HOST,
     NODEMAILER_PORT,
@@ -42,7 +41,6 @@ describe('Email module', () => {
         process.env.AWS_DEFAULT_REGION = AWS_DEFAULT_REGION;
         process.env.AWS_REGION = AWS_REGION;
         process.env.NOTIFICATIONS_EMAIL = NOTIFICATIONS_EMAIL;
-        process.env.SES_CONFIGURATION_SET_DEFAULT = SES_CONFIGURATION_SET_DEFAULT;
         process.env.NODEMAILER_HOST = NODEMAILER_HOST;
         process.env.NODEMAILER_PORT = NODEMAILER_PORT;
         process.env.NODEMAILER_EMAIL = NODEMAILER_EMAIL;
@@ -62,7 +60,6 @@ describe('Email module', () => {
         delete process.env.AWS_REGION;
         delete process.env.AWS_DEFAULT_REGION;
         delete process.env.NOTIFICATIONS_EMAIL;
-        delete process.env.SES_CONFIGURATION_SET_DEFAULT;
     }
 
     const sandbox = sinon.createSandbox();
@@ -89,7 +86,6 @@ describe('Email module', () => {
             process.env.AWS_DEFAULT_REGION = 'us-west-2';
             process.env.AWS_REGION = 'us-west-2';
             process.env.NOTIFICATIONS_EMAIL = 'fake@example.org';
-            process.env.SES_CONFIGURATION_SET_DEFAULT = 'default-configuration-set';
         });
 
         it('Fails when NOTIFICATIONS_EMAIL is missing', async () => {
@@ -105,22 +101,6 @@ describe('Email module', () => {
             expect(err.message).to.be.a('string').and.satisfy(
                 (msg) => msg.startsWith('NOTIFICATIONS_EMAIL is not set'),
             );
-        });
-
-        it('sends configuration set name if SES_CONFIGURATION_SET_DEFAULT is set', async () => {
-            const sendSpy = sandbox.spy();
-            sandbox.stub(awsTransport, 'getSESClient').returns({ send: sendSpy });
-            await awsTransport.sendEmail(testEmail);
-            expect(sendSpy.called).is.true;
-            expect(sendSpy.args[0][0].input.ConfigurationSetName).to.equal('default-configuration-set');
-        });
-        it('does not require a configuration set name', async () => {
-            delete process.env.SES_CONFIGURATION_SET_DEFAULT;
-            const sendSpy = sandbox.spy();
-            sandbox.stub(awsTransport, 'getSESClient').returns({ send: sendSpy });
-            await awsTransport.sendEmail(testEmail);
-            expect(sendSpy.called).is.true;
-            expect(sendSpy.args[0][0].input).to.not.have.property('ConfigurationSetName');
         });
 
         it('correctly formats from email without name', async () => {

--- a/packages/server/src/lib/gost-aws.js
+++ b/packages/server/src/lib/gost-aws.js
@@ -103,9 +103,6 @@ async function sendEmail(message) {
     if (message.ccAddress) {
         params.Destination.CcAddresses = [message.ccAddress];
     }
-    if (process.env.SES_CONFIGURATION_SET_DEFAULT) {
-        params.ConfigurationSetName = process.env.SES_CONFIGURATION_SET_DEFAULT;
-    }
     const command = new SendEmailCommand(params);
     try {
         const data = await transport.send(command);


### PR DESCRIPTION
### Ticket #2880 
## Description
Previous PR https://github.com/usdigitalresponse/usdr-gost/pull/2974 broke email sending on staging. Looking at logs in Datadog, the error is:

> AccessDenied: User `arn:aws:sts::357150818708:assumed-role/gost-staging-api-ECSTask-2023021701041477300000000a/b364e64fadbe43adba07741023661cc3' is not authorized to perform `ses:SendEmail' on resource `arn:aws:ses:us-west-2:357150818708:configuration-set/gost-staging-default'

This PR undoes the code that adds the configuration set to emails, so as to fix email sending until the permissions issue can be addressed.

## Screenshots / Demo Video
N/A

## Testing
Once merged to staging, test that email sending is working:
1. Have a login passcode email sent from staging. Check that it was sent and that you received it.

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [ ] Provided ticket and description
- [ ] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers