### PR TITLE
Fix failing `dependency-review-action` jobs

### DIFF
--- a/.github/workflows/code-scanning.yml
+++ b/.github/workflows/code-scanning.yml
@@ -24,7 +24,9 @@ jobs:
           disable-sudo: true
           egress-policy: block
           allowed-endpoints: >
+            api.deps.dev:443
             api.github.com:443
+            api.securityscorecards.dev:443
             github.com:443
       - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
         with:


### PR DESCRIPTION
### Relates to PR #3135

## Description

This PR fixes an issue introduced by the recent `actions/dependency-review-action` upgrade to [v4.3.3](https://github.com/actions/dependency-review-action/releases/tag/v4.3.3) in #3135. New API endpoints are now being called by this action, and those domains were missing from our `dependency-review` job's egress policy. This PR adds the following allowed endpoints:
- `api.deps.dev:443`
- `api.securityscorecards.dev:443`

See also https://github.com/actions/dependency-review-action/issues/736.