### PR TITLE
Fix: Invalid `target_format` in SES logs-to-metrics pipeline (again)

### DIFF
--- a/terraform/datadog_email_activity.tf
+++ b/terraform/datadog_email_activity.tf
@@ -103,7 +103,6 @@ resource "datadog_logs_custom_pipeline" "email_pipeline" {
       source_type          = "attribute"
       target               = "version"
       target_type          = "tag"
-      target_format        = "string"
       preserve_source      = true
       override_on_conflict = false
       name                 = "Map mail.tags.version to 'version' tag"


### PR DESCRIPTION
### Ticket #2882 (relates to #3387 #3415)
## Description

Follow-up to #3415 to fix a remaining stray usage of `target_format`, which I missed in the previous PR.