### PR TITLE
Enable email metrics in Production

### DIFF
--- a/terraform/prod.tfvars
+++ b/terraform/prod.tfvars
@@ -90,4 +90,4 @@ consume_grants_datadog_environment_variables = {
 }
 
 // Email
-email_enable_tracking = false
+email_enable_tracking = true


### PR DESCRIPTION
### Ticket #3098
## Description

This PR simply enables SES email tracking metric in Production. Most of the relevant infrastructure has already been provisioned, but the main on/off gate we use for this feature is an SES-to-SNS event destination, which currently does not exist in Production for our SES configuration set.