### PR TITLE
Include assignee name in Recent Activity view

### DIFF
--- a/packages/client/src/components/ActivityTable.spec.js
+++ b/packages/client/src/components/ActivityTable.spec.js
@@ -1,0 +1,44 @@
+import {
+  beforeEach, describe, it, expect,
+} from 'vitest';
+import { createLocalVue, mount } from '@vue/test-utils';
+import { BootstrapVue } from 'bootstrap-vue';
+import ActivityTable from '@/components/ActivityTable.vue';
+
+let wrapper;
+const stubs = ['b-icon'];
+const localVue = createLocalVue();
+localVue.use(BootstrapVue);
+
+describe('ActivityTable.vue', () => {
+  describe('when view is loaded', () => {
+    beforeEach(() => {
+      wrapper = mount(ActivityTable, {
+        localVue,
+        stubs,
+        propsData: {
+          grantsInterested: [],
+          onRowSelected: () => {},
+          onRowClicked: () => {},
+        },
+      });
+    });
+
+    it('displays information about interested grants', async () => {
+      await wrapper.setProps({
+        grantsInterested: [{
+          created_at: '2024-06-16T00:00:00.000Z', name: 'USDR', status_code: 'Rejected', interested_name: 'Will Apply', agency_id: 0, title: 'Rejected Grant', grant_id: '666997', assigned_by: null, assigned_by_user_name: null,
+        }, {
+          created_at: '2024-06-15T00:00:00.000Z', name: 'USDR', status_code: 'Interested', interested_name: 'Will Apply', agency_id: 0, title: 'Test Grant 666999', grant_id: '666999', assigned_by: null, assigned_by_user_name: null,
+        }, {
+          created_at: '2024-06-20T00:00:00.000Z', name: 'USDR', status_code: null, interested_name: null, agency_id: 0, title: 'EAR Postdoctoral Fellowships', grant_id: '333334', assigned_by: 17, assigned_by_user_name: 'USDR Staff',
+        }],
+      });
+
+      const text = wrapper.text();
+      expect(text).toContain('USDR  rejected Rejected Grant');
+      expect(text).toContain('USDR  is  interested  in Test Grant 666999');
+      expect(text).toContain('USDR Staff shared  EAR Postdoctoral Fellowships with USDR');
+    });
+  });
+});

--- a/packages/client/src/components/ActivityTable.vue
+++ b/packages/client/src/components/ActivityTable.vue
@@ -59,7 +59,7 @@
       </div>
     </template>
     <template #cell(agencyAndGrant)="agencies">
-      <div>
+      <div v-if="agencies.item.interested !== statuses.assigned">
         {{ agencies.item.agency }}
         <span
           v-if="agencies.item.interested === statuses.rejected"
@@ -70,7 +70,6 @@
             <strong> interested </strong>
           </span> in
         </span>
-        <span v-if="agencies.item.interested === statuses.assigned"> was<strong> assigned </strong> </span>
         <span v-if="agencies.item.interested === statuses.awarded"> was<strong><span
           class="color-yellow"
         > awarded </span></strong> </span>
@@ -80,6 +79,12 @@
         <span v-if="agencies.item.interested === statuses.lost"><strong><span
           class="color-yellow"
         > lost </span></strong> </span>{{ agencies.item.grant }}
+      </div>
+      <div>
+        <span v-if="agencies.item.interested === statuses.assigned">
+          {{ agencies.item.assigned_by_user_name }}<strong> shared </strong> {{ agencies.item.grant }}
+          with {{ agencies.item.agency }}
+        </span>
       </div>
     </template>
     <template #cell(date)="dates">
@@ -148,6 +153,7 @@ export default {
         agency: grantsInterested.name,
         grant: grantsInterested.title,
         grant_id: grantsInterested.grant_id,
+        assigned_by_user_name: grantsInterested.assigned_by_user_name,
         interested: (() => {
           let retVal = null;
           if (grantsInterested.status_code != null) {

--- a/packages/server/__tests__/db/db.test.js
+++ b/packages/server/__tests__/db/db.test.js
@@ -308,6 +308,11 @@ describe('db', () => {
             expect(rows.data).to.have.lengthOf(2);
             expect(rows.data.map((r) => r.created_at.getTime())).to.have.all.members([1663117521515, 1659827033570]);
         });
+        it('includes assigned_by_user_name for assigned grants', async () => {
+            const rows = await db.getGrantsInterested({ agencyId: fixtures.users.staffUser.agency_id, perPage: 6, currentPage: 1 });
+            const record = rows.data.find((el) => el.assigned_by === 1);
+            expect(record.assigned_by_user_name).to.equal('Admin User');
+        });
     });
 
     context('getClosestGrant', () => {

--- a/packages/server/src/db/index.js
+++ b/packages/server/src/db/index.js
@@ -1119,7 +1119,8 @@ async function getGrantsInterested({ agencyId, perPage, currentPage }) {
                           grants_interested.agency_id,
                           grants.title,
                           grants.grant_id,
-                          NULL AS assigned_by`))
+                          NULL AS assigned_by,
+                          NULL AS assigned_by_user_name`))
         .innerJoin('agencies', 'agencies.id', 'grants_interested.agency_id')
         .innerJoin('interested_codes', 'interested_codes.id', 'grants_interested.interested_code_id')
         .innerJoin('grants', 'grants.grant_id', 'grants_interested.grant_id')
@@ -1132,8 +1133,10 @@ async function getGrantsInterested({ agencyId, perPage, currentPage }) {
                                 assigned_grants_agency.agency_id,
                                 grants.title,
                                 grants.grant_id,
-                                assigned_grants_agency.assigned_by`))
+                                assigned_grants_agency.assigned_by,
+                                users.name AS assigned_by_user_name`))
                 .from('assigned_grants_agency')
+                .innerJoin('users', 'users.id', 'assigned_grants_agency.assigned_by')
                 .innerJoin('agencies', 'agencies.id', 'assigned_grants_agency.agency_id')
                 .innerJoin('grants', 'grants.grant_id', 'assigned_grants_agency.grant_id')
                 .whereIn('agencies.id', agencies.map((subAgency) => subAgency.id))


### PR DESCRIPTION
### Ticket #3062
## Description
The Recent Activity log includes information about interested grants, rejected grants, assigned grants, etc. This change updates the language around assigned grants and includes the name of the user who shared the grant.

## Screenshots / Demo Video
Last item in the Recent Activity table shows that a user shared a grant.
<img width="892" alt="image" src="https://github.com/usdigitalresponse/usdr-gost/assets/2312138/6abf8932-1d46-4b14-a568-ce918a54c5b4">


## Testing
Navigate to the Recent Activity log (`/dashboard`). In order for an assigned grant to show up, the record in the `assigned_grants_agency` table must have a non-null `assigned_by` value.

### Automated and Unit Tests
- [x] Added Unit tests

### Manual tests for Reviewer
- [x] Added steps to test feature/functionality manually

## Checklist
- [x] Provided ticket and description
- [x] Provided screenshots/demo
- [x] Provided testing information
- [x] Provided adequate test coverage for all new code
- [ ] Added PR reviewers