### PR TITLE
bump: terraform version from 13.8 to 13.13

### DIFF
--- a/terraform/modules/gost_postgres/main.tf
+++ b/terraform/modules/gost_postgres/main.tf
@@ -2,9 +2,9 @@ data "aws_region" "current" {}
 data "aws_partition" "current" {}
 data "aws_caller_identity" "current" {}
 
-data "aws_rds_engine_version" "postgres13_8" {
+data "aws_rds_engine_version" "postgres13_12" {
   engine  = "aurora-postgresql"
-  version = "13.8"
+  version = "13.12"
 }
 
 terraform {
@@ -56,8 +56,8 @@ module "db" {
 
   name                       = "${var.namespace}-postgres"
   cluster_use_name_prefix    = true
-  engine                     = data.aws_rds_engine_version.postgres13_8.engine
-  engine_version             = data.aws_rds_engine_version.postgres13_8.version
+  engine                     = data.aws_rds_engine_version.postgres13_12.engine
+  engine_version             = data.aws_rds_engine_version.postgres13_12.version
   auto_minor_version_upgrade = true
   engine_mode                = "provisioned"
   storage_encrypted          = true

--- a/terraform/modules/gost_postgres/main.tf
+++ b/terraform/modules/gost_postgres/main.tf
@@ -2,9 +2,9 @@ data "aws_region" "current" {}
 data "aws_partition" "current" {}
 data "aws_caller_identity" "current" {}
 
-data "aws_rds_engine_version" "postgres13_12" {
+data "aws_rds_engine_version" "postgres13_13" {
   engine  = "aurora-postgresql"
-  version = "13.12"
+  version = "13.13"
 }
 
 terraform {
@@ -56,8 +56,8 @@ module "db" {
 
   name                       = "${var.namespace}-postgres"
   cluster_use_name_prefix    = true
-  engine                     = data.aws_rds_engine_version.postgres13_12.engine
-  engine_version             = data.aws_rds_engine_version.postgres13_12.version
+  engine                     = data.aws_rds_engine_version.postgres13_13.engine
+  engine_version             = data.aws_rds_engine_version.postgres13_13.version
   auto_minor_version_upgrade = true
   engine_mode                = "provisioned"
   storage_encrypted          = true


### PR DESCRIPTION
This is done to resolve the various downgrading problems experienced when deploying to staging. For some reason currently unknown the postgres version in AWS is 12 rather than 8.

Since there is no configuration in terraform that is currently compatible with version 12 this PR bumps it to version 13 instead.

https://github.com/usdigitalresponse/usdr-gost/actions/runs/9767620685/job/27000430430
```
##[debug]Set output stdout = module.postgres.module.db.aws_rds_cluster.this[0]: Modifying... [id=gost-staging-postgres-20230217010405040800000006]
##[debug]module.api.aws_ecs_task_definition.default[0]: Creating...
##[debug]module.api.aws_ecs_task_definition.default[0]: Creation complete after 1s [id=gost-staging-api]
##[debug]module.api.module.grant_digest_scheduled_task.data.aws_iam_policy_document.permissions[0]: Reading...
##[debug]module.api.module.grant_digest_scheduled_task.data.aws_iam_policy_document.permissions[0]: Read complete after 0s [id=4034382145]
##[debug]module.api.module.grant_digest_scheduled_task.aws_scheduler_schedule.default[0]: Modifying... [id=default/gost-staging-grant-digest-task20240404183105743500000002]
##[debug]module.api.aws_ecs_service.default[0]: Modifying... [id=arn:aws:ecs:us-west-2:357150818708:service/gost-staging/gost-staging-api]
##[debug]module.api.module.grant_digest_scheduled_task.aws_scheduler_schedule.default[0]: Modifications complete after 0s [id=default/gost-staging-grant-digest-task20240404183105743500000002]
##[debug]module.api.aws_ecs_service.default[0]: Modifications complete after 0s [id=arn:aws:ecs:us-west-2:357150818708:service/gost-staging/gost-staging-api]
##[debug]
##[debug]Set output stderr = 
##[debug]Error: updating RDS Cluster (gost-staging-postgres-20230217010405040800000006): InvalidParameterCombination: Cannot upgrade aurora-postgresql from 13.12 to 13.8
##[debug]	status code: 400, request id: 6a9a2e[97](https://github.com/usdigitalresponse/usdr-gost/actions/runs/9767620685/job/27000430430#step:14:98)-7311-4e2f-9159-49cc9bf3d771
##[debug]
##[debug]  with module.postgres.module.db.aws_rds_cluster.this[0],
##[debug]  on .terraform/modules/postgres.db/main.tf line 39, in resource "aws_rds_cluster" "this":
##[debug]  39: resource "aws_rds_cluster" "this" {
##[debug]
##[debug]
##[debug]Set output exitcode = 1
##[debug]Finishing: Terraform Apply
```