### PR TITLE
feat: update email preferences copy

### DIFF
--- a/packages/client/src/views/MyProfileView.spec.js
+++ b/packages/client/src/views/MyProfileView.spec.js
@@ -1,0 +1,59 @@
+import {
+  describe, it, beforeEach, expect, vi,
+} from 'vitest';
+import { createLocalVue, shallowMount } from '@vue/test-utils';
+import Vuex from 'vuex';
+import MyProfileView from '@/views/MyProfileView.vue';
+import { shareTerminologyEnabled } from '@/helpers/featureFlags';
+
+describe('MyProfileView.vue', () => {
+  const localVue = createLocalVue();
+  localVue.use(Vuex);
+  const store = new Vuex.Store({
+    getters: {
+      'users/loggedInUser': () => ({
+        emailPreferences: {
+          GRANT_ASSIGNMENT: 'SUBSCRIBED',
+          GRANT_INTEREST: 'SUBSCRIBED',
+          GRANT_DIGEST: 'SUBSCRIBED',
+          GRANT_FINDER_UPDATES: 'SUBSCRIBED',
+        },
+      }),
+    },
+  });
+
+  vi.mock('@/helpers/featureFlags', async (importOriginal) => ({
+    ...await importOriginal(),
+    shareTerminologyEnabled: vi.fn(),
+  }));
+
+  describe('when share terminology flag is off', () => {
+    beforeEach(() => {
+      vi.mocked(shareTerminologyEnabled).mockReturnValue(false);
+    });
+
+    it('should show assign terminology', () => {
+      const wrapper = shallowMount(MyProfileView, { store, localVue });
+      const text = wrapper.text();
+      expect(text).toContain('Grants Assignment');
+      expect(text).toContain(
+        'Send me notifications if a grant has been assigned to my USDR Grants team.',
+      );
+    });
+  });
+
+  describe('when share terminology flag is on', () => {
+    beforeEach(() => {
+      vi.mocked(shareTerminologyEnabled).mockReturnValue(true);
+    });
+
+    it('should show share terminology', () => {
+      const wrapper = shallowMount(MyProfileView, { store, localVue });
+      const text = wrapper.text();
+      expect(text).toContain('Shared Grants');
+      expect(text).toContain(
+        'Send me an email notification when someone shares a grant with my team.',
+      );
+    });
+  });
+});

--- a/packages/client/src/views/MyProfileView.vue
+++ b/packages/client/src/views/MyProfileView.vue
@@ -72,6 +72,7 @@
 
 <script>
 import { mapGetters, mapActions } from 'vuex';
+import { shareTerminologyEnabled } from '@/helpers/featureFlags';
 import EditUserModal from '@/components/Modals/EditUser.vue';
 import UserAvatar from '@/components/UserAvatar.vue';
 
@@ -81,6 +82,10 @@ export default {
     UserAvatar,
   },
   data() {
+    const shareTerminologyEnabledFlag = shareTerminologyEnabled() === true;
+    const grantAssignmentDescription = 'Send me notifications if a grant has been assigned to my USDR Grants team.';
+    const grantShareDescription = 'Send me an email notification when someone shares a grant with my team.';
+
     return {
       prefs: [
         {
@@ -89,9 +94,9 @@ export default {
           description: 'Send me a daily email if new grants match my saved search(es).',
         },
         {
-          name: 'Grants Assignment',
+          name: shareTerminologyEnabledFlag ? 'Shared Grants' : 'Grants Assignment',
           key: 'GRANT_ASSIGNMENT',
-          description: 'Send me notifications if a grant has been assigned to my USDR Grants team.',
+          description: shareTerminologyEnabledFlag ? grantShareDescription : grantAssignmentDescription,
         },
       ],
       breadcrumb_items: [


### PR DESCRIPTION
### Ticket #3064 
## Description
This change is part of the Assign-to-Share project. We want the copy within the Email Notifications settings to change if the feature flag `shareTerminologyEnabled` is set to true.

## Screenshots / Demo Video
"Assign" copy:
<img width="605" alt="image" src="https://github.com/usdigitalresponse/usdr-gost/assets/2312138/4a6ec84c-01ca-4d78-b722-3fbb3a9592ee">

"Share" copy:
<img width="588" alt="image" src="https://github.com/usdigitalresponse/usdr-gost/assets/2312138/30bc295d-33ea-4488-aef0-342087e7eae3">

## Testing
I verified this change locally. `MyProfileView.vue` doesn't seem to have a corresponding test file yet. I've been on engineering teams where the process in this case would be to create a separate chore to write tests for `MyProfileView.vue` (especially since the change made in this PR is small). But if the process here is to commit a test without exception, then I may ask to pair briefly with someone on a unit test for this code (I'm not super familiar with Vue.js, and I hit my timebox for getting a test working on my own).

Manual steps for reviewer:
Navigate to `My Profile -> Email Notifications` to verify the copy change (the `shareTerminologyEnabledFlag` will need to be manually set to false/true in the code to see the change).

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [x] Added steps to test feature/functionality manually

## Checklist
- [x] Provided ticket and description
- [x] Provided screenshots/demo
- [x] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers