### PR TITLE
fix: project summaries v2 tab pulls metadata from last *EC* record

### DIFF
--- a/packages/server/src/arpa_reporter/lib/audit-report.js
+++ b/packages/server/src/arpa_reporter/lib/audit-report.js
@@ -312,7 +312,7 @@ async function createReportsGroupedByProject(periodId, tenantId, dateFormat = RE
         const lastProjectRecord = projectSheetRecords[projectSheetRecords.length - 1];
         const row = {
             'Project ID': projectId,
-            'Project Description': lastProjectRecord?.content.Project_Description__c,
+            'Project Description': lastProjectRecord?.content.Project_Description__c ?? '[project not listed in any upload]',
             'Project Expenditure Category Group': ec(lastProjectRecord?.type),
             'Project Expenditure Category': lastProjectRecord?.subcategory,
             'Capital Expenditure Amount': 0,

--- a/packages/server/src/arpa_reporter/lib/audit-report.js
+++ b/packages/server/src/arpa_reporter/lib/audit-report.js
@@ -6,7 +6,7 @@ const XLSX = require('xlsx');
 const { PutObjectCommand } = require('@aws-sdk/client-s3');
 const { log } = require('../../lib/logging');
 const aws = require('../../lib/gost-aws');
-const { currencyNumeric, ec } = require('./format');
+const { EXPENDITURE_CATEGORIES, currencyNumeric, ec } = require('./format');
 
 const { getPreviousReportingPeriods, getAllReportingPeriods, getReportingPeriod } = require('../db/reporting-periods');
 const { getCurrentReportingPeriodID } = require('../db/settings');
@@ -308,12 +308,13 @@ async function createReportsGroupedByProject(periodId, tenantId, dateFormat = RE
         projectLogger.debug('populating row from records in project');
 
         // set values for columns that are common across all records of projectId
-        const lastProjectRecord = projectRecords[projectRecords.length - 1];
+        const projectSheetRecords = projectRecords.filter((record) => Object.keys(EXPENDITURE_CATEGORIES).includes(record.type));
+        const lastProjectRecord = projectSheetRecords[projectSheetRecords.length - 1];
         const row = {
             'Project ID': projectId,
-            'Project Description': lastProjectRecord.content.Project_Description__c,
-            'Project Expenditure Category Group': ec(lastProjectRecord.type),
-            'Project Expenditure Category': lastProjectRecord.subcategory,
+            'Project Description': lastProjectRecord?.content.Project_Description__c,
+            'Project Expenditure Category Group': ec(lastProjectRecord?.type),
+            'Project Expenditure Category': lastProjectRecord?.subcategory,
             'Capital Expenditure Amount': 0,
         };
 


### PR DESCRIPTION
### Ticket #3088
## Description

Fixes a bug in which project descriptions and expenditure category group could sometimes be missing from the audit report's "Project Summaries V2" tab.

While implementing the previous version of this feature, it slipped my mind that not all "records" generated from an upload are rows from the EC tabs.  Instead of blindly selecting the last record associated with a project and hoping that it is from an EC tab, this change filters for EC tab records explicitly and selects the last of those.

To test locally, upload the following input spreadsheet to your local instance and generate the audit report.

https://staging.grants.usdr.dev/arpa_reporter/uploads/ca1e3747-03fd-4477-9baf-aab9a911702c

## Screenshots / Demo Video

BEFORE

<img width="933" alt="image" src="https://github.com/usdigitalresponse/usdr-gost/assets/11449340/dde0dcf2-d75f-4367-9337-8dbb1193dadb">

AFTER

<img width="882" alt="image" src="https://github.com/usdigitalresponse/usdr-gost/assets/11449340/8dd98aed-221e-4eaa-bfe0-6b1793863ba6">


## Testing

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [x] Added steps to test feature/functionality manually

## Checklist
- [x] Provided ticket and description
- [x] Provided screenshots/demo
- [x] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [x] Added PR reviewers