### PR TITLE
Upgrade RDS certificate on Staging

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -443,9 +443,10 @@ module "postgres" {
   namespace                = var.namespace
   permissions_boundary_arn = local.permissions_boundary_arn
 
-  default_db_name = "gost"
-  vpc_id          = data.aws_ssm_parameter.vpc_id.value
-  subnet_ids      = local.private_subnet_ids
+  default_db_name    = "gost"
+  ca_cert_identifier = var.postgres_ca_cert_identifier
+  vpc_id             = data.aws_ssm_parameter.vpc_id.value
+  subnet_ids         = local.private_subnet_ids
   ingress_security_groups = {
     from_api                  = module.api_to_postgres_security_group.id
     from_consume_grants       = module.consume_grants_to_postgres_security_group.id

--- a/terraform/modules/gost_postgres/main.tf
+++ b/terraform/modules/gost_postgres/main.tf
@@ -61,6 +61,7 @@ module "db" {
   auto_minor_version_upgrade = true
   engine_mode                = "provisioned"
   storage_encrypted          = true
+  ca_cert_identifier         = var.ca_cert_identifier
 
   vpc_id                         = var.vpc_id
   subnets                        = var.subnet_ids

--- a/terraform/modules/gost_postgres/variables.tf
+++ b/terraform/modules/gost_postgres/variables.tf
@@ -64,3 +64,8 @@ variable "query_logging_enabled" {
   type        = bool
   default     = false
 }
+
+variable "ca_cert_identifier" {
+  description = "Certificate Authority identifier for RDS Aurora Postgres cluster instances."
+  type        = string
+}

--- a/terraform/prod.tfvars
+++ b/terraform/prod.tfvars
@@ -81,6 +81,7 @@ postgres_enabled                   = true
 postgres_prevent_destroy           = true
 postgres_snapshot_before_destroy   = true
 postgres_apply_changes_immediately = false
+postgres_ca_cert_identifier        = "rds-ca-2019"
 
 // Grant events consumer
 consume_grants_source_event_bus_name = "default"

--- a/terraform/sandbox.tfvars
+++ b/terraform/sandbox.tfvars
@@ -37,6 +37,7 @@ postgres_enabled                   = true
 postgres_prevent_destroy           = true
 postgres_snapshot_before_destroy   = false
 postgres_apply_changes_immediately = true
+postgres_ca_cert_identifier        = "rds-ca-rsa2048-g1"
 
 // Consume Grants
 consume_grants_source_event_bus_name = "default"

--- a/terraform/staging.tfvars
+++ b/terraform/staging.tfvars
@@ -79,6 +79,7 @@ postgres_prevent_destroy           = true
 postgres_snapshot_before_destroy   = true
 postgres_apply_changes_immediately = false
 postgres_query_logging_enabled     = true
+postgres_ca_cert_identifier        = "rds-ca-rsa2048-g1"
 
 // Grant events consumer
 consume_grants_source_event_bus_name = "default"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -233,6 +233,10 @@ variable "postgres_query_logging_enabled" {
   type    = bool
   default = false
 }
+variable "postgres_ca_cert_identifier" {
+  description = "Certificate Authority identifier for RDS Aurora Postgres cluster instances."
+  type        = string
+}
 
 # Consume Grants
 variable "consume_grants_source_event_bus_name" {


### PR DESCRIPTION
## Description

This PR adds explicit configuration for setting the SSL/TLS certificate for RDS Aurora Postgres in Terraform and sets values for the new config in each environment. Deploying this change to the Staging environment will trigger rotation of the current `rds-ca-2019` certificate to the new `rds-ca-rsa2048-g1` certificate. It will NOT affect the certificate on Production.

Note that #3273 updated the CA bundle file used to verify SSL/TLS connections. Previously, the bundle was only compatible with the `rds-ca-2019` certificate; the new bundle file is compatible with both `rds-ca-2019` and `rds-ca-rsa-2048-g1` certificates.

Per-environment configuration:
- Sandbox: 
  - Certificate identifier: `rds-ca-rsa-2048-g1` 
  - Effect: The certificate in this environment has already been manually rotated, so this setting has no effect.
- Staging:
  - Certificate identifier: `rds-ca-rsa-2048-g1`
  - Effect: As the Staging environment currently uses the `rds-ca-2019` certificate, this change will prompt RDS to schedule a certificate upgrade in this environment.
- Production: 
  - Certificate identifier: `rds-ca-2019`
  - Effect: This environment currently uses the `rds-ca-2019` certificate, so this setting has no effect.
