### PR TITLE
feat(grants-collaboration): create library

### DIFF
--- a/packages/server/__tests__/db/db.test.js
+++ b/packages/server/__tests__/db/db.test.js
@@ -6,6 +6,7 @@ const { TABLES } = require('../../src/db/constants');
 const fixtures = require('./seeds/fixtures');
 const emailConstants = require('../../src/lib/email/constants');
 const keywordMigrationScript = require('../../src/db/saved_search_migration');
+const { saveNoteRevision, getOrganizationNotesForGrant } = require('../../src/lib/grantsCollaboration/notes');
 
 const BASIC_SEARCH_CRITERIA = JSON.stringify({
     includeKeywords: 'Grant',
@@ -27,6 +28,56 @@ describe('db', () => {
 
     after(async () => {
         await db.knex.destroy();
+    });
+    context('saveNoteRevision', () => {
+        it('creates new note', async () => {
+            const result = await saveNoteRevision(knex, fixtures.grants.earFellowship.grant_id, fixtures.roles.adminRole.id, 'This is a test revision');
+            expect(result.id).to.equal(1);
+        });
+        it('creates new note revision', async () => {
+            const result = await saveNoteRevision(knex, fixtures.grants.earFellowship.grant_id, fixtures.roles.adminRole.id, 'This is a test revision #2');
+            expect(result.id).to.equal(2);
+        });
+    });
+    context('getOrganizationNotesForGrant', () => {
+        it('get existing organization notes for grant', async () => {
+            const result = await getOrganizationNotesForGrant(knex, fixtures.grants.earFellowship.grant_id, fixtures.agencies.accountancy.tenant_id);
+            const expectedNoteStructure = {
+                notes: [{
+                    id: 2,
+                    createdAt: result.notes[0].createdAt, // store to pass structure check
+                    text: 'This is a test revision #2',
+                    grant: { id: fixtures.grants.earFellowship.grant_id },
+                    user: {
+                        id: fixtures.roles.adminRole.id,
+                        name: fixtures.users.adminUser.name,
+                        team: {
+                            id: fixtures.agencies.accountancy.id,
+                            name: fixtures.agencies.accountancy.name,
+                        },
+                        organization: {
+                            id: fixtures.tenants.SBA.id,
+                            name: fixtures.tenants.SBA.display_name,
+                        },
+                    },
+                }],
+                pagination: {
+                    from: 2,
+                },
+            };
+
+            // validate createdAt is valid time
+            expect(result.notes[0].createdAt).to.satisfy((date) => {
+                const timestamp = new Date(date).getTime();
+                return !Number.isNaN(timestamp);
+            });
+
+            // remove createdAt to validate the rest of the structure
+            delete expectedNoteStructure.notes[0].createdAt;
+            delete result.notes[0].createdAt;
+
+            expect(result).to.deep.equal(expectedNoteStructure);
+        });
     });
     context('migrate keywords to saved search', () => {
         it('migrates keywords to saved search dry-run', async () => {

--- a/packages/server/__tests__/db/db.test.js
+++ b/packages/server/__tests__/db/db.test.js
@@ -6,7 +6,6 @@ const { TABLES } = require('../../src/db/constants');
 const fixtures = require('./seeds/fixtures');
 const emailConstants = require('../../src/lib/email/constants');
 const keywordMigrationScript = require('../../src/db/saved_search_migration');
-const { saveNoteRevision, getOrganizationNotesForGrant } = require('../../src/lib/grantsCollaboration/notes');
 
 const BASIC_SEARCH_CRITERIA = JSON.stringify({
     includeKeywords: 'Grant',
@@ -28,56 +27,6 @@ describe('db', () => {
 
     after(async () => {
         await db.knex.destroy();
-    });
-    context('saveNoteRevision', () => {
-        it('creates new note', async () => {
-            const result = await saveNoteRevision(knex, fixtures.grants.earFellowship.grant_id, fixtures.roles.adminRole.id, 'This is a test revision');
-            expect(result.id).to.equal(1);
-        });
-        it('creates new note revision', async () => {
-            const result = await saveNoteRevision(knex, fixtures.grants.earFellowship.grant_id, fixtures.roles.adminRole.id, 'This is a test revision #2');
-            expect(result.id).to.equal(2);
-        });
-    });
-    context('getOrganizationNotesForGrant', () => {
-        it('get existing organization notes for grant', async () => {
-            const result = await getOrganizationNotesForGrant(knex, fixtures.grants.earFellowship.grant_id, fixtures.agencies.accountancy.tenant_id);
-            const expectedNoteStructure = {
-                notes: [{
-                    id: 2,
-                    createdAt: result.notes[0].createdAt, // store to pass structure check
-                    text: 'This is a test revision #2',
-                    grant: { id: fixtures.grants.earFellowship.grant_id },
-                    user: {
-                        id: fixtures.roles.adminRole.id,
-                        name: fixtures.users.adminUser.name,
-                        team: {
-                            id: fixtures.agencies.accountancy.id,
-                            name: fixtures.agencies.accountancy.name,
-                        },
-                        organization: {
-                            id: fixtures.tenants.SBA.id,
-                            name: fixtures.tenants.SBA.display_name,
-                        },
-                    },
-                }],
-                pagination: {
-                    from: 2,
-                },
-            };
-
-            // validate createdAt is valid time
-            expect(result.notes[0].createdAt).to.satisfy((date) => {
-                const timestamp = new Date(date).getTime();
-                return !Number.isNaN(timestamp);
-            });
-
-            // remove createdAt to validate the rest of the structure
-            delete expectedNoteStructure.notes[0].createdAt;
-            delete result.notes[0].createdAt;
-
-            expect(result).to.deep.equal(expectedNoteStructure);
-        });
     });
     context('migrate keywords to saved search', () => {
         it('migrates keywords to saved search dry-run', async () => {

--- a/packages/server/__tests__/lib/access-helpers.test.js
+++ b/packages/server/__tests__/lib/access-helpers.test.js
@@ -1,7 +1,6 @@
 const { expect } = require('chai');
 const sinon = require('sinon');
 const { getAdminAuthInfo, isMicrosoftSafeLinksRequest } = require('../../src/lib/access-helpers');
-const db = require('../../src/db');
 const fixtures = require('../db/seeds/fixtures');
 
 async function expectUnauthorized(request) {
@@ -13,13 +12,6 @@ async function expectUnauthorized(request) {
 }
 
 describe('Acces Helper Module', () => {
-    before(async () => {
-        await fixtures.seed(db.knex);
-    });
-
-    after(async () => {
-        await db.knex.destroy();
-    });
     context('getAdminAuthInfo', () => {
         it('throws error if no user ID exists in signed cookie', async () => {
             const requestFake = {

--- a/packages/server/__tests__/lib/grants-collaboration.test.js
+++ b/packages/server/__tests__/lib/grants-collaboration.test.js
@@ -53,10 +53,56 @@ describe('Grants Collaboration', () => {
 
             expect(result).to.deep.equal(expectedNoteStructure);
         });
+        it('get existing organization notes for grant after a revision', async () => {
+            const result = await getOrganizationNotesForGrant(knex, fixtures.grants.earFellowship.grant_id, fixtures.agencies.accountancy.tenant_id, { afterRevision: 1 });
+            const expectedNoteStructure = {
+                notes: [{
+                    id: 2,
+                    createdAt: result.notes[0].createdAt, // store to pass structure check
+                    text: 'This is a test revision #2',
+                    grant: { id: fixtures.grants.earFellowship.grant_id },
+                    user: {
+                        id: fixtures.roles.adminRole.id,
+                        name: fixtures.users.adminUser.name,
+                        team: {
+                            id: fixtures.agencies.accountancy.id,
+                            name: fixtures.agencies.accountancy.name,
+                        },
+                        organization: {
+                            id: fixtures.tenants.SBA.id,
+                            name: fixtures.tenants.SBA.display_name,
+                        },
+                    },
+                }],
+                pagination: {
+                    from: 2,
+                },
+            };
+            // validate createdAt is valid time
+            expect(result.notes[0].createdAt).to.satisfy((date) => {
+                const timestamp = new Date(date).getTime();
+                return !Number.isNaN(timestamp);
+            });
 
+            // remove createdAt to validate the rest of the structure
+            delete expectedNoteStructure.notes[0].createdAt;
+            delete result.notes[0].createdAt;
+
+            expect(result).to.deep.equal(expectedNoteStructure);
+        });
+        it('get no organization notes for grant after a revision', async () => {
+            const result = await getOrganizationNotesForGrant(knex, fixtures.grants.earFellowship.grant_id, fixtures.agencies.accountancy.tenant_id, { afterRevision: 2 });
+            const expectedNoteStructure = {
+                notes: [],
+                pagination: {
+                    from: 2,
+                },
+            };
+
+            expect(result).to.deep.equal(expectedNoteStructure);
+        });
         it('get no organization notes for grant', async () => {
             const result = await getOrganizationNotesForGrant(knex, fixtures.grants.earFellowship.grant_id, fixtures.agencies.usdr.tenant_id);
-            console.log('HELLO', result);
             const expectedNoteStructure = {
                 notes: [],
                 pagination: {

--- a/packages/server/__tests__/lib/grants-collaboration.test.js
+++ b/packages/server/__tests__/lib/grants-collaboration.test.js
@@ -1,17 +1,9 @@
 const { expect } = require('chai');
-const db = require('../../src/db');
 const knex = require('../../src/db/connection');
 const fixtures = require('../db/seeds/fixtures');
 const { saveNoteRevision, getOrganizationNotesForGrant } = require('../../src/lib/grantsCollaboration/notes');
 
-describe('db', () => {
-    before(async () => {
-        await fixtures.seed(db.knex);
-    });
-
-    after(async () => {
-        await db.knex.destroy();
-    });
+describe('Grants Collaboration', () => {
     context('saveNoteRevision', () => {
         it('creates new note', async () => {
             const result = await saveNoteRevision(knex, fixtures.grants.earFellowship.grant_id, fixtures.roles.adminRole.id, 'This is a test revision');
@@ -58,6 +50,19 @@ describe('db', () => {
             // remove createdAt to validate the rest of the structure
             delete expectedNoteStructure.notes[0].createdAt;
             delete result.notes[0].createdAt;
+
+            expect(result).to.deep.equal(expectedNoteStructure);
+        });
+
+        it('get no organization notes for grant', async () => {
+            const result = await getOrganizationNotesForGrant(knex, fixtures.grants.earFellowship.grant_id, fixtures.agencies.usdr.tenant_id);
+            console.log('HELLO', result);
+            const expectedNoteStructure = {
+                notes: [],
+                pagination: {
+                    from: undefined,
+                },
+            };
 
             expect(result).to.deep.equal(expectedNoteStructure);
         });

--- a/packages/server/__tests__/lib/grants-collaboration.test.js
+++ b/packages/server/__tests__/lib/grants-collaboration.test.js
@@ -1,0 +1,65 @@
+const { expect } = require('chai');
+const db = require('../../src/db');
+const knex = require('../../src/db/connection');
+const fixtures = require('../db/seeds/fixtures');
+const { saveNoteRevision, getOrganizationNotesForGrant } = require('../../src/lib/grantsCollaboration/notes');
+
+describe('db', () => {
+    before(async () => {
+        await fixtures.seed(db.knex);
+    });
+
+    after(async () => {
+        await db.knex.destroy();
+    });
+    context('saveNoteRevision', () => {
+        it('creates new note', async () => {
+            const result = await saveNoteRevision(knex, fixtures.grants.earFellowship.grant_id, fixtures.roles.adminRole.id, 'This is a test revision');
+            expect(result.id).to.equal(1);
+        });
+        it('creates new note revision', async () => {
+            const result = await saveNoteRevision(knex, fixtures.grants.earFellowship.grant_id, fixtures.roles.adminRole.id, 'This is a test revision #2');
+            expect(result.id).to.equal(2);
+        });
+    });
+    context('getOrganizationNotesForGrant', () => {
+        it('get existing organization notes for grant', async () => {
+            const result = await getOrganizationNotesForGrant(knex, fixtures.grants.earFellowship.grant_id, fixtures.agencies.accountancy.tenant_id);
+            const expectedNoteStructure = {
+                notes: [{
+                    id: 2,
+                    createdAt: result.notes[0].createdAt, // store to pass structure check
+                    text: 'This is a test revision #2',
+                    grant: { id: fixtures.grants.earFellowship.grant_id },
+                    user: {
+                        id: fixtures.roles.adminRole.id,
+                        name: fixtures.users.adminUser.name,
+                        team: {
+                            id: fixtures.agencies.accountancy.id,
+                            name: fixtures.agencies.accountancy.name,
+                        },
+                        organization: {
+                            id: fixtures.tenants.SBA.id,
+                            name: fixtures.tenants.SBA.display_name,
+                        },
+                    },
+                }],
+                pagination: {
+                    from: 2,
+                },
+            };
+
+            // validate createdAt is valid time
+            expect(result.notes[0].createdAt).to.satisfy((date) => {
+                const timestamp = new Date(date).getTime();
+                return !Number.isNaN(timestamp);
+            });
+
+            // remove createdAt to validate the rest of the structure
+            delete expectedNoteStructure.notes[0].createdAt;
+            delete result.notes[0].createdAt;
+
+            expect(result).to.deep.equal(expectedNoteStructure);
+        });
+    });
+});

--- a/packages/server/__tests__/lib/test-global-setup.js
+++ b/packages/server/__tests__/lib/test-global-setup.js
@@ -1,0 +1,10 @@
+const db = require('../../src/db');
+const fixtures = require('../db/seeds/fixtures');
+
+before(async () => {
+    await fixtures.seed(db.knex);
+});
+
+after(async () => {
+    await db.knex.destroy();
+});

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -36,7 +36,7 @@
     "test:arpa": "NODE_ENV=test __tests__/run_arpa_reporter_tests.sh",
     "test:db": "NODE_ENV=test mocha --timeout 10000 __tests__/db/*.test.js",
     "test:email": "NODE_ENV=test mocha __tests__/email/*.test.js",
-    "test:lib": "NODE_ENV=test mocha __tests__/lib/*.test.js",
+    "test:lib": "NODE_ENV=test mocha  --file __tests__/lib/test-global-setup.js __tests__/lib/*.test.js",
     "test:scripts": "NODE_ENV=test mocha __tests__/scripts/*.test.js",
     "test:userimport": "NODE_ENV=test SUPPRESS_EMAIL=true mocha --exit --bail --require __tests__/api/fixtures.js __tests__/db/userImporter._test_.js",
     "test": "yarn test:apis && yarn test:arpa && yarn test:db && yarn test:userimport && yarn test:agencyimport && yarn test:email && yarn test:lib && yarn test:scripts",

--- a/packages/server/src/lib/grantsCollaboration/index.js
+++ b/packages/server/src/lib/grantsCollaboration/index.js
@@ -1,0 +1,5 @@
+const { saveNoteRevision, getOrganizationNotesForGrant } = require('./notes');
+
+module.exports = {
+    saveNoteRevision, getOrganizationNotesForGrant,
+};

--- a/packages/server/src/lib/grantsCollaboration/notes.js
+++ b/packages/server/src/lib/grantsCollaboration/notes.js
@@ -1,6 +1,4 @@
 async function saveNoteRevision(knex, grantId, userId, text) {
-    console.log(knex, grantId, userId, text);
-
     let grantNoteId;
 
     const grantNotesRevisionId = await knex.transaction(async (trx) => {
@@ -77,8 +75,6 @@ async function getOrganizationNotesForGrant(knex, grantId, organizationId, { aft
     const notes = await query
         .orderBy('rev.created_at', 'desc')
         .limit(limit);
-    console.log('notes');
-    console.log(notes.length);
     return {
         notes: notes.map((note) => ({
             id: note.latest_revision_id,

--- a/packages/server/src/lib/grantsCollaboration/notes.js
+++ b/packages/server/src/lib/grantsCollaboration/notes.js
@@ -1,0 +1,109 @@
+async function saveNoteRevision(knex, grantId, userId, text) {
+    console.log(knex, grantId, userId, text);
+    // if (!knex || !grantId || !userId || !text) {
+    //     throw new Error('Invalid arguments. None of the arguments can be null or undefined.');
+    // }
+
+    let grantNoteId;
+
+    await knex.transaction(async (trx) => {
+        const existingNote = await trx('grant_notes')
+            .select('id')
+            .where({ grant_id: grantId, user_id: userId })
+            .first();
+
+        if (existingNote) {
+            grantNoteId = existingNote.id;
+        } else {
+            const [newNoteId] = await trx('grant_notes')
+                .insert({
+                    grant_id: grantId,
+                    user_id: userId,
+                })
+                .returning('id');
+            grantNoteId = newNoteId;
+        }
+
+        const [revisionId] = await trx('grant_notes_revisions')
+            .insert({
+                grant_note_id: grantNoteId,
+                text,
+            })
+            .returning('id');
+
+        return { id: revisionId };
+    });
+
+    return { id: grantNoteId };
+}
+
+async function getOrganizationNotesForGrant(knex, grantId, organizationId, { afterRevision, limit = 50 } = {}) {
+    const subquery = knex.select([
+        'r.id',
+        'r.grant_note_id',
+        'r.created_at',
+        'r.text',
+    ])
+        .from({ r: 'grant_notes_revisions' })
+        .whereRaw('r.grant_note_id = grant_notes.id')
+        .orderBy('r.created_at', 'desc')
+        .limit(1)
+        .as('rev');
+
+    let query = knex('grant_notes')
+        .select([
+            'grant_notes.id',
+            'grant_notes.created_at',
+            'grant_notes.grant_id',
+            'rev.id as latest_revision_id',
+            'rev.created_at as revised_at',
+            'rev.text',
+            'users.id as user_id',
+            'users.name as user_name',
+            'users.email as user_email',
+            'tenants.id as organization_id',
+            'tenants.display_name as organization_name',
+            'agencies.id as team_id',
+            'agencies.name as team_name',
+        ])
+        .joinRaw(`LEFT JOIN LATERAL (${subquery.toQuery()}) AS rev ON rev.grant_note_id = grant_notes.id`)
+        .join('users', 'users.id', 'grant_notes.user_id')
+        .join('agencies', 'agencies.id', 'users.agency_id')
+        .join('tenants', 'tenants.id', 'users.tenant_id')
+        .where('grant_notes.grant_id', grantId)
+        .andWhere('tenants.id', organizationId);
+
+    if (afterRevision) {
+        query = query.andWhere('rev.id', '>', afterRevision);
+    }
+
+    const notes = await query
+        .orderBy('rev.created_at', 'desc')
+        .limit(limit);
+
+    return {
+        notes: notes.map((note) => ({
+            id: note.latest_revision_id,
+            createdAt: note.revised_at,
+            text: note.text,
+            grant: { id: note.grant_id },
+            user: {
+                id: note.user_id,
+                name: note.user_name,
+                team: {
+                    id: note.team_id,
+                    name: note.team_name,
+                },
+                organization: {
+                    id: note.organization_id,
+                    name: note.organization_name,
+                },
+            },
+        })),
+        pagination: {
+            from: notes.length > 0 ? notes[notes.length - 1].latest_revision_id : afterRevision,
+        },
+    };
+}
+
+module.exports = { saveNoteRevision, getOrganizationNotesForGrant };


### PR DESCRIPTION
### Ticket #3201 
## Description
Created the `saveNoteRevision` and `getOrganizationNotesForGrant` funcs as described in the ticket. Added some tests in `packages/server/__tests__/lib/grants-collaboration.test.js`. Was having some issues w/ the `knex` connection in a new file - the issue was that after 1 file destroyed the shared knex connection (`access-helpers.test.js`), it wasn't available to use in the next test file. To remediate this, I moved the before and after hooks into a util file, and called this file from the actual script in `package.json`. 

Technically I don't think this knex connection was ever even used in `access-helpers.test.js`, so I could probably have just gotten rid of the before and after hooks in this file, but I thought it might be better just to have these hooks in a global file so no one else runs into this issue in the future as we add modules, but open to either solution. 

## Screenshots / Demo Video

## Testing

### Automated and Unit Tests
- [x] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [x] Provided ticket and description
- [ ] Provided screenshots/demo
- [x] Provided testing information
- [x] Provided adequate test coverage for all new code
- [x] Added PR reviewers