### PR TITLE
Assign-to-Share: Update email templates

### DIFF
--- a/packages/server/__tests__/email/email.test.js
+++ b/packages/server/__tests__/email/email.test.js
@@ -47,6 +47,7 @@ describe('Email module', () => {
         process.env.NODEMAILER_PORT = NODEMAILER_PORT;
         process.env.NODEMAILER_EMAIL = NODEMAILER_EMAIL;
         process.env.NODEMAILER_EMAIL_PW = NODEMAILER_EMAIL_PW;
+        process.env.SHARE_TERMINOLOGY_ENABLED = false;
     }
 
     function clearNodemailerEnvironmentVariables() {
@@ -308,6 +309,56 @@ describe('Email sender', () => {
             expect(sendFake.firstCall.args[0].body.includes('... View on')).to.equal(true);
         });
     });
+
+    context('send grant shared email', () => {
+        it('calls the transport function with appropriate parameters', async () => {
+            process.env.SHARE_TERMINOLOGY_ENABLED = true
+            const sendFake = sinon.fake.returns('foo');
+            sinon.replace(emailService, 'getTransport', sinon.fake.returns({ sendEmail: sendFake }));
+
+            await email.sendGrantAssignedEmails({ grantId: '335255', agencyIds: [0, 1], userId: 1 });
+
+            // There are 3 total users in agencies 0 and 1 and none are explicitly unsubscribed for grant assignment
+            // notifications which means they are all implicitly subscribed.
+            expect(sendFake.callCount).to.equal(3);
+            expect(sendFake.calledWithMatch(
+                {
+                    fromName: 'USDR Federal Grant Finder',
+                    toAddress: 'staff.user@test.com',
+                    subject: 'Admin User Shared a Grant with Your Team',
+                    tags: ['notification_type=grant_assignment', 'user_role=staff', 'organization_id=0', 'team_id=0'],
+                },
+            )).to.be.true;
+            expect(sendFake.calledWithMatch(
+                {
+                    fromName: 'USDR Federal Grant Finder',
+                    toAddress: 'sub.staff.user@test.com',
+                    subject: 'Admin User Shared a Grant with Your Team',
+                    tags: ['notification_type=grant_assignment', 'user_role=staff', 'organization_id=0', 'team_id=1'],
+                },
+            )).to.be.true;
+            expect(sendFake.calledWithMatch(
+                {
+                    fromName: 'USDR Federal Grant Finder',
+                    toAddress: 'admin.user@test.com',
+                    subject: 'Admin User Shared a Grant with Your Team',
+                    tags: ['notification_type=grant_assignment', 'user_role=admin', 'organization_id=0', 'team_id=0'],
+                },
+            )).to.be.true;
+        });
+        it('is resilient to missing grant description', async () => {
+            process.env.SHARE_TERMINOLOGY_ENABLED = true
+            const sendFake = sinon.fake.returns('foo');
+            sinon.replace(emailService, 'getTransport', sinon.fake.returns({ sendEmail: sendFake }));
+            const grant = fixtures.grants.noDescOrEligibilityCodes;
+
+            await email.sendGrantAssignedEmails({ grantId: grant.grant_id, agencyIds: [0], userId: 1 });
+
+            expect(sendFake.called).to.equal(true);
+            expect(sendFake.firstCall.args[0].body.includes('... View on')).to.equal(true);
+        });
+    });
+
     context('send async report email', () => {
         it('sendAsyncReportEmail delivers an email with the signedURL for audit report', async () => {
             const sendFake = sinon.fake.returns('foo');

--- a/packages/server/__tests__/email/email.test.js
+++ b/packages/server/__tests__/email/email.test.js
@@ -25,6 +25,7 @@ const {
     NODEMAILER_PORT,
     NODEMAILER_EMAIL,
     NODEMAILER_EMAIL_PW,
+    SHARE_TERMINOLOGY_ENABLED,
 } = process.env;
 
 const testEmail = {
@@ -47,7 +48,7 @@ describe('Email module', () => {
         process.env.NODEMAILER_PORT = NODEMAILER_PORT;
         process.env.NODEMAILER_EMAIL = NODEMAILER_EMAIL;
         process.env.NODEMAILER_EMAIL_PW = NODEMAILER_EMAIL_PW;
-        process.env.SHARE_TERMINOLOGY_ENABLED = false;
+        process.env.SHARE_TERMINOLOGY_ENABLED = SHARE_TERMINOLOGY_ENABLED;
     }
 
     function clearNodemailerEnvironmentVariables() {
@@ -265,6 +266,8 @@ describe('Email sender', () => {
     });
     context('send grant assigned email', () => {
         it('calls the transport function with appropriate parameters', async () => {
+            process.env.SHARE_TERMINOLOGY_ENABLED = false;
+
             const sendFake = sinon.fake.returns('foo');
             sinon.replace(emailService, 'getTransport', sinon.fake.returns({ sendEmail: sendFake }));
 
@@ -299,6 +302,8 @@ describe('Email sender', () => {
             )).to.be.true;
         });
         it('is resilient to missing grant description', async () => {
+            process.env.SHARE_TERMINOLOGY_ENABLED = false;
+
             const sendFake = sinon.fake.returns('foo');
             sinon.replace(emailService, 'getTransport', sinon.fake.returns({ sendEmail: sendFake }));
             const grant = fixtures.grants.noDescOrEligibilityCodes;

--- a/packages/server/__tests__/email/email.test.js
+++ b/packages/server/__tests__/email/email.test.js
@@ -312,7 +312,7 @@ describe('Email sender', () => {
 
     context('send grant shared email', () => {
         it('calls the transport function with appropriate parameters', async () => {
-            process.env.SHARE_TERMINOLOGY_ENABLED = true
+            process.env.SHARE_TERMINOLOGY_ENABLED = true;
             const sendFake = sinon.fake.returns('foo');
             sinon.replace(emailService, 'getTransport', sinon.fake.returns({ sendEmail: sendFake }));
 
@@ -347,7 +347,7 @@ describe('Email sender', () => {
             )).to.be.true;
         });
         it('is resilient to missing grant description', async () => {
-            process.env.SHARE_TERMINOLOGY_ENABLED = true
+            process.env.SHARE_TERMINOLOGY_ENABLED = true;
             const sendFake = sinon.fake.returns('foo');
             sinon.replace(emailService, 'getTransport', sinon.fake.returns({ sendEmail: sendFake }));
             const grant = fixtures.grants.noDescOrEligibilityCodes;

--- a/packages/server/src/lib/email.js
+++ b/packages/server/src/lib/email.js
@@ -310,7 +310,7 @@ async function buildGrantDetail(grant, emailNotificationType) {
     return grantDetail;
 }
 
-async function sendGrantAssignedEmailsForAgency(assignee_agency, grantDetail, assignorUserId) {
+async function sendGrantAssignedEmailsForAgencyLegacy(assignee_agency, grantDetail, assignorUserId) {
     const grantAssignedBodyTemplate = fileSystem.readFileSync(path.join(__dirname, '../static/email_templates/_grant_assigned_body.html'));
 
     const assignor = await db.getUser(assignorUserId);
@@ -353,7 +353,7 @@ async function sendGrantAssignedEmailsForAgency(assignee_agency, grantDetail, as
     await asyncBatch(inputs, deliverEmail, 2);
 }
 
-async function sendGrantSharedEmailsForAgency(assignee_agency, grant, grantDetail, assignorUserId) {
+async function sendGrantAssignedEmailsForAgency(assignee_agency, grant, grantDetail, assignorUserId) {
     const grantAssignedBodyTemplate = fileSystem.readFileSync(path.join(__dirname, '../static/email_templates/_grant_assigned_body.html'));
 
     const assignor = await db.getUser(assignorUserId);
@@ -413,8 +413,8 @@ async function sendGrantAssignedEmails({ grantId, agencyIds, userId }) {
             agencies,
             async (agency) => {
                 process.env.SHARE_TERMINOLOGY_ENABLED === 'true'
-                    ? await sendGrantSharedEmailsForAgency(agency, grant, grantDetail, userId)
-                    : await sendGrantAssignedEmailsForAgency(agency, grantDetail, userId);
+                    ? await sendGrantAssignedEmailsForAgency(agency, grant, grantDetail, userId)
+                    : await sendGrantAssignedEmailsForAgencyLegacy(agency, grantDetail, userId);
             },
             2,
         );

--- a/packages/server/src/lib/email.js
+++ b/packages/server/src/lib/email.js
@@ -320,6 +320,7 @@ async function sendGrantAssignedEmailsForAgencyLegacy(assignee_agency, grantDeta
         assignor_agency_name: assignor.agency.name,
         assignee_agency_name: assignee_agency.name,
         grant_assigned_header: 'Grant Assigned',
+        use_share_terminology: false,
     }, {
         grant_detail: grantDetail,
     });
@@ -363,6 +364,7 @@ async function sendGrantAssignedEmailsForAgency(assignee_agency, grant, grantDet
         assignor_name: assignor.name,
         assignor_agency_name: assignor.agency.name,
         assignee_agency_name: assignee_agency.name,
+        use_share_terminology: true,
     }, {
         grant_detail: grantDetail,
     });

--- a/packages/server/src/static/email_templates/_grant_assigned_body.html
+++ b/packages/server/src/static/email_templates/_grant_assigned_body.html
@@ -21,6 +21,7 @@
                                                 </p>
                                             </td>
                                         </tr>
+                                        {{^use_share_terminology}}
                                         <tr style="border-collapse:collapse">
                                             <td align="left" style="padding:0;Margin:0">
                                                 <p
@@ -30,6 +31,7 @@
                                                 </p>
                                             </td>
                                         </tr>
+                                        {{/use_share_terminology}}
                                     </table>
                                 </td>
                             </tr>

--- a/packages/server/src/static/email_templates/_grant_assigned_body.html
+++ b/packages/server/src/static/email_templates/_grant_assigned_body.html
@@ -1,4 +1,4 @@
-<table class="es-content" cellspacing="0" cellpadding="0" align="center"
+<table class="es-content" cellspacing="0" cellpadding="0" align="center" style="padding-left:20px;padding-right:20px"
     style="mso-table-lspace:0pt;mso-table-rspace:0pt;border-collapse:collapse;border-spacing:0px;table-layout:fixed !important;width:100%">
     <tr style="border-collapse:collapse">
         <td align="center" bgcolor="#FFFFFF" style="padding:0;Margin:0;background-color:#ffffff">
@@ -17,7 +17,7 @@
                                             <td align="left" style="padding:0;Margin:0">
                                                 <p
                                                     style="Margin:0;-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;font-family:arial, 'helvetica neue', helvetica, sans-serif;line-height:39px;color:#000000;font-size:26px">
-                                                    <strong>Grant Assigned</strong>
+                                                    <strong>{{grant_assigned_header}}</strong>
                                                 </p>
                                             </td>
                                         </tr>


### PR DESCRIPTION
### Ticket #3065 
## Description
Update email templates for assign-to-share terminology
## Screenshots / Demo Video

<img width="1512" alt="Screenshot 2024-06-18 at 8 08 43 PM" src="https://github.com/usdigitalresponse/usdr-gost/assets/9020627/d0e66153-984e-4673-ba52-77062650f351">


## Testing
Added a new test with the SHARE_TERMINOLOGY_ENABLED environment variable set. Test covers that the new terminology is used. 