### PR TITLE
fix: ensure uploads are sorted when fetched from DB

### DIFF
--- a/packages/server/src/arpa_reporter/db/uploads.js
+++ b/packages/server/src/arpa_reporter/db/uploads.js
@@ -64,7 +64,8 @@ function usedForTreasuryExport(periodId, tenantId = useTenantId(), trns = knex) 
                 .andOn('uploads.agency_id', '=', 'agency_max_val.agency_id')
                 .andOn('uploads.ec_code', '=', 'agency_max_val.ec_code')
                 .andOn('uploads.reporting_period_id', '=', 'agency_max_val.reporting_period_id');
-        });
+        })
+        .orderBy('created_at', 'asc');
 }
 
 /*  getUploadSummaries() returns a knex promise containing an array of


### PR DESCRIPTION
### Ticket #3088 
## Description

Another attempt to fix #3088.

I think I worked out my mistake the first time around:

In the very first iteration of this audit report we used a WITH clause in our SQL query to try to select only the latest upload for each EC category + reporting period + agency.  In most cases this is sufficient to ensure that the audit report only reads the latest instance of each project and there is no conflict about which project details will be written into the audit report.

However, if the EC code that a project is written into changes, then that project may appear more than once in the set of "latest" uploads that we pull from the database.

In my last change, #3116, I attempted to correct for this by ensuring we always used the "last" upload with matching project info from the list returned by the SQL query above.  However, what I didn't consider was that there is currently no guaranteed order in that list as it is returned by SQL.

This change resolves that by explicitly sorting the uploads fetched from the DB by `created_at`, ensuring that the "last" upload returned will also be the most recently modified.

## Screenshots / Demo Video

## Testing

In any order, submit the following two uploads to your local arpa instance and generate the audit report.

https://staging.grants.usdr.dev/arpa_reporter/uploads/7a5b219b-7bdd-4344-a6eb-17a0b6ff76f1
https://staging.grants.usdr.dev/arpa_reporter/uploads/30b183e3-efbb-4dec-ab4b-4ef543796b1a

You can also experiment with inverting the "asc" sort order in the SQL query to see the impact on the generated audit report.

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [x] Provided ticket and description
- [x] Provided screenshots/demo
- [x] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [x] Added PR reviewers