### PR TITLE
Fix `FromAsCasing` build check error

### DIFF
--- a/docker/production-api.Dockerfile
+++ b/docker/production-api.Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20.11.1-alpine as app_base
+FROM node:20.11.1-alpine AS app_base
 
 # Define build argument defaults
 ARG GIT_COMMIT=""


### PR DESCRIPTION
## Description

This PR fixes a Dockerfile casing issue (see [`FromAsCasing` build check](https://docs.docker.com/reference/build-checks/from-as-casing/)) that regularly surfaces as a PR check warning ([example](https://github.com/usdigitalresponse/usdr-gost/pull/3470/files#annotation_25988010942)).