### PR TITLE
Fix vue-select component registration

### DIFF
--- a/packages/client/src/main.js
+++ b/packages/client/src/main.js
@@ -9,7 +9,7 @@ if (window.APP_CONFIG?.DD_RUM_ENABLED === true) {
 import Vue from 'vue';
 import VueRouter from 'vue-router';
 import { BootstrapVue, IconsPlugin } from 'bootstrap-vue';
-import vSelect from 'vue-select';
+import { VueSelect } from 'vue-select';
 import { setUserForGoogleAnalytics } from '@/helpers/gtag';
 import App from '@/App.vue';
 import router from '@/router';
@@ -31,7 +31,7 @@ Vue.use(BootstrapVue);
 // Optionally install the BootstrapVue icon components plugin
 Vue.use(IconsPlugin);
 Vue.use(VueRouter);
-Vue.component('VSelect', vSelect);
+Vue.component('VSelect', VueSelect);
 
 Vue.config.productionTip = false;
 Vue.prototype.$negative_keywords_enabled = process.env.VUE_APP_NEGATIVE_KEYWORDS_ENABLED === 'true';


### PR DESCRIPTION
### Ticket #3103 
## Description
We noticed that the vue-select widgets were no longer rendering on staging, and the error was showing in console: 

<img width="668" alt="image" src="https://github.com/usdigitalresponse/usdr-gost/assets/126250/a87d19e2-8173-4d62-9b72-f36cbdd51647">

<img width="668" alt="image" src="https://github.com/usdigitalresponse/usdr-gost/assets/126250/2a2f9f73-c97d-4f4d-9e72-c316d9d1c971">

After investigation, it looks like switching to `type: "module"` in `package.json` in #3089 changed how `vue-select` got imported, so this PR fixes our usage to register the component properly in this context.  

## Screenshots / Demo Video

<img width="668" alt="image" src="https://github.com/usdigitalresponse/usdr-gost/assets/126250/16193eba-7795-403c-b957-02f99ca3bb2a">

## Testing

Verified the console error is now gone and the widgets render and function correctly on my devbox. 

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [ ] Provided ticket and description
- [ ] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers