### PR TITLE
Deploy client-side `shareTerminologyEnabled` feature flag

### DIFF
--- a/terraform/prod.tfvars
+++ b/terraform/prod.tfvars
@@ -50,6 +50,7 @@ website_datadog_rum_options = {
 website_feature_flags = {
   newTerminologyEnabled      = true,
   newGrantsDetailPageEnabled = true,
+  shareTerminologyEnabled    = false,
 }
 
 // Google Analytics Account ID: 233192355, Property ID: 321194851, Stream ID: 3802896350

--- a/terraform/staging.tfvars
+++ b/terraform/staging.tfvars
@@ -47,6 +47,7 @@ website_datadog_rum_options = {
 website_feature_flags = {
   newTerminologyEnabled      = true,
   newGrantsDetailPageEnabled = true,
+  shareTerminologyEnabled    = true,
 }
 
 // Google Analytics Account ID: 233192355, Property ID: 429910307, Stream ID: 7590745080


### PR DESCRIPTION
### Ticket #3060 (follow up to #3147)
## Description

This PR registers the client-side `shareTerminologyEnabled` feature flag in Staging and Production environments. By default, it is enabled in Staging and disabled in Production.