### PR TITLE
Bug fix: My Grants showing all grants

### DIFF
--- a/packages/client/src/router/index.js
+++ b/packages/client/src/router/index.js
@@ -67,7 +67,7 @@ export const routes = [
       {
         path: '/grants',
         name: 'grants',
-        component: () => import('../views/GrantsView.vue'),
+        component: () => import('@/views/GrantsView.vue'),
         meta: {
           requiresAuth: true,
         },
@@ -87,26 +87,9 @@ export const routes = [
         redirect: { name: 'myGrants', params: { tab: myGrantsTabs[0] } },
       },
       {
-        path: '/my-grants/assigned',
-        name: 'assigned',
-        redirect: { name: shareTerminologyEnabled ? 'shared-with-your-team' : undefined },
-        meta: {
-          requiresAuth: true,
-        },
-      },
-      {
-        path: '/my-grants/shared-with-your-team',
-        name: 'shared-with-your-team',
-        component: () => import('@/views/MyGrantsView.vue'),
-        meta: {
-          requiresAuth: true,
-          requiresShareTerminologyEnabled: true,
-        },
-      },
-      {
         path: '/my-grants/:tab',
         name: 'myGrants',
-        component: () => import('../views/MyGrantsView.vue'),
+        component: () => import('@/views/MyGrantsView.vue'),
         meta: {
           tabNames: myGrantsTabs,
           requiresAuth: true,
@@ -166,7 +149,7 @@ export const routes = [
       {
         path: '/my-profile',
         name: 'myProfile',
-        component: () => import('../views/MyProfileView.vue'),
+        component: () => import('@/views/MyProfileView.vue'),
         meta: {
           requiresAuth: true,
           hideLayoutTabs: true,
@@ -176,7 +159,7 @@ export const routes = [
   },
   {
     path: '/:pathMatch(.*)*',
-    component: () => import('../views/NotFoundView.vue'),
+    component: () => import('@/views/NotFoundView.vue'),
     name: 'notFound',
     meta: {
       requiresAuth: true,

--- a/packages/client/src/store/modules/grants.js
+++ b/packages/client/src/store/modules/grants.js
@@ -185,16 +185,15 @@ export default {
         agencyIds,
       });
     },
-    unmarkGrantAsInterested({ rootGetters }, {
+    async unmarkGrantAsInterested({ rootGetters, commit, dispatch }, {
       grantId, agencyIds, interestedCode, agencyId,
     }) {
-      return fetchApi.deleteRequest(`/api/organizations/${rootGetters['users/selectedAgencyId']}/grants/${grantId}/interested/${agencyId}`, {
+      await fetchApi.deleteRequest(`/api/organizations/${rootGetters['users/selectedAgencyId']}/grants/${grantId}/interested/${agencyId}`, {
         agencyIds,
         interestedCode,
       });
-    },
-    fetchInterestedAgencies({ rootGetters }, { grantId }) {
-      return fetchApi.get(`/api/organizations/${rootGetters['users/selectedAgencyId']}/grants/${grantId}/interested`);
+      const interestedAgencies = await dispatch('getInterestedAgencies', { grantId });
+      commit('UPDATE_GRANT', { grantId, data: { interested_agencies: interestedAgencies } });
     },
     async markGrantAsInterested({ commit, rootGetters }, { grantId, agencyId, interestedCode }) {
       const interestedAgencies = await fetchApi.put(`/api/organizations/${rootGetters['users/selectedAgencyId']}/grants/${grantId}/interested/${agencyId}`, {

--- a/packages/client/src/views/GrantDetailsView.spec.js
+++ b/packages/client/src/views/GrantDetailsView.spec.js
@@ -1,10 +1,9 @@
-import GrantDetailsView from '@/views/GrantDetailsView.vue';
-
 import {
   describe, it, expect, vi,
 } from 'vitest';
 import { shallowMount } from '@vue/test-utils';
 import { createStore } from 'vuex';
+import GrantDetailsView from '@/views/GrantDetailsView.vue';
 
 describe('GrantDetailsView', () => {
   const store = createStore({
@@ -23,7 +22,6 @@ describe('GrantDetailsView', () => {
       'grants/markGrantAsViewed': vi.fn(),
       'grants/markGrantAsInterested': vi.fn(),
       'grants/unmarkGrantAsInterested': vi.fn(),
-      'grants/getInterestedAgencies': vi.fn(),
       'grants/getGrantAssignedAgencies': vi.fn(),
       'grants/assignAgenciesToGrant': vi.fn(),
       'grants/unassignAgenciesToGrant': vi.fn(),

--- a/packages/client/src/views/GrantDetailsView.vue
+++ b/packages/client/src/views/GrantDetailsView.vue
@@ -378,7 +378,6 @@ export default {
       markGrantAsViewedAction: 'grants/markGrantAsViewed',
       markGrantAsInterestedAction: 'grants/markGrantAsInterested',
       unmarkGrantAsInterestedAction: 'grants/unmarkGrantAsInterested',
-      getInterestedAgencies: 'grants/getInterestedAgencies',
       fetchAgencies: 'agencies/fetchAgencies',
       fetchGrantDetails: 'grants/fetchGrantDetails',
     }),
@@ -421,7 +420,6 @@ export default {
         agencyIds: [agency.agency_id],
         interestedCode: agency.interested_code_id,
       });
-      this.currentGrant.interested_agencies = await this.getInterestedAgencies({ grantId: this.currentGrant.grant_id });
       const eventName = 'remove team status for grant';
       gtagEvent(eventName);
       datadogRum.addAction(eventName);


### PR DESCRIPTION
### Ticket #3512 
## Description
- We were able to replicate this issue as a race condition from multiple grant tabs sharing a list of grants. 
- Resolutions for bugs on My Grants tab:
  1. Race condition for tabs sharing same grants fetching API endpoint.
  2. Duplicate route(s) causing match for first tab of `MyGrantsView` page and redirecting to page component without proper data (`tabNames`)
  3. Direct mutation of vuex state outside of commit/mutation calls

## Screenshots / Demo Video

## Testing
- Steps to replicate: This issue can be reproduced by switching quickly between tabs on My Grants section where one return set is much larger than another (and returns from the server w/ delay).

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [x] Provided ticket and description
- [ ] Provided screenshots/demo
- [x] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers