### PR TITLE
Fix: Typo in `trace_id_remapper.sources` list

### DIFF
--- a/terraform/datadog_email_activity.tf
+++ b/terraform/datadog_email_activity.tf
@@ -111,7 +111,7 @@ resource "datadog_logs_custom_pipeline" "email_pipeline" {
   }
   processor {
     trace_id_remapper {
-      sources    = ["mail.tags.dd_trace_id, mail.tags.dd_span_id"]
+      sources    = ["mail.tags.dd_trace_id", "mail.tags.dd_span_id"]
       name       = "trace id remapper"
       is_enabled = true
     }


### PR DESCRIPTION
### Ticket #3386 (relates to #3387)
## Description

This PR fixes a typo in Terraform code that defines the source log attributes from which trace IDs and span IDs are remapped in the Datadog logs pipeline for SES email events. Previously the source attributes were defined as a single, comma-separated string value; they should each be separate member values of the `sources` list.