### PR TITLE
Fix issue with double-submission of new search

### DIFF
--- a/packages/client/src/components/Modals/SearchPanel.vue
+++ b/packages/client/src/components/Modals/SearchPanel.vue
@@ -11,7 +11,6 @@
 
     <b-form
       class="search-form"
-      @keyup.enter="onEnter"
       @submit.prevent="onSubmit"
       @reset="cancel"
     >
@@ -422,12 +421,6 @@ export default {
     },
     onShown() {
       this.initFormState();
-    },
-    async onEnter(event) {
-      const enterInOpenDropdown = event.target.closest('.vs--open');
-      if (this.saveEnabled && !enterInOpenDropdown) {
-        await this.onSubmit();
-      }
     },
     async onSubmit() {
       this.apply();


### PR DESCRIPTION
### Ticket #3295 
## Description
With the Vue 3 migration PR merged (#3190) it seems submission behavior for bootstrap-vue's form is changed. It automatically counts an "enter" key while focused on the form to trigger the submit event. We had previously been handling both events individually, which thus started double-submitting that form, returning an error for a duplicate DB row. 

<img width="945" alt="image" src="https://github.com/user-attachments/assets/13c6383a-967d-4210-b3df-f21fc779f6b9">

## Screenshots / Demo Video

<img width="945" alt="image" src="https://github.com/user-attachments/assets/d27023dc-8657-4934-a0d4-5a1e91ab07af">


## Testing
- Repro'd the issue without the fix (two requests in the network tab, with the second erroring)
- Introduced the fix and saw the desired behavior (only one request in the network tab, and no errors)

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [ ] Provided ticket and description
- [ ] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers