### PR TITLE
feat(grants): Forecasted UI - - MERGE AFTER PR # 3456

### DIFF
--- a/packages/client/src/components/GrantsTable.vue
+++ b/packages/client/src/components/GrantsTable.vue
@@ -279,6 +279,25 @@ export default {
         txt.innerHTML = t;
         return txt.value;
       };
+      const generateCloseDate = (date, status, closeDateExplanation) => {
+        const formattedDate = new Date(date).toLocaleDateString('en-US', { timeZone: 'UTC' });
+        const dateExists = date && date !== '2100-01-01';
+        if (!dateExists) {
+          return closeDateExplanation ? 'See details' : 'Not yet issued';
+        }
+        if (status === 'forecasted') {
+          return `est. ${formattedDate}`;
+        }
+
+        return formattedDate;
+      };
+      const generateOpenDate = (date, status) => {
+        const formattedDate = new Date(date).toLocaleDateString('en-US', { timeZone: 'UTC' });
+        if (status === 'forecasted') {
+          return `est. ${formattedDate}`;
+        }
+        return formattedDate;
+      };
       return this.grants.map((grant) => ({
         ...grant,
         title: generateTitle(grant.title),
@@ -288,10 +307,10 @@ export default {
         viewed_by: grant.viewed_by_agencies
           .map((v) => v.agency_abbreviation)
           .join(', '),
-        status: grant.opportunity_status,
+        status: titleize(grant.opportunity_status),
         award_ceiling: grant.award_ceiling,
-        open_date: new Date(grant.open_date).toLocaleDateString('en-US', { timeZone: 'UTC' }),
-        close_date: new Date(grant.close_date).toLocaleDateString('en-US', { timeZone: 'UTC' }),
+        open_date: generateOpenDate(grant.open_date, grant.opportunity_status?.toLowerCase()),
+        close_date: generateCloseDate(grant.close_date, grant.opportunity_status?.toLowerCase(), grant.close_date_explanation),
         _cellVariants: (() => {
           const daysUntilClose = daysUntil(grant.close_date);
           if (daysUntilClose <= dangerThreshold) {

--- a/packages/client/src/components/GrantsTable.vue
+++ b/packages/client/src/components/GrantsTable.vue
@@ -293,6 +293,10 @@ export default {
       };
       const generateOpenDate = (date, status) => {
         const formattedDate = new Date(date).toLocaleDateString('en-US', { timeZone: 'UTC' });
+        const dateExists = date && date !== '2100-01-01';
+        if (!dateExists) {
+          return 'Not yet issued';
+        }
         if (status === 'forecasted') {
           return `est. ${formattedDate}`;
         }

--- a/packages/client/src/components/Modals/SearchPanel.vue
+++ b/packages/client/src/components/Modals/SearchPanel.vue
@@ -269,7 +269,7 @@ const defaultCriteria = {
   includeKeywords: null,
   excludeKeywords: null,
   opportunityNumber: null,
-  opportunityStatuses: ['posted'],
+  opportunityStatuses: ['forecasted', 'posted'],
   fundingTypes: null,
   agency: null,
   bill: null,
@@ -310,6 +310,7 @@ export default {
         { code: 'O', name: 'Other' },
       ],
       opportunityStatusOptions: [
+        { text: 'Forecasted', value: 'forecasted' },
         { text: 'Posted', value: 'posted' },
         // b-form-checkbox-group doesn't handle multiple values well 'archived' is added
         // whenever 'closed' is checked, but as post processing step. See apply()

--- a/packages/client/src/store/modules/grants.js
+++ b/packages/client/src/store/modules/grants.js
@@ -68,8 +68,8 @@ function buildGrantsNextQuery({ filters, ordering, pagination }) {
   criteria.fundingActivityCategories = criteria.fundingActivityCategories?.map((c) => c.code);
 
   if (!criteria.opportunityStatuses || criteria.opportunityStatuses.length === 0) {
-    // by default, only show posted opportunities
-    criteria.opportunityStatuses = ['posted'];
+    // by default, only show forecasted and posted opportunities
+    criteria.opportunityStatuses = ['forecasted', 'posted'];
   }
   const paginationQuery = Object.entries(pagination)
     // filter out undefined and nulls since api expects parameters not present as undefined

--- a/packages/client/src/views/GrantDetailsView.vue
+++ b/packages/client/src/views/GrantDetailsView.vue
@@ -103,7 +103,8 @@
                     hover
                   >
                     <template #cell()="data">
-                      <span :class="{ 'text-muted font-weight-normal': data.item.displayMuted }">
+                      <i v-if="data.item.displayEstimatedText">est.&nbsp;</i>
+                      <span :class="{'text-muted font-weight-normal': data.item.displayMuted}">
                         {{ data.value }}
                       </span>
                     </template>
@@ -223,7 +224,8 @@ import GrantActivity from '@/components/GrantActivity.vue';
 
 const HEADER = '__HEADER__';
 const FAR_FUTURE_CLOSE_DATE = '2100-01-01';
-const NOT_AVAILABLE_TEXT = 'Not Available';
+const NOT_YET_ISSUED_TEXT = 'Not yet issued';
+const FORECASTED = 'forecasted';
 
 export default {
   components: {
@@ -283,10 +285,12 @@ export default {
       }, {
         name: 'Open Date',
         value: this.openDateDisplay,
+        displayEstimatedText: this.displayEstimatedOpenDateText,
       }, {
         name: 'Close Date',
         value: this.closeDateDisplay,
         displayMuted: this.closeDateDisplayMuted,
+        displayEstimatedText: this.displayEstimatedCloseDateText,
       }, {
         name: 'Grant ID',
         value: this.currentGrant.grant_id,
@@ -315,19 +319,22 @@ export default {
       ];
     },
     openDateDisplay() {
-      // make 'forecasted' a constant
-      if (this.currentGrant.opportunity_status === 'forecasted') {
+      if (!this.currentGrant.open_date || this.currentGrant.open_date === FAR_FUTURE_CLOSE_DATE) {
+        return NOT_YET_ISSUED_TEXT;
+      }
+      if (this.currentGrant.opportunity_status === FORECASTED) {
         // check for date validity here and in closeDateDisplay
-        return `est. ${this.formatDate(this.currentGrant.open_date)}`;
+        return `${this.formatDate(this.currentGrant.open_date)}`;
       }
       return this.formatDate(this.currentGrant.open_date);
     },
     closeDateDisplay() {
       // If we have an explainer text instead of a real close date, display that instead
       if (!this.currentGrant.close_date || this.currentGrant.close_date === FAR_FUTURE_CLOSE_DATE) {
-        return this.currentGrant.close_date_explanation ?? NOT_AVAILABLE_TEXT;
-      } if (this.currentGrant.opportunity_status === 'forecasted') {
-        return `est. ${this.formatDate(this.currentGrant.close_date)}`;
+        return this.currentGrant.close_date_explanation ?? NOT_YET_ISSUED_TEXT;
+      }
+      if (this.currentGrant.opportunity_status === FORECASTED) {
+        return `${this.formatDate(this.currentGrant.close_date)}`;
       }
       return this.formatDate(this.currentGrant.close_date);
     },
@@ -359,6 +366,12 @@ export default {
     followNotesEnabled,
     statusSubmitButtonDisabled() {
       return this.selectedInterestedCode === null;
+    },
+    displayEstimatedCloseDateText() {
+      return this.currentGrant.close_date && this.currentGrant.opportunity_status === 'forecasted';
+    },
+    displayEstimatedOpenDateText() {
+      return this.currentGrant.open_date && this.currentGrant.opportunity_status === 'forecasted';
     },
   },
   watch: {

--- a/packages/client/src/views/GrantDetailsView.vue
+++ b/packages/client/src/views/GrantDetailsView.vue
@@ -223,7 +223,7 @@ import GrantActivity from '@/components/GrantActivity.vue';
 
 const HEADER = '__HEADER__';
 const FAR_FUTURE_CLOSE_DATE = '2100-01-01';
-const NOT_AVAILABLE_TEXT = 'Not available';
+const NOT_AVAILABLE_TEXT = 'Not Available';
 
 export default {
   components: {
@@ -282,7 +282,7 @@ export default {
         value: this.currentGrant.grant_number,
       }, {
         name: 'Open Date',
-        value: this.formatDate(this.currentGrant.open_date),
+        value: this.openDateDisplay,
       }, {
         name: 'Close Date',
         value: this.closeDateDisplay,
@@ -314,10 +314,20 @@ export default {
       },
       ];
     },
+    openDateDisplay() {
+      // make 'forecasted' a constant
+      if (this.currentGrant.opportunity_status === 'forecasted') {
+        // check for date validity here and in closeDateDisplay
+        return `est. ${this.formatDate(this.currentGrant.open_date)}`;
+      }
+      return this.formatDate(this.currentGrant.open_date);
+    },
     closeDateDisplay() {
       // If we have an explainer text instead of a real close date, display that instead
-      if (this.currentGrant.close_date === FAR_FUTURE_CLOSE_DATE) {
+      if (!this.currentGrant.close_date || this.currentGrant.close_date === FAR_FUTURE_CLOSE_DATE) {
         return this.currentGrant.close_date_explanation ?? NOT_AVAILABLE_TEXT;
+      } if (this.currentGrant.opportunity_status === 'forecasted') {
+        return `est. ${this.formatDate(this.currentGrant.close_date)}`;
       }
       return this.formatDate(this.currentGrant.close_date);
     },

--- a/packages/server/src/db/index.js
+++ b/packages/server/src/db/index.js
@@ -714,6 +714,9 @@ function addCsvData(qb) {
     agencyId: number
 */
 async function getGrantsNew(filters, paginationParams, orderingParams, tenantId, agencyId, toCsv) {
+    // get grants for grants table
+    console.log(JSON.stringify([filters, paginationParams, orderingParams, tenantId, agencyId, toCsv]));
+
     const errors = validateSearchFilters(filters);
     if (errors.length > 0) {
         throw new Error(`Invalid filters: ${errors.join(', ')}`);
@@ -730,6 +733,7 @@ async function getGrantsNew(filters, paginationParams, orderingParams, tenantId,
             'grants.cfda_list',
             'grants.open_date',
             'grants.close_date',
+            'grants.close_date_explanation',
             'grants.archive_date',
             'grants.reviewer_name',
             'grants.opportunity_category',
@@ -751,6 +755,7 @@ async function getGrantsNew(filters, paginationParams, orderingParams, tenantId,
             CASE
             WHEN grants.archive_date <= now() THEN 'archived'
             WHEN grants.close_date <= now() THEN 'closed'
+            WHEN grants.open_date > now() THEN 'forecasted'
             ELSE 'posted'
             END as opportunity_status
         `))

--- a/packages/server/src/db/index.js
+++ b/packages/server/src/db/index.js
@@ -548,7 +548,7 @@ function grantsQuery(queryBuilder, filters, agencyId, orderingParams, pagination
             CASE
             WHEN grants.archive_date <= now() THEN 'archived'
             WHEN grants.close_date <= now() THEN 'closed'
-            WHEN grants.opportunity_status = 'forecasted' THEN 'forecasted'
+            WHEN grants.open_date > now() OR grants.opportunity_status = 'forecasted' THEN 'forecasted'
             ELSE 'posted'
             END IN (${Array(filters.opportunityStatuses.length).fill('?').join(',')})`, filters.opportunityStatuses);
     }

--- a/packages/server/src/db/index.js
+++ b/packages/server/src/db/index.js
@@ -750,12 +750,13 @@ async function getGrantsNew(filters, paginationParams, orderingParams, tenantId,
             'grants.funding_instrument_codes',
             'grants.bill',
             'grants.funding_activity_category_codes',
+            'grants.opportunity_status',
         ])
         .select(knex.raw(`
             CASE
             WHEN grants.archive_date <= now() THEN 'archived'
             WHEN grants.close_date <= now() THEN 'closed'
-            WHEN grants.open_date > now() THEN 'forecasted'
+            WHEN grants.open_date > now() OR grants.opportunity_status = 'forecasted' THEN 'forecasted'
             ELSE 'posted'
             END as opportunity_status
         `))

--- a/packages/server/src/db/index.js
+++ b/packages/server/src/db/index.js
@@ -715,9 +715,6 @@ function addCsvData(qb) {
     agencyId: number
 */
 async function getGrantsNew(filters, paginationParams, orderingParams, tenantId, agencyId, toCsv) {
-    // get grants for grants table
-    console.log(JSON.stringify([filters, paginationParams, orderingParams, tenantId, agencyId, toCsv]));
-
     const errors = validateSearchFilters(filters);
     if (errors.length > 0) {
         throw new Error(`Invalid filters: ${errors.join(', ')}`);

--- a/packages/server/src/db/index.js
+++ b/packages/server/src/db/index.js
@@ -548,6 +548,7 @@ function grantsQuery(queryBuilder, filters, agencyId, orderingParams, pagination
             CASE
             WHEN grants.archive_date <= now() THEN 'archived'
             WHEN grants.close_date <= now() THEN 'closed'
+            WHEN grants.opportunity_status = 'forecasted' THEN 'forecasted'
             ELSE 'posted'
             END IN (${Array(filters.opportunityStatuses.length).fill('?').join(',')})`, filters.opportunityStatuses);
     }

--- a/packages/server/src/routes/grants.js
+++ b/packages/server/src/routes/grants.js
@@ -47,6 +47,7 @@ router.get('/', requireUser, async (req, res) => {
 });
 
 function criteriaToFiltersObj(criteria, agencyId) {
+    // this function makes request to populate grants table
     const filters = criteria || {};
     const postedWithinOptions = {
         'All Time': 0, 'One Week': 7, '30 Days': 30, '60 Days': 60,
@@ -71,6 +72,7 @@ function criteriaToFiltersObj(criteria, agencyId) {
 }
 
 router.get('/next', requireUser, async (req, res) => {
+    // api call to populate table
     const { user } = req.session;
 
     let orderingParams;


### PR DESCRIPTION
## Blocked from merging
Blocked by - https://github.com/usdigitalresponse/usdr-gost/pull/3456 - Hide forecasted grants while UI is being developed to support forecasted grants

----

### Ticket #2201
* [Figma](https://www.figma.com/design/N1wuvwvciNhdKZNSdomTqn/Forecasted?node-id=0-1&node-type=canvas&t=OipzblueWgTOtCXi-0)

## Note

I tried adding tests, but the setup is missing for being able to do a full render - may need to wait until we upgrade ViTest.

[See slack thread for more details](https://usdigitalresponse.slack.com/archives/C0324KDQSCR/p1729638908483319)

## Description
UI changes that display forecasted grant data. The bulk of these changes touch the grants table, and the grants detail page.

To run this...
1) Checkout branch 
```
git checkout lsr-forecasted-ui-seeds
```
2) run seed command to populate the db with forecasted grants
```
docker compose exec app yarn db:seed
```
3) switch back to this branch 
```
git checkout ms-forecasted-ui
```

## Screenshots / Demo Video

## Grants table with forecasted and posted grants
![grants table with forecasted grants](https://github.com/user-attachments/assets/8f7cfd4c-c266-48e6-8aa8-62fde57b3f06)

## csv output
![csv output](https://github.com/user-attachments/assets/e533eaea-1db6-4114-9153-200bf2c1a584)

## grant detail  - both dates valid
![grant detail - forecasted - both dates valid](https://github.com/user-attachments/assets/191b61b2-7c96-4f7e-8e07-a37eb0e68fea)

## grant detail - with close_date_explanation
![grant detail - forecasted - close_date_explanation](https://github.com/user-attachments/assets/d4881aa2-f58c-425e-a17e-432f6cf53a62)

## grant detail - both dates = null
![grant deatil - not yet issued](https://github.com/user-attachments/assets/b1087d73-e191-44c6-8113-67819438c1c3)

## sorting on close date

Manually changed data - see
* est. 9/6/2025
* 10/28/2025

![image](https://github.com/user-attachments/assets/c84661e8-0fec-4265-8b93-a0af81e4b6b0)

![image](https://github.com/user-attachments/assets/a1cd5e32-e66e-4ce2-a32a-ce203494afb8)

## Filtering

### Posted only
![image](https://github.com/user-attachments/assets/a1038655-7d17-4681-9bfc-05ec464a5f31)


### Forecasted only
![image](https://github.com/user-attachments/assets/2de4a5bd-354c-4bf0-b576-06cc13fd5802)




## Testing


### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [ ] Provided ticket and description
- [ ] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers