### PR TITLE
Adding trace ids to email tags

### DIFF
--- a/packages/server/__tests__/email/email.test.js
+++ b/packages/server/__tests__/email/email.test.js
@@ -251,7 +251,7 @@ describe('Email sender', () => {
                 toAddress: 'staff.user@test.com',
                 subject: 'USDR Grants Tool Access Link',
                 text: 'Your link to access USDR\'s Grants tool is https://api.grants.usdigitalresponse.org/api/sessions?passcode=83c7c74a-6b38-4392-84fa-d1f3993f448d. It expires in 30 minutes',
-                tags: ['notification_type=passcode', 'user_role=staff', 'organization_id=0', 'team_id=0', 'service=test-dd-service', 'env=test-dd-env', 'version=test-dd-version', 'dd_trace_id=undefined', 'dd_span_id=undefined'],
+                tags: ['notification_type=passcode', 'user_role=staff', 'organization_id=0', 'team_id=0', 'service=test-dd-service', 'env=test-dd-env', 'version=test-dd-version'],
             });
             expect(sendFake.firstCall.args[0].body).contains('<title>Login Passcode</title>');
         });
@@ -270,7 +270,7 @@ describe('Email sender', () => {
                 toAddress: 'sub.staff.user@test.com',
                 subject: 'Welcome to USDR Grants Tool',
                 text: 'Visit USDR\'s Grants Tool at: https://staging.grants.usdr.dev.',
-                tags: ['notification_type=welcome', 'user_role=staff', 'organization_id=0', 'team_id=1', 'service=test-dd-service', 'env=test-dd-env', 'version=test-dd-version', 'dd_trace_id=undefined', 'dd_span_id=undefined'],
+                tags: ['notification_type=welcome', 'user_role=staff', 'organization_id=0', 'team_id=1', 'service=test-dd-service', 'env=test-dd-env', 'version=test-dd-version'],
             });
         });
     });
@@ -291,7 +291,7 @@ describe('Email sender', () => {
                     fromName: 'USDR Federal Grant Finder',
                     toAddress: 'staff.user@test.com',
                     subject: 'Grant Assigned to State Board of Accountancy',
-                    tags: ['notification_type=grant_assignment', 'user_role=staff', 'organization_id=0', 'team_id=0', 'service=test-dd-service', 'env=test-dd-env', 'version=test-dd-version', 'dd_trace_id=undefined', 'dd_span_id=undefined'],
+                    tags: ['notification_type=grant_assignment', 'user_role=staff', 'organization_id=0', 'team_id=0', 'service=test-dd-service', 'env=test-dd-env', 'version=test-dd-version'],
                 },
             )).to.be.true;
             expect(sendFake.calledWithMatch(
@@ -299,7 +299,7 @@ describe('Email sender', () => {
                     fromName: 'USDR Federal Grant Finder',
                     toAddress: 'sub.staff.user@test.com',
                     subject: 'Grant Assigned to State Board of Sub Accountancy',
-                    tags: ['notification_type=grant_assignment', 'user_role=staff', 'organization_id=0', 'team_id=1', 'service=test-dd-service', 'env=test-dd-env', 'version=test-dd-version', 'dd_trace_id=undefined', 'dd_span_id=undefined'],
+                    tags: ['notification_type=grant_assignment', 'user_role=staff', 'organization_id=0', 'team_id=1', 'service=test-dd-service', 'env=test-dd-env', 'version=test-dd-version'],
                 },
             )).to.be.true;
             expect(sendFake.calledWithMatch(
@@ -307,7 +307,7 @@ describe('Email sender', () => {
                     fromName: 'USDR Federal Grant Finder',
                     toAddress: 'admin.user@test.com',
                     subject: 'Grant Assigned to State Board of Accountancy',
-                    tags: ['notification_type=grant_assignment', 'user_role=admin', 'organization_id=0', 'team_id=0', 'service=test-dd-service', 'env=test-dd-env', 'version=test-dd-version', 'dd_trace_id=undefined', 'dd_span_id=undefined'],
+                    tags: ['notification_type=grant_assignment', 'user_role=admin', 'organization_id=0', 'team_id=0', 'service=test-dd-service', 'env=test-dd-env', 'version=test-dd-version'],
                 },
             )).to.be.true;
         });
@@ -341,7 +341,7 @@ describe('Email sender', () => {
                     fromName: 'USDR Federal Grant Finder',
                     toAddress: 'staff.user@test.com',
                     subject: 'Admin User Shared a Grant with Your Team',
-                    tags: ['notification_type=grant_assignment', 'user_role=staff', 'organization_id=0', 'team_id=0', 'service=test-dd-service', 'env=test-dd-env', 'version=test-dd-version', 'dd_trace_id=undefined', 'dd_span_id=undefined'],
+                    tags: ['notification_type=grant_assignment', 'user_role=staff', 'organization_id=0', 'team_id=0', 'service=test-dd-service', 'env=test-dd-env', 'version=test-dd-version'],
                 },
             )).to.be.true;
             expect(sendFake.calledWithMatch(
@@ -349,7 +349,7 @@ describe('Email sender', () => {
                     fromName: 'USDR Federal Grant Finder',
                     toAddress: 'sub.staff.user@test.com',
                     subject: 'Admin User Shared a Grant with Your Team',
-                    tags: ['notification_type=grant_assignment', 'user_role=staff', 'organization_id=0', 'team_id=1', 'service=test-dd-service', 'env=test-dd-env', 'version=test-dd-version', 'dd_trace_id=undefined', 'dd_span_id=undefined'],
+                    tags: ['notification_type=grant_assignment', 'user_role=staff', 'organization_id=0', 'team_id=1', 'service=test-dd-service', 'env=test-dd-env', 'version=test-dd-version'],
                 },
             )).to.be.true;
             expect(sendFake.calledWithMatch(
@@ -357,7 +357,7 @@ describe('Email sender', () => {
                     fromName: 'USDR Federal Grant Finder',
                     toAddress: 'admin.user@test.com',
                     subject: 'Admin User Shared a Grant with Your Team',
-                    tags: ['notification_type=grant_assignment', 'user_role=admin', 'organization_id=0', 'team_id=0', 'service=test-dd-service', 'env=test-dd-env', 'version=test-dd-version', 'dd_trace_id=undefined', 'dd_span_id=undefined'],
+                    tags: ['notification_type=grant_assignment', 'user_role=admin', 'organization_id=0', 'team_id=0', 'service=test-dd-service', 'env=test-dd-env', 'version=test-dd-version'],
                 },
             )).to.be.true;
         });
@@ -394,8 +394,6 @@ describe('Email sender', () => {
                 'service=test-dd-service',
                 'env=test-dd-env',
                 'version=test-dd-version',
-                'dd_trace_id=undefined',
-                'dd_span_id=undefined',
             ]);
         });
         it('sendAsyncReportEmail delivers an email with the signedURL for treasury report', async () => {
@@ -417,8 +415,6 @@ describe('Email sender', () => {
                 'service=test-dd-service',
                 'env=test-dd-env',
                 'version=test-dd-version',
-                'dd_trace_id=undefined',
-                'dd_span_id=undefined',
             ]);
         });
     });
@@ -449,8 +445,6 @@ describe('Email sender', () => {
                 'service=test-dd-service',
                 'env=test-dd-env',
                 'version=test-dd-version',
-                'dd_trace_id=undefined',
-                'dd_span_id=undefined',
             ]);
         });
     });
@@ -566,7 +560,7 @@ describe('Email sender', () => {
                 ccAddress: undefined,
                 toAddress: 'admin.user@test.com',
                 subject: 'New Grants Published for Simple 2 result search based on included keywords',
-                tags: ['notification_type=grant_digest', 'user_role=admin', 'organization_id=0', 'team_id=0', 'service=test-dd-service', 'env=test-dd-env', 'version=test-dd-version', 'dd_trace_id=undefined', 'dd_span_id=undefined'],
+                tags: ['notification_type=grant_digest', 'user_role=admin', 'organization_id=0', 'team_id=0', 'service=test-dd-service', 'env=test-dd-env', 'version=test-dd-version'],
             });
         });
         it('Sends an email for all users\' saved searches', async () => {

--- a/packages/server/__tests__/email/email.test.js
+++ b/packages/server/__tests__/email/email.test.js
@@ -251,7 +251,7 @@ describe('Email sender', () => {
                 toAddress: 'staff.user@test.com',
                 subject: 'USDR Grants Tool Access Link',
                 text: 'Your link to access USDR\'s Grants tool is https://api.grants.usdigitalresponse.org/api/sessions?passcode=83c7c74a-6b38-4392-84fa-d1f3993f448d. It expires in 30 minutes',
-                tags: ['notification_type=passcode', 'user_role=staff', 'organization_id=0', 'team_id=0', 'service=test-dd-service', 'env=test-dd-env', 'version=test-dd-version'],
+                tags: ['notification_type=passcode', 'user_role=staff', 'organization_id=0', 'team_id=0', 'service=test-dd-service', 'env=test-dd-env', 'version=test-dd-version', 'dd_trace_id=undefined', 'dd_span_id=undefined'],
             });
             expect(sendFake.firstCall.args[0].body).contains('<title>Login Passcode</title>');
         });
@@ -270,7 +270,7 @@ describe('Email sender', () => {
                 toAddress: 'sub.staff.user@test.com',
                 subject: 'Welcome to USDR Grants Tool',
                 text: 'Visit USDR\'s Grants Tool at: https://staging.grants.usdr.dev.',
-                tags: ['notification_type=welcome', 'user_role=staff', 'organization_id=0', 'team_id=1', 'service=test-dd-service', 'env=test-dd-env', 'version=test-dd-version'],
+                tags: ['notification_type=welcome', 'user_role=staff', 'organization_id=0', 'team_id=1', 'service=test-dd-service', 'env=test-dd-env', 'version=test-dd-version', 'dd_trace_id=undefined', 'dd_span_id=undefined'],
             });
         });
     });
@@ -291,7 +291,7 @@ describe('Email sender', () => {
                     fromName: 'USDR Federal Grant Finder',
                     toAddress: 'staff.user@test.com',
                     subject: 'Grant Assigned to State Board of Accountancy',
-                    tags: ['notification_type=grant_assignment', 'user_role=staff', 'organization_id=0', 'team_id=0', 'service=test-dd-service', 'env=test-dd-env', 'version=test-dd-version'],
+                    tags: ['notification_type=grant_assignment', 'user_role=staff', 'organization_id=0', 'team_id=0', 'service=test-dd-service', 'env=test-dd-env', 'version=test-dd-version', 'dd_trace_id=undefined', 'dd_span_id=undefined'],
                 },
             )).to.be.true;
             expect(sendFake.calledWithMatch(
@@ -299,7 +299,7 @@ describe('Email sender', () => {
                     fromName: 'USDR Federal Grant Finder',
                     toAddress: 'sub.staff.user@test.com',
                     subject: 'Grant Assigned to State Board of Sub Accountancy',
-                    tags: ['notification_type=grant_assignment', 'user_role=staff', 'organization_id=0', 'team_id=1', 'service=test-dd-service', 'env=test-dd-env', 'version=test-dd-version'],
+                    tags: ['notification_type=grant_assignment', 'user_role=staff', 'organization_id=0', 'team_id=1', 'service=test-dd-service', 'env=test-dd-env', 'version=test-dd-version', 'dd_trace_id=undefined', 'dd_span_id=undefined'],
                 },
             )).to.be.true;
             expect(sendFake.calledWithMatch(
@@ -307,7 +307,7 @@ describe('Email sender', () => {
                     fromName: 'USDR Federal Grant Finder',
                     toAddress: 'admin.user@test.com',
                     subject: 'Grant Assigned to State Board of Accountancy',
-                    tags: ['notification_type=grant_assignment', 'user_role=admin', 'organization_id=0', 'team_id=0', 'service=test-dd-service', 'env=test-dd-env', 'version=test-dd-version'],
+                    tags: ['notification_type=grant_assignment', 'user_role=admin', 'organization_id=0', 'team_id=0', 'service=test-dd-service', 'env=test-dd-env', 'version=test-dd-version', 'dd_trace_id=undefined', 'dd_span_id=undefined'],
                 },
             )).to.be.true;
         });
@@ -341,7 +341,7 @@ describe('Email sender', () => {
                     fromName: 'USDR Federal Grant Finder',
                     toAddress: 'staff.user@test.com',
                     subject: 'Admin User Shared a Grant with Your Team',
-                    tags: ['notification_type=grant_assignment', 'user_role=staff', 'organization_id=0', 'team_id=0', 'service=test-dd-service', 'env=test-dd-env', 'version=test-dd-version'],
+                    tags: ['notification_type=grant_assignment', 'user_role=staff', 'organization_id=0', 'team_id=0', 'service=test-dd-service', 'env=test-dd-env', 'version=test-dd-version', 'dd_trace_id=undefined', 'dd_span_id=undefined'],
                 },
             )).to.be.true;
             expect(sendFake.calledWithMatch(
@@ -349,7 +349,7 @@ describe('Email sender', () => {
                     fromName: 'USDR Federal Grant Finder',
                     toAddress: 'sub.staff.user@test.com',
                     subject: 'Admin User Shared a Grant with Your Team',
-                    tags: ['notification_type=grant_assignment', 'user_role=staff', 'organization_id=0', 'team_id=1', 'service=test-dd-service', 'env=test-dd-env', 'version=test-dd-version'],
+                    tags: ['notification_type=grant_assignment', 'user_role=staff', 'organization_id=0', 'team_id=1', 'service=test-dd-service', 'env=test-dd-env', 'version=test-dd-version', 'dd_trace_id=undefined', 'dd_span_id=undefined'],
                 },
             )).to.be.true;
             expect(sendFake.calledWithMatch(
@@ -357,7 +357,7 @@ describe('Email sender', () => {
                     fromName: 'USDR Federal Grant Finder',
                     toAddress: 'admin.user@test.com',
                     subject: 'Admin User Shared a Grant with Your Team',
-                    tags: ['notification_type=grant_assignment', 'user_role=admin', 'organization_id=0', 'team_id=0', 'service=test-dd-service', 'env=test-dd-env', 'version=test-dd-version'],
+                    tags: ['notification_type=grant_assignment', 'user_role=admin', 'organization_id=0', 'team_id=0', 'service=test-dd-service', 'env=test-dd-env', 'version=test-dd-version', 'dd_trace_id=undefined', 'dd_span_id=undefined'],
                 },
             )).to.be.true;
         });
@@ -394,6 +394,8 @@ describe('Email sender', () => {
                 'service=test-dd-service',
                 'env=test-dd-env',
                 'version=test-dd-version',
+                'dd_trace_id=undefined',
+                'dd_span_id=undefined',
             ]);
         });
         it('sendAsyncReportEmail delivers an email with the signedURL for treasury report', async () => {
@@ -415,6 +417,8 @@ describe('Email sender', () => {
                 'service=test-dd-service',
                 'env=test-dd-env',
                 'version=test-dd-version',
+                'dd_trace_id=undefined',
+                'dd_span_id=undefined',
             ]);
         });
     });
@@ -445,6 +449,8 @@ describe('Email sender', () => {
                 'service=test-dd-service',
                 'env=test-dd-env',
                 'version=test-dd-version',
+                'dd_trace_id=undefined',
+                'dd_span_id=undefined',
             ]);
         });
     });
@@ -560,7 +566,7 @@ describe('Email sender', () => {
                 ccAddress: undefined,
                 toAddress: 'admin.user@test.com',
                 subject: 'New Grants Published for Simple 2 result search based on included keywords',
-                tags: ['notification_type=grant_digest', 'user_role=admin', 'organization_id=0', 'team_id=0', 'service=test-dd-service', 'env=test-dd-env', 'version=test-dd-version'],
+                tags: ['notification_type=grant_digest', 'user_role=admin', 'organization_id=0', 'team_id=0', 'service=test-dd-service', 'env=test-dd-env', 'version=test-dd-version', 'dd_trace_id=undefined', 'dd_span_id=undefined'],
             });
         });
         it('Sends an email for all users\' saved searches', async () => {

--- a/packages/server/src/lib/email.js
+++ b/packages/server/src/lib/email.js
@@ -52,6 +52,13 @@ async function deliverEmail({
     const activeContext = tracer.scope().active()?.context();
     const traceId = activeContext?.toTraceId();
     const spanId = activeContext?.toSpanId();
+    const ddTraceTags = [];
+    if (traceId) {
+        ddTraceTags.push(`dd_trace_id=${traceId}`);
+        if (spanId) {
+            ddTraceTags.push(`dd_span_id=${spanId}`);
+        }
+    }
     if (recipientId) {
         const recipient = await db.getUser(recipientId);
         userTags = [
@@ -74,8 +81,7 @@ async function deliverEmail({
             `service=${process.env.DD_SERVICE}`,
             `env=${process.env.DD_ENV}`,
             `version=${process.env.DD_VERSION}`,
-            `dd_trace_id=${traceId}`,
-            `dd_span_id=${spanId}`,
+            ...ddTraceTags,
         ],
     });
 }

--- a/packages/server/src/lib/email.js
+++ b/packages/server/src/lib/email.js
@@ -58,8 +58,6 @@ async function deliverEmail({
             `user_role=${getUserRoleTag(recipient)}`,
             `organization_id=${recipient.tenant_id}`,
             `team_id=${recipient.agency_id}`,
-            `dd_trace_id=${traceId}`,
-            `dd_span_id=${spanId}`,
         ];
     }
 
@@ -76,6 +74,8 @@ async function deliverEmail({
             `service=${process.env.DD_SERVICE}`,
             `env=${process.env.DD_ENV}`,
             `version=${process.env.DD_VERSION}`,
+            `dd_trace_id=${traceId}`,
+            `dd_span_id=${spanId}`,
         ],
     });
 }

--- a/packages/server/src/lib/email.js
+++ b/packages/server/src/lib/email.js
@@ -1,3 +1,4 @@
+const tracer = require('dd-trace').init();
 const { URL } = require('url');
 const moment = require('moment');
 const { capitalize } = require('lodash');
@@ -48,12 +49,17 @@ async function deliverEmail({
 }) {
     let userTags = [];
     const recipientId = await db.getUserIdForEmail(toAddress);
+    const activeContext = tracer.scope().active()?.context();
+    const traceId = activeContext?.toTraceId();
+    const spanId = activeContext?.toSpanId();
     if (recipientId) {
         const recipient = await db.getUser(recipientId);
         userTags = [
             `user_role=${getUserRoleTag(recipient)}`,
             `organization_id=${recipient.tenant_id}`,
             `team_id=${recipient.agency_id}`,
+            `dd_trace_id=${traceId}`,
+            `dd_span_id=${spanId}`,
         ];
     }
 


### PR DESCRIPTION
### Ticket #3386 
## Description
Adding DataDog trace and span ids to email tags. Updated `email.test.js` to set default values for the tags.

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [ ] Provided ticket and description
- [ ] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers