### PR TITLE
Add unified service tags to email metrics generated from logs

### DIFF
--- a/terraform/datadog_email_activity.tf
+++ b/terraform/datadog_email_activity.tf
@@ -8,8 +8,8 @@ resource "datadog_logs_custom_pipeline" "email_pipeline" {
     query = "source:sns @Sns.Subject:\"Amazon SES Email Event Notification\""
   }
 
-  // Associate trace ID
-  // Note: trace_id_remapper is destructive; first duplicate mail.tags.dd_trace_id to a top-level tag
+  # Associate trace ID
+  # Note: trace_id_remapper is destructive; first duplicate mail.tags.dd_trace_id to a top-level tag
   processor {
     attribute_remapper {
       name                 = "Copy mail.tags.dd_trace_id to remapped_dd_trace_id"
@@ -23,7 +23,7 @@ resource "datadog_logs_custom_pipeline" "email_pipeline" {
       override_on_conflict = true
     }
   }
-  // Set temporary remapped_dd_trace_id as associated trace ID, which drops the source attribute
+  # Set temporary remapped_dd_trace_id as associated trace ID, which drops the source attribute
   processor {
     trace_id_remapper {
       name       = "Set Trace ID (removes remapped_dd_trace_id)"
@@ -32,7 +32,7 @@ resource "datadog_logs_custom_pipeline" "email_pipeline" {
     }
   }
 
-  // Add unified service tags (sevice, env, version) from email tags
+  # Add unified service tags (sevice, env, version) from email tags
   processor {
     service_remapper {
       name       = "Define mail.tags.service as the 'service' tag of the log"

--- a/terraform/datadog_email_activity.tf
+++ b/terraform/datadog_email_activity.tf
@@ -3,6 +3,7 @@ resource "datadog_logs_custom_pipeline" "email_pipeline" {
 
   name       = "Email SES"
   is_enabled = true
+
   filter {
     query = "source:sns @Sns.Subject:\"Amazon SES Email Event Notification\""
   }
@@ -31,7 +32,7 @@ resource "datadog_logs_custom_pipeline" "email_pipeline" {
     }
   }
 
-  // Add unified service tags (sevice, env, version)
+  // Add unified service tags (sevice, env, version) from email tags
   processor {
     service_remapper {
       name       = "Define mail.tags.service as the 'service' tag of the log"

--- a/terraform/datadog_email_activity.tf
+++ b/terraform/datadog_email_activity.tf
@@ -30,6 +30,8 @@ resource "datadog_logs_custom_pipeline" "email_pipeline" {
       sources    = ["remapped_dd_trace_id"]
     }
   }
+
+  // Add unified service tags (sevice, env, version)
   processor {
     service_remapper {
       name       = "Define mail.tags.service as the 'service' tag of the log"
@@ -39,43 +41,21 @@ resource "datadog_logs_custom_pipeline" "email_pipeline" {
   }
   processor {
     attribute_remapper {
-      sources              = ["mail.tags.team_id"]
+      name                 = "Map @mail.tags.env to 'env' tag of the log"
+      is_enabled           = true
+      sources              = ["mail.tags.env.0"]
       source_type          = "attribute"
-      target               = "team-id"
+      target               = "env"
       target_type          = "tag"
       preserve_source      = true
       override_on_conflict = false
-      name                 = "Map mail.tags.team_id to 'team-id' tag"
-      is_enabled           = true
     }
   }
   processor {
     attribute_remapper {
-      sources              = ["mail.tags.organization_id"]
-      source_type          = "attribute"
-      target               = "organization-id"
-      target_type          = "tag"
-      preserve_source      = true
-      override_on_conflict = false
-      name                 = "Map mail.tags.organization_id to 'organization-id' tag"
+      name                 = "Map mail.tags.version to 'version' tag of the log"
       is_enabled           = true
-    }
-  }
-  processor {
-    attribute_remapper {
-      sources              = ["mail.tags.ses:configuration-set"]
-      source_type          = "attribute"
-      target               = "configuration-set"
-      target_type          = "tag"
-      preserve_source      = true
-      override_on_conflict = false
-      name                 = "Map mail.tags.ses:configuration-set to 'configuration-set' tag"
-      is_enabled           = true
-    }
-  }
-  processor {
-    attribute_remapper {
-      sources              = ["mail.tags.version"]
+      sources              = ["mail.tags.version.0"]
       source_type          = "attribute"
       target               = "version"
       target_type          = "tag"

--- a/terraform/datadog_email_activity.tf
+++ b/terraform/datadog_email_activity.tf
@@ -76,6 +76,22 @@ resource "datadog_logs_metric" "gost_ses_email_sending_event_subscription" {
   filter {
     query = "@Sns.Subject:\"Amazon SES Email Event Notification\" @eventType:Subscription service:gost"
   }
+
+  # Project the universal service tags (service, env, version) from source log to metric
+  group_by {
+    path     = "service"
+    tag_name = "service"
+  }
+  group_by {
+    path     = "env"
+    tag_name = "env"
+  }
+  group_by {
+    path     = "version"
+    tag_name = "version"
+  }
+
+  # Add certain log attributes as tags for the metric
   group_by {
     path     = "@mail.tags.notification_type"
     tag_name = "notification-type"
@@ -108,6 +124,22 @@ resource "datadog_logs_metric" "gost_ses_email_sending_event_open" {
   filter {
     query = "@Sns.Subject:\"Amazon SES Email Event Notification\" @eventType:Open service:gost"
   }
+
+  # Project the universal service tags (service, env, version) from source log to metric
+  group_by {
+    path     = "service"
+    tag_name = "service"
+  }
+  group_by {
+    path     = "env"
+    tag_name = "env"
+  }
+  group_by {
+    path     = "version"
+    tag_name = "version"
+  }
+
+  # Add certain log attributes as tags for the metric
   group_by {
     path     = "@mail.tags.notification_type"
     tag_name = "notification-type"
@@ -140,6 +172,22 @@ resource "datadog_logs_metric" "gost_ses_email_sending_event_delivery_delay" {
   filter {
     query = "@Sns.Subject:\"Amazon SES Email Event Notification\" @eventType:DeliveryDelay service:gost"
   }
+
+  # Project the universal service tags (service, env, version) from source log to metric
+  group_by {
+    path     = "service"
+    tag_name = "service"
+  }
+  group_by {
+    path     = "env"
+    tag_name = "env"
+  }
+  group_by {
+    path     = "version"
+    tag_name = "version"
+  }
+
+  # Add certain log attributes as tags for the metric
   group_by {
     path     = "@mail.tags.notification_type"
     tag_name = "notification-type"
@@ -172,6 +220,22 @@ resource "datadog_logs_metric" "gost_ses_email_sending_event_rendering_failure" 
   filter {
     query = "@Sns.Subject:\"Amazon SES Email Event Notification\" @eventType:RenderingFailure service:gost"
   }
+
+  # Project the universal service tags (service, env, version) from source log to metric
+  group_by {
+    path     = "service"
+    tag_name = "service"
+  }
+  group_by {
+    path     = "env"
+    tag_name = "env"
+  }
+  group_by {
+    path     = "version"
+    tag_name = "version"
+  }
+
+  # Add certain log attributes as tags for the metric
   group_by {
     path     = "@mail.tags.notification_type"
     tag_name = "notification-type"
@@ -204,6 +268,22 @@ resource "datadog_logs_metric" "gost_ses_email_sending_event_click" {
   filter {
     query = "@Sns.Subject:\"Amazon SES Email Event Notification\" @eventType:Click service:gost"
   }
+
+  # Project the universal service tags (service, env, version) from source log to metric
+  group_by {
+    path     = "service"
+    tag_name = "service"
+  }
+  group_by {
+    path     = "env"
+    tag_name = "env"
+  }
+  group_by {
+    path     = "version"
+    tag_name = "version"
+  }
+
+  # Add certain log attributes as tags for the metric
   group_by {
     path     = "@mail.tags.notification_type"
     tag_name = "notification-type"
@@ -236,6 +316,22 @@ resource "datadog_logs_metric" "gost_ses_email_sending_event_reject" {
   filter {
     query = "@Sns.Subject:\"Amazon SES Email Event Notification\" @eventType:Reject service:gost"
   }
+
+  # Project the universal service tags (service, env, version) from source log to metric
+  group_by {
+    path     = "service"
+    tag_name = "service"
+  }
+  group_by {
+    path     = "env"
+    tag_name = "env"
+  }
+  group_by {
+    path     = "version"
+    tag_name = "version"
+  }
+
+  # Add certain log attributes as tags for the metric
   group_by {
     path     = "@mail.tags.notification_type"
     tag_name = "notification-type"
@@ -268,6 +364,22 @@ resource "datadog_logs_metric" "gost_ses_email_sending_event_complaint" {
   filter {
     query = "@Sns.Subject:\"Amazon SES Email Event Notification\" @eventType:Complaint service:gost"
   }
+
+  # Project the universal service tags (service, env, version) from source log to metric
+  group_by {
+    path     = "service"
+    tag_name = "service"
+  }
+  group_by {
+    path     = "env"
+    tag_name = "env"
+  }
+  group_by {
+    path     = "version"
+    tag_name = "version"
+  }
+
+  # Add certain log attributes as tags for the metric
   group_by {
     path     = "@mail.tags.notification_type"
     tag_name = "notification-type"
@@ -300,6 +412,22 @@ resource "datadog_logs_metric" "gost_ses_email_sending_event_bounce" {
   filter {
     query = "@Sns.Subject:\"Amazon SES Email Event Notification\" @eventType:Bounce service:gost"
   }
+
+  # Project the universal service tags (service, env, version) from source log to metric
+  group_by {
+    path     = "service"
+    tag_name = "service"
+  }
+  group_by {
+    path     = "env"
+    tag_name = "env"
+  }
+  group_by {
+    path     = "version"
+    tag_name = "version"
+  }
+
+  # Add certain log attributes as tags for the metric
   group_by {
     path     = "@mail.tags.notification_type"
     tag_name = "notification-type"
@@ -332,6 +460,22 @@ resource "datadog_logs_metric" "gost_ses_email_sending_event_send" {
   filter {
     query = "@Sns.Subject:\"Amazon SES Email Event Notification\" @eventType:Send service:gost"
   }
+
+  # Project the universal service tags (service, env, version) from source log to metric
+  group_by {
+    path     = "service"
+    tag_name = "service"
+  }
+  group_by {
+    path     = "env"
+    tag_name = "env"
+  }
+  group_by {
+    path     = "version"
+    tag_name = "version"
+  }
+
+  # Add certain log attributes as tags for the metric
   group_by {
     path     = "@mail.tags.notification_type"
     tag_name = "notification-type"
@@ -364,6 +508,22 @@ resource "datadog_logs_metric" "gost_ses_email_sending_event_delivery" {
   filter {
     query = "@Sns.Subject:\"Amazon SES Email Event Notification\" @eventType:Delivery service:gost"
   }
+
+  # Project the universal service tags (service, env, version) from source log to metric
+  group_by {
+    path     = "service"
+    tag_name = "service"
+  }
+  group_by {
+    path     = "env"
+    tag_name = "env"
+  }
+  group_by {
+    path     = "version"
+    tag_name = "version"
+  }
+
+  # Add certain log attributes as tags for the metric
   group_by {
     path     = "@mail.tags.notification_type"
     tag_name = "notification-type"


### PR DESCRIPTION
### Ticket #2882 
## Description

This PR modifies the Terraform infrastructure responsible for generating SES email event metrics in the following ways:
1. The pipeline has been updated to associate Trace IDs with log entries in a nondestructive manner. Since the [Trace ID remapper](https://docs.datadoghq.com/logs/log_configuration/processors/?tab=ui#trace-remapper) processor type always removes the source attribute, we first duplicate the trace ID at `mail.tags.dd_trace_id` to a (temporary) attribute, which is then removed by the Trace ID remapper.
2. Pipeline processing steps that were failing to execute have been fixed so that tags are remapped from the 0th index of the source attribute. This is necessary because SES tags are key/value pairs where the value is always an array; however, arrays (even when single-item) cannot be remapped as the value of a tag. Since all of our arrays are single-item, this PR modifies all [Attribute remappers](https://docs.datadoghq.com/logs/log_configuration/processors/?tab=ui#remapper) by setting `path.to.array.0` as the remapper source (e.g. `mail.tags.env.0` instead of `mail.tags.env`).
3. Pipeline processing steps have been reduced to extracting a Trace ID (for log/trace correlation), along with universal service tags (`service`, `env`, and `version`). Other attribute remappers have been dropped since they are not strictly necessary for tagging log-derived metrics.
4. All log-derived metrics  under the `gost.ses.email_sending_event.*` namespace are now generated with `service`, `env`, and `version` tags (sourced from the corresponding tag on the source log entry). Existing metric tags are unaltered.