### PR TITLE
Fix: Invalid `target_format` in SES logs-to-metrics pipeline

### DIFF
--- a/terraform/datadog_email_activity.tf
+++ b/terraform/datadog_email_activity.tf
@@ -17,7 +17,6 @@ resource "datadog_logs_custom_pipeline" "email_pipeline" {
       source_type          = "attribute"
       target               = "env"
       target_type          = "tag"
-      target_format        = "string"
       preserve_source      = true
       override_on_conflict = false
       name                 = "Map @mail.tags.env to 'env' tag"
@@ -30,7 +29,6 @@ resource "datadog_logs_custom_pipeline" "email_pipeline" {
       source_type          = "attribute"
       target               = "notification-type"
       target_type          = "tag"
-      target_format        = "string"
       preserve_source      = true
       override_on_conflict = false
       name                 = "Map @mail.tags.notification_type to 'notification-type' tag"
@@ -43,7 +41,6 @@ resource "datadog_logs_custom_pipeline" "email_pipeline" {
       source_type          = "attribute"
       target               = "event-type"
       target_type          = "tag"
-      target_format        = "string"
       preserve_source      = true
       override_on_conflict = false
       name                 = "Map 'eventType' to 'event-type' tag"
@@ -56,7 +53,6 @@ resource "datadog_logs_custom_pipeline" "email_pipeline" {
       source_type          = "attribute"
       target               = "user-role"
       target_type          = "tag"
-      target_format        = "string"
       preserve_source      = true
       override_on_conflict = false
       name                 = "Map mail.tags.user_role to 'user-role' tag"
@@ -69,7 +65,6 @@ resource "datadog_logs_custom_pipeline" "email_pipeline" {
       source_type          = "attribute"
       target               = "team-id"
       target_type          = "tag"
-      target_format        = "string"
       preserve_source      = true
       override_on_conflict = false
       name                 = "Map mail.tags.team_id to 'team-id' tag"
@@ -82,7 +77,6 @@ resource "datadog_logs_custom_pipeline" "email_pipeline" {
       source_type          = "attribute"
       target               = "organization-id"
       target_type          = "tag"
-      target_format        = "string"
       preserve_source      = true
       override_on_conflict = false
       name                 = "Map mail.tags.organization_id to 'organization-id' tag"
@@ -95,7 +89,6 @@ resource "datadog_logs_custom_pipeline" "email_pipeline" {
       source_type          = "attribute"
       target               = "configuration-set"
       target_type          = "tag"
-      target_format        = "string"
       preserve_source      = true
       override_on_conflict = false
       name                 = "Map mail.tags.ses:configuration-set to 'configuration-set' tag"

--- a/terraform/datadog_email_activity.tf
+++ b/terraform/datadog_email_activity.tf
@@ -1,4 +1,6 @@
 resource "datadog_logs_custom_pipeline" "email_pipeline" {
+  count = var.datadog_email_pipeline_enabled ? 1 : 0
+
   filter {
     query = "source:ses @Sns.Subject:'Amazon SES Email Event Notification'"
   }
@@ -118,6 +120,8 @@ resource "datadog_logs_custom_pipeline" "email_pipeline" {
 }
 
 resource "datadog_logs_metric" "gost_ses_email_sending_event_subscription" {
+  count = var.datadog_email_pipeline_metrics_enabled ? 1 : 0
+
   name = "gost.ses.email_sending_event.subscription"
   compute {
     aggregation_type = "count"
@@ -148,6 +152,8 @@ resource "datadog_logs_metric" "gost_ses_email_sending_event_subscription" {
 }
 
 resource "datadog_logs_metric" "gost_ses_email_sending_event_open" {
+  count = var.datadog_email_pipeline_metrics_enabled ? 1 : 0
+
   name = "gost.ses.email_sending_event.open"
   compute {
     aggregation_type = "count"
@@ -178,6 +184,8 @@ resource "datadog_logs_metric" "gost_ses_email_sending_event_open" {
 }
 
 resource "datadog_logs_metric" "gost_ses_email_sending_event_delivery_delay" {
+  count = var.datadog_email_pipeline_metrics_enabled ? 1 : 0
+
   name = "gost.ses.email_sending_event.delivery_delay"
   compute {
     aggregation_type = "count"
@@ -208,6 +216,8 @@ resource "datadog_logs_metric" "gost_ses_email_sending_event_delivery_delay" {
 }
 
 resource "datadog_logs_metric" "gost_ses_email_sending_event_rendering_failure" {
+  count = var.datadog_email_pipeline_metrics_enabled ? 1 : 0
+
   name = "gost.ses.email_sending_event.rendering_failure"
   compute {
     aggregation_type = "count"
@@ -238,6 +248,8 @@ resource "datadog_logs_metric" "gost_ses_email_sending_event_rendering_failure" 
 }
 
 resource "datadog_logs_metric" "gost_ses_email_sending_event_click" {
+  count = var.datadog_email_pipeline_metrics_enabled ? 1 : 0
+
   name = "gost.ses.email_sending_event.click"
   compute {
     aggregation_type = "count"
@@ -268,6 +280,8 @@ resource "datadog_logs_metric" "gost_ses_email_sending_event_click" {
 }
 
 resource "datadog_logs_metric" "gost_ses_email_sending_event_reject" {
+  count = var.datadog_email_pipeline_metrics_enabled ? 1 : 0
+
   name = "gost.ses.email_sending_event.reject"
   compute {
     aggregation_type = "count"
@@ -298,6 +312,8 @@ resource "datadog_logs_metric" "gost_ses_email_sending_event_reject" {
 }
 
 resource "datadog_logs_metric" "gost_ses_email_sending_event_complaint" {
+  count = var.datadog_email_pipeline_metrics_enabled ? 1 : 0
+
   name = "gost.ses.email_sending_event.complaint"
   compute {
     aggregation_type = "count"
@@ -328,6 +344,8 @@ resource "datadog_logs_metric" "gost_ses_email_sending_event_complaint" {
 }
 
 resource "datadog_logs_metric" "gost_ses_email_sending_event_bounce" {
+  count = var.datadog_email_pipeline_metrics_enabled ? 1 : 0
+
   name = "gost.ses.email_sending_event.bounce"
   compute {
     aggregation_type = "count"
@@ -358,6 +376,8 @@ resource "datadog_logs_metric" "gost_ses_email_sending_event_bounce" {
 }
 
 resource "datadog_logs_metric" "gost_ses_email_sending_event_send" {
+  count = var.datadog_email_pipeline_metrics_enabled ? 1 : 0
+
   name = "gost.ses.email_sending_event.send"
   compute {
     aggregation_type = "count"
@@ -388,6 +408,8 @@ resource "datadog_logs_metric" "gost_ses_email_sending_event_send" {
 }
 
 resource "datadog_logs_metric" "gost_ses_email_sending_event_delivery" {
+  count = var.datadog_email_pipeline_metrics_enabled ? 1 : 0
+
   name = "gost.ses.email_sending_event.delivery"
   compute {
     aggregation_type = "count"

--- a/terraform/staging.tfvars
+++ b/terraform/staging.tfvars
@@ -6,10 +6,12 @@ ssm_service_parameters_path_prefix    = "/gost/staging"
 ssm_deployment_parameters_path_prefix = "/gost/staging/deploy-config"
 
 // Datadog provider
-datadog_draft                        = true
-datadog_monitors_enabled             = true
-datadog_monitor_notification_handles = []
-ses_datadog_events_enabled           = true
+datadog_draft                          = true
+datadog_monitors_enabled               = true
+datadog_monitor_notification_handles   = []
+ses_datadog_events_enabled             = true
+datadog_email_pipeline_enabled         = true
+datadog_email_pipeline_metrics_enabled = true
 
 // Website
 website_enabled     = true

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -54,6 +54,18 @@ variable "ses_datadog_events_enabled" {
   default     = false
 }
 
+variable "datadog_email_pipeline_enabled" {
+  description = "Whether to create Datadog logs pipeline for SES events. Should only be enabled in Staging."
+  type        = bool
+  default     = false
+}
+
+variable "datadog_email_pipeline_metrics_enabled" {
+  description = "Whether to create Datadog logs metrics for SES events. Should only be enabled in Staging."
+  type        = bool
+  default     = false
+}
+
 // Common
 variable "permissions_boundary_policy_name" {
   description = "Name of the permissions boundary for service roles"


### PR DESCRIPTION
### Ticket #2882 (relates to #3387)
## Description

This PR fixes an issue introduced in 34c97ce83be83b70fd11f54eb3f6db6e654116ad. Terraform documentation [states](https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/logs_custom_pipeline#target_format) that for `processor.attribute_remapper` blocks, the `target_format` may not be specified when `target_type = "tag"`. Currently, we specify `target_format = "string"` for all steps which convert a log attribute to a tag, so this PR fixes those usages by omitting usages of `target_format`.

Additionally, this PR modifies the creation of Datadog logs-to-metrics infrastructure for SES events so that they are only managed in Staging, which is necessary to avoid errors due to duplicate Datadog infrastructure.