### PR TITLE
Fix breaking change in actions/upload-artifacts 4.4.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -215,6 +215,7 @@ jobs:
           name: ${{ env.ATTESTATION_ARTIFACTS_KEY }}
           path: ${{ steps.store-attestations.outputs.path }}
           if-no-files-found: error
+          include-hidden-files: true
           retention-days: ${{ inputs.server-image-artifacts-retention-days }}
           overwrite: true
 
@@ -281,5 +282,6 @@ jobs:
           name: ${{ env.ARTIFACTS_KEY }}
           path: ${{ env.ARTIFACTS_PATH }}
           if-no-files-found: error
+          include-hidden-files: true
           retention-days: ${{ inputs.website-artifact-retention-days }}
           overwrite: true

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -234,5 +234,6 @@ jobs:
             ${{ github.workspace }}/terraform
             !${{ github.workspace }}/terraform/.terraform
           if-no-files-found: error
+          include-hidden-files: true
           retention-days: ${{ inputs.artifacts-retention-days }}
           overwrite: true


### PR DESCRIPTION
### See also

https://github.com/usdigitalresponse/usdr-gost/pull/3452 (PR that introduced the breaking change)
https://github.com/actions/upload-artifact/issues/602
https://github.com/actions/upload-artifact/releases/tag/v4.4.0

## Description

This fixes the breaking change in [`actions/upload-artifacts` v4.4.0](https://github.com/actions/upload-artifact/releases/tag/v4.4.0) by configuring our usages of the action to include hidden files, which was the default behavior prior to this version change.