### PR TITLE
Upgrade RDS certificate on Production

### DIFF
--- a/terraform/prod.tfvars
+++ b/terraform/prod.tfvars
@@ -81,7 +81,7 @@ postgres_enabled                   = true
 postgres_prevent_destroy           = true
 postgres_snapshot_before_destroy   = true
 postgres_apply_changes_immediately = false
-postgres_ca_cert_identifier        = "rds-ca-2019"
+postgres_ca_cert_identifier        = "rds-ca-rsa2048-g1"
 
 // Grant events consumer
 consume_grants_source_event_bus_name = "default"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -236,6 +236,7 @@ variable "postgres_query_logging_enabled" {
 variable "postgres_ca_cert_identifier" {
   description = "Certificate Authority identifier for RDS Aurora Postgres cluster instances."
   type        = string
+  default     = "rds-ca-rsa2048-g1"
 }
 
 # Consume Grants


### PR DESCRIPTION
## Description

This PR adjusts the configuration for the RDS Aurora SSL/TLS certificate in the Production environment. It also configures the `postgres_ca_cert_identifier` Terraform input variable with a default value of `rds-ca-rsa-2048-g1`, since that value is now shared by all targeted environments.

Note that #3273 updated the CA bundle file used to verify SSL/TLS connections, and #3286 applied the same configuration change in Staging. Now that we have successfully rotated the Staging environment certificate from `rds-ca-2019` to `rds-ca-rsa-2048-g1` without any problems or downtime, we should be able to safely apply the same upgrade operation while targeting Production. 

As with #3286, changes from this pull request will not take effect immediately. Rather, the upgrade will be a pending action for the next RDS maintenance window, which is currently scheduled to run on Sunday, August 04, 2024 at 1am Eastern.

This PR is expected to conclude changes related to the planned August 22, 2024 expiration of the `rds-ca-2019` certificate authority.