### PR TITLE
fix: support validation of projects with ec code 7.3

### DIFF
--- a/packages/server/__tests__/arpa_reporter/server/services/validate-upload.spec.js
+++ b/packages/server/__tests__/arpa_reporter/server/services/validate-upload.spec.js
@@ -99,6 +99,7 @@ describe('validate record', () => {
         Place_of_Performance_Zip__c: '02920',
         Description__c: 'Sample description',
         Subaward_Changed__c: 'No',
+        IAA_Basic_Conditions__c: '1. It imposes conditions on the use of funds by the agency, department, or part of government receiving funds to carry out the program',
     };
 
     it('validates a valid project succesfully', () => validateRecord({

--- a/packages/server/src/arpa_reporter/lib/arpa-ec-codes.js
+++ b/packages/server/src/arpa_reporter/lib/arpa-ec-codes.js
@@ -80,6 +80,7 @@ const ecCodes = {
     5.21: 'Broadband: Other projects',
     7.1: 'Administrative Expenses',
     7.2: 'Transfers to Other Units of Government',
+    7.3: 'Costs Associated with Satisfying Certain Legal and Administrative Requirements of the SLFRF Program After December 31, 2024',
 };
 
 module.exports = {

--- a/packages/server/src/arpa_reporter/services/generate-arpa-report.js
+++ b/packages/server/src/arpa_reporter/services/generate-arpa-report.js
@@ -786,7 +786,8 @@ async function generateProjectBaseline(records) {
                 case '3.4':
                 case '3.5':
                 case '7.1':
-                case '7.2': {
+                case '7.2':
+                case '7.3': {
                     return [
                         null, // first col is blank
                         ec(record.type),

--- a/packages/server/src/arpa_reporter/services/validate-upload.js
+++ b/packages/server/src/arpa_reporter/services/validate-upload.js
@@ -7,6 +7,7 @@ const { createRecipient, findRecipient, updateRecipient } = require('../db/arpa-
 const { recordsForUpload, TYPE_TO_SHEET_NAME } = require('./records');
 const { getRules } = require('./validation-rules');
 const { ecCodes } = require('../lib/arpa-ec-codes');
+const { multiselect } = require('../lib/format');
 
 const ValidationError = require('../lib/validation-error');
 
@@ -291,7 +292,7 @@ async function validateRecord({ upload, record, typeRules: rules }) {
             // make sure pick value is one of pick list values
             if (rule.listVals.length > 0) {
                 // enforce validation in lower case
-                const lcItems = rule.listVals.map((val) => val.toLowerCase());
+                const lcItems = rule.listVals.map((val) => multiselect(val.toLowerCase()));
 
                 // for pick lists, the value must be one of possible values
                 if (rule.dataType === 'Pick List' && !lcItems.includes(value)) {
@@ -307,7 +308,7 @@ async function validateRecord({ upload, record, typeRules: rules }) {
                     for (const entry of entries) {
                         if (!lcItems.includes(entry)) {
                             errors.push(new ValidationError(
-                                `Entry '${entry}' of ${key} is not one of ${lcItems.length} valid options`,
+                                `Entry '${entry}' of ${key} is not one of ${lcItems.length} valid options (${JSON.stringify(lcItems)})`,
                                 { col: rule.columnName, severity: 'err' },
                             ));
                         }


### PR DESCRIPTION
### Ticket #3365
## Description

This addresses a few validation issues that were not resolved in #3371.

- declare ec code 7.3
- map ec code 7.3 to project baseline template in treasury exports
- add unit test coverage for new column IAA_Basic_Conditions__c
- validate commas in multiselect values after normalization

## Screenshots / Demo Video

<img width="1216" alt="image" src="https://github.com/user-attachments/assets/c192ca2c-c7a8-4cbe-b975-1d9cee1c4bee">

## Testing

### Automated and Unit Tests
- [x] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [x] Provided ticket and description
- [x] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [x] Added PR reviewers