### PR TITLE
3372 - adds database changes to support managing IAA subrecipients

### DIFF
--- a/packages/server/__tests__/arpa_reporter/server/db/arpa-subrecipients.spec.js
+++ b/packages/server/__tests__/arpa_reporter/server/db/arpa-subrecipients.spec.js
@@ -7,10 +7,8 @@
 */
 const { findRecipient } = requireSrc(__filename);
 const assert = require('assert');
-const _ = require('lodash');
-const { requestProviderMiddleware } = require('../../../../src/arpa_reporter/use-request');
-const { withTenantId } = require('../helpers/with-tenant-id');
 const knex = require('../../../../src/db/connection');
+const { withTenantId } = require('../helpers/with-tenant-id');
 
 const TENANT_A = 0;
 
@@ -41,9 +39,16 @@ describe('db/arpa-subrecipients.js', () => {
     });
     describe('findRecipient', () => {
         it('Returns a recipient with UEI', async () => {
-            const result = await requestProviderMiddleware({ session: { user: { tenant_id: TENANT_A } } }, null, findRecipient('uei', 'UEI-1'));
-            console.log(result);
-            assert.equal(result.length, 21);
+            const result = await withTenantId(TENANT_A, findRecipient, 'uei', 'UEI-1');
+            assert.equal(result.name, 'Contractor with UEI');
+        });
+        it('Returns a recipient with TIN', async () => {
+            const result = await withTenantId(TENANT_A, findRecipient, 'tin', 'TIN-1');
+            assert.equal(result.name, 'Beneficiary with TIN');
+        });
+        it('Returns a recipient with Name', async () => {
+            const result = await withTenantId(TENANT_A, findRecipient, 'name', 'IAA');
+            assert.equal(result.name, 'IAA');
         });
     });
 });

--- a/packages/server/__tests__/arpa_reporter/server/db/arpa-subrecipients.spec.js
+++ b/packages/server/__tests__/arpa_reporter/server/db/arpa-subrecipients.spec.js
@@ -238,5 +238,3 @@ describe('db/arpa-subrecipients.js', () => {
         });
     });
 });
-
-// NOTE: This file was copied from tests/server/db/reporting-periods.spec.js (git @ ada8bfdc98) in the arpa-reporter repo on 2022-09-23T20:05:47.735Z

--- a/packages/server/__tests__/arpa_reporter/server/db/arpa-subrecipients.spec.js
+++ b/packages/server/__tests__/arpa_reporter/server/db/arpa-subrecipients.spec.js
@@ -19,16 +19,19 @@ const NONEXISTENT_TENANT = 100;
 describe('db/reporting-periods.js', () => {
     const recipients = {
         beneficiaryWithTIN: {
+            tenant_id: TENANT_A,
             name: 'Beneficiary with TIN',
             tin: 'TIN-1',
             uei: null,
         },
         iaa: {
+            tenant_id: TENANT_A,
             name: 'IAA',
             tin: null,
             uei: null,
         },
         contractorWithUEI: {
+            tenant_id: TENANT_A,
             name: 'Contractor with UEI',
             tin: null,
             uei: 'UEI-1',

--- a/packages/server/__tests__/arpa_reporter/server/db/arpa-subrecipients.spec.js
+++ b/packages/server/__tests__/arpa_reporter/server/db/arpa-subrecipients.spec.js
@@ -39,15 +39,15 @@ describe('db/arpa-subrecipients.js', () => {
     });
     describe('findRecipient', () => {
         it('Returns a recipient with UEI', async () => {
-            const result = await withTenantId(TENANT_A, findRecipient, 'uei', 'UEI-1');
+            const result = await withTenantId(TENANT_A, () => findRecipient('uei', 'UEI-1'));
             assert.equal(result.name, 'Contractor with UEI');
         });
         it('Returns a recipient with TIN', async () => {
-            const result = await withTenantId(TENANT_A, findRecipient, 'tin', 'TIN-1');
+            const result = await withTenantId(TENANT_A, () => findRecipient('tin', 'TIN-1'));
             assert.equal(result.name, 'Beneficiary with TIN');
         });
         it('Returns a recipient with Name', async () => {
-            const result = await withTenantId(TENANT_A, findRecipient, 'name', 'IAA');
+            const result = await withTenantId(TENANT_A, () => findRecipient('name', 'IAA'));
             assert.equal(result.name, 'IAA');
         });
     });
@@ -63,7 +63,7 @@ describe('db/arpa-subrecipients.js', () => {
 
             await assert.rejects(
                 async () => {
-                    await withTenantId(TENANT_A, createRecipient, recipient);
+                    await withTenantId(TENANT_A, () => createRecipient(recipient));
                 },
                 (err) => {
                     assert.strictEqual(err.name, 'Error');
@@ -82,7 +82,7 @@ describe('db/arpa-subrecipients.js', () => {
 
             await assert.rejects(
                 async () => {
-                    await withTenantId(TENANT_A, createRecipient, recipient);
+                    await withTenantId(TENANT_A, () => createRecipient(recipient));
                 },
                 (err) => {
                     assert.strictEqual(err.name, 'Error');
@@ -101,7 +101,7 @@ describe('db/arpa-subrecipients.js', () => {
 
             await assert.rejects(
                 async () => {
-                    await withTenantId(TENANT_A, createRecipient, recipient);
+                    await withTenantId(TENANT_A, () => createRecipient(recipient));
                 },
                 (err) => {
                     assert.strictEqual(err.name, 'Error');
@@ -120,7 +120,7 @@ describe('db/arpa-subrecipients.js', () => {
 
             await assert.rejects(
                 async () => {
-                    await withTenantId(TENANT_A, createRecipient, recipient);
+                    await withTenantId(TENANT_A, () => createRecipient(recipient));
                 },
                 (err) => {
                     assert.strictEqual(err.name, 'Error');

--- a/packages/server/__tests__/arpa_reporter/server/db/arpa-subrecipients.spec.js
+++ b/packages/server/__tests__/arpa_reporter/server/db/arpa-subrecipients.spec.js
@@ -233,7 +233,7 @@ describe('db/arpa-subrecipients.js', () => {
             };
             const values = `(${recipient.tenant_id}, '${recipient.name}', '${recipient.tin}', ${recipient.uei})`;
             await withTenantId(TENANT_A, () => knex.raw(insertStatement + values));
-            const result = await knex('arpa_subrecipients').where('tenant_id', TENANT_A).where('name', 'IAA').all();
+            const result = await knex('arpa_subrecipients').where('tenant_id', TENANT_A).where('name', 'IAA');
             assert.strictEqual(result.length, 2);
         });
     });

--- a/packages/server/__tests__/arpa_reporter/server/db/arpa-subrecipients.spec.js
+++ b/packages/server/__tests__/arpa_reporter/server/db/arpa-subrecipients.spec.js
@@ -13,10 +13,8 @@ const { withTenantId } = require('../helpers/with-tenant-id');
 const knex = require('../../../../src/db/connection');
 
 const TENANT_A = 0;
-const TENANT_B = 1;
-const NONEXISTENT_TENANT = 100;
 
-describe('db/reporting-periods.js', () => {
+describe('db/arpa-subrecipients.js', () => {
     const recipients = {
         beneficiaryWithTIN: {
             tenant_id: TENANT_A,
@@ -36,7 +34,7 @@ describe('db/reporting-periods.js', () => {
             tin: null,
             uei: 'UEI-1',
         },
-    }
+    };
     before(async () => {
         await knex.raw('TRUNCATE TABLE arpa_subrecipients CASCADE');
         await knex('arpa_subrecipients').insert(Object.values(recipients));

--- a/packages/server/__tests__/arpa_reporter/server/db/arpa-subrecipients.spec.js
+++ b/packages/server/__tests__/arpa_reporter/server/db/arpa-subrecipients.spec.js
@@ -50,6 +50,18 @@ describe('db/arpa-subrecipients.js', () => {
             const result = await withTenantId(TENANT_A, () => findRecipient('name', 'IAA'));
             assert.equal(result.name, 'IAA');
         });
+        it('Throws error when querying for a recipient with an invalid field type', async () => {
+            await assert.rejects(
+                async () => {
+                    await withTenantId(TENANT_A, () => findRecipient('invalid', 'IAA'));
+                },
+                (err) => {
+                    assert.strictEqual(err.name, 'Error');
+                    assert.strictEqual(err.message, 'Cannot query for recipient without a valid field type');
+                    return true;
+                },
+            );
+        });
     });
 
     describe('createRecipient', () => {

--- a/packages/server/__tests__/arpa_reporter/server/db/arpa-subrecipients.spec.js
+++ b/packages/server/__tests__/arpa_reporter/server/db/arpa-subrecipients.spec.js
@@ -1,0 +1,50 @@
+/*
+--------------------------------------------------------------------------------
+-                     tests/db/arpa-subrecipients.spec.js
+--------------------------------------------------------------------------------
+  A arpa_subrecipients record in postgres looks like this:
+
+*/
+const { findRecipient } = requireSrc(__filename);
+const assert = require('assert');
+const _ = require('lodash');
+const { requestProviderMiddleware } = require('../../../../src/arpa_reporter/use-request');
+const { withTenantId } = require('../helpers/with-tenant-id');
+const knex = require('../../../../src/db/connection');
+
+const TENANT_A = 0;
+const TENANT_B = 1;
+const NONEXISTENT_TENANT = 100;
+
+describe('db/reporting-periods.js', () => {
+    const recipients = {
+        beneficiaryWithTIN: {
+            name: 'Beneficiary with TIN',
+            tin: 'TIN-1',
+            uei: null,
+        },
+        iaa: {
+            name: 'IAA',
+            tin: null,
+            uei: null,
+        },
+        contractorWithUEI: {
+            name: 'Contractor with UEI',
+            tin: null,
+            uei: 'UEI-1',
+        },
+    }
+    before(async () => {
+        await knex.raw('TRUNCATE TABLE arpa_subrecipients CASCADE');
+        await knex('arpa_subrecipients').insert(Object.values(recipients));
+    });
+    describe('findRecipient', () => {
+        it('Returns a recipient with UEI', async () => {
+            const result = await requestProviderMiddleware({ session: { user: { tenant_id: TENANT_A } } }, null, findRecipient('uei', 'UEI-1'));
+            console.log(result);
+            assert.equal(result.length, 21);
+        });
+    });
+});
+
+// NOTE: This file was copied from tests/server/db/reporting-periods.spec.js (git @ ada8bfdc98) in the arpa-reporter repo on 2022-09-23T20:05:47.735Z

--- a/packages/server/__tests__/arpa_reporter/server/db/arpa-subrecipients.spec.js
+++ b/packages/server/__tests__/arpa_reporter/server/db/arpa-subrecipients.spec.js
@@ -91,6 +91,44 @@ describe('db/arpa-subrecipients.js', () => {
                 },
             );
         });
+        it('Throws error creating two IAA with the same name and no UEI/TIN value', async () => {
+            const recipient = {
+                tenant_id: TENANT_A,
+                name: 'IAA',
+                tin: null,
+                uei: null,
+            };
+
+            await assert.rejects(
+                async () => {
+                    await withTenantId(TENANT_A, createRecipient, recipient);
+                },
+                (err) => {
+                    assert.strictEqual(err.name, 'Error');
+                    assert.strictEqual(err.message, 'A recipient with this name already exists');
+                    return true;
+                },
+            );
+        });
+        it('Throws error creating a subrecipient with no name, uei, or tin', async () => {
+            const recipient = {
+                tenant_id: TENANT_A,
+                name: null,
+                tin: null,
+                uei: null,
+            };
+
+            await assert.rejects(
+                async () => {
+                    await withTenantId(TENANT_A, createRecipient, recipient);
+                },
+                (err) => {
+                    assert.strictEqual(err.name, 'Error');
+                    assert.strictEqual(err.message, 'recipient row must include a `uei`, `tin`, or `name` field');
+                    return true;
+                },
+            );
+        });
     });
 });
 

--- a/packages/server/__tests__/arpa_reporter/server/db/arpa-subrecipients.spec.js
+++ b/packages/server/__tests__/arpa_reporter/server/db/arpa-subrecipients.spec.js
@@ -2,8 +2,10 @@
 --------------------------------------------------------------------------------
 -                     tests/db/arpa-subrecipients.spec.js
 --------------------------------------------------------------------------------
-  A arpa_subrecipients record in postgres looks like this:
-
+  To see what the `arpa_subrecipients` table looks like in postgres, run the following command:
+    docker compose run --rm -it app /bin/bash
+    PGPASSWORD=password123 psql -U postgres -d usdr_grants -h postgres
+    \d arpa_subrecipients
 */
 const { findRecipient, createRecipient } = requireSrc(__filename);
 const assert = require('assert');

--- a/packages/server/__tests__/arpa_reporter/server/helpers/with-tenant-id.js
+++ b/packages/server/__tests__/arpa_reporter/server/helpers/with-tenant-id.js
@@ -8,12 +8,12 @@ const { requestProviderMiddleware } = require('../../../../src/arpa_reporter/use
  * @returns {Promise}
  * A promise that resolves to the return value of the callback, if any.
  */
-async function withTenantId(tenantId, callback, ...args) {
+async function withTenantId(tenantId, callback) {
     return new Promise((resolve) => {
         requestProviderMiddleware(
             { session: { user: { tenant_id: tenantId } } },
             null,
-            () => resolve(callback(...args)),
+            () => resolve(callback()),
         );
     });
 }

--- a/packages/server/__tests__/arpa_reporter/server/helpers/with-tenant-id.js
+++ b/packages/server/__tests__/arpa_reporter/server/helpers/with-tenant-id.js
@@ -8,12 +8,12 @@ const { requestProviderMiddleware } = require('../../../../src/arpa_reporter/use
  * @returns {Promise}
  * A promise that resolves to the return value of the callback, if any.
  */
-async function withTenantId(tenantId, callback) {
+async function withTenantId(tenantId, callback, ...args) {
     return new Promise((resolve) => {
         requestProviderMiddleware(
             { session: { user: { tenant_id: tenantId } } },
             null,
-            () => resolve(callback()),
+            () => resolve(callback(...args)),
         );
     });
 }

--- a/packages/server/__tests__/arpa_reporter/server/services/validate-upload.spec.js
+++ b/packages/server/__tests__/arpa_reporter/server/services/validate-upload.spec.js
@@ -561,11 +561,12 @@ describe('updateOrCreateRecipient', () => {
     it('should call createRecipient when existingRecipient is falsy', async () => {
         const trns = {};
         const upload = { id: 1 };
-        const newRecipient = { Unique_Entity_Identifier__c: 'UEI1', EIN__c: 'EIN1' };
+        const newRecipient = { Name: 'Test 1', Unique_Entity_Identifier__c: 'UEI1', EIN__c: 'EIN1' };
 
         await updateOrCreateRecipient(null, newRecipient, trns, upload, createRecipientStub, updateRecipientStub);
 
         sinon.assert.calledWith(createRecipientStub, {
+            name: 'Test 1',
             uei: 'UEI1',
             tin: 'EIN1',
             record: newRecipient,

--- a/packages/server/__tests__/arpa_reporter/server/services/validate-upload.spec.js
+++ b/packages/server/__tests__/arpa_reporter/server/services/validate-upload.spec.js
@@ -199,21 +199,21 @@ describe('findRecipientInDatabase', () => {
         it('should return the recipient found by UEI', async () => {
             const mockFindRecipient = sinon.stub().withArgs('UEI123', null, trns).resolves({ name: 'John' });
             validateUploadModule.__set__('findRecipient', mockFindRecipient);
-            const result = await findRecipientInDatabase({ beneficiaryRecipient, trns }, mockFindRecipient);
+            const result = await findRecipientInDatabase({ recipient: beneficiaryRecipient, trns }, mockFindRecipient);
             expect(result).to.deep.equal({ name: 'John' });
         });
 
         it('should return the recipient found by EIN', async () => {
             const mockFindRecipient = sinon.stub().withArgs(null, 'EIN123', trns).resolves({ name: 'Jane' });
             validateUploadModule.__set__('findRecipient', mockFindRecipient);
-            const result = await findRecipientInDatabase({ beneficiaryRecipient, trns }, mockFindRecipient);
+            const result = await findRecipientInDatabase({ recipient: beneficiaryRecipient, trns }, mockFindRecipient);
             expect(result).to.deep.equal({ name: 'Jane' });
         });
 
         it('should return null if recipient is not found', async () => {
             const mockFindRecipient = sinon.stub().resolves(null);
             validateUploadModule.__set__('findRecipient', mockFindRecipient);
-            const result = await findRecipientInDatabase({ beneficiaryRecipient, trns }, mockFindRecipient);
+            const result = await findRecipientInDatabase({ recipient: beneficiaryRecipient, trns }, mockFindRecipient);
             expect(result).to.be.null;
         });
     });
@@ -234,21 +234,21 @@ describe('findRecipientInDatabase', () => {
         it('should return the recipient found by UEI', async () => {
             const mockFindRecipient = sinon.stub().withArgs('uei', 'UEI123', trns).resolves({ name: 'John' });
             validateUploadModule.__set__('findRecipient', mockFindRecipient);
-            const result = await findRecipientInDatabase({ beneficiaryRecipient, trns }, mockFindRecipient);
+            const result = await findRecipientInDatabase({ recipient: beneficiaryRecipient, trns }, mockFindRecipient);
             expect(result).to.deep.equal({ name: 'John' });
         });
 
         it('should return the recipient found by EIN', async () => {
             const mockFindRecipient = sinon.stub().withArgs('tin', 'EIN123', trns).resolves({ name: 'Jane' });
             validateUploadModule.__set__('findRecipient', mockFindRecipient);
-            const result = await findRecipientInDatabase({ beneficiaryRecipient, trns }, mockFindRecipient);
+            const result = await findRecipientInDatabase({ recipient: beneficiaryRecipient, trns }, mockFindRecipient);
             expect(result).to.deep.equal({ name: 'Jane' });
         });
 
         it('should return the recipient found by Name', async () => {
             const mockFindRecipient = sinon.stub().withArgs('name', 'IAA Recipient', trns).resolves({ name: 'IAA Recipient' });
             validateUploadModule.__set__('findRecipient', mockFindRecipient);
-            const result = await findRecipientInDatabase({ beneficiaryRecipient, trns }, mockFindRecipient);
+            const result = await findRecipientInDatabase({ recipient: beneficiaryRecipient, trns }, mockFindRecipient);
             expect(result).to.deep.equal({ name: 'IAA Recipient' });
         });
     });

--- a/packages/server/__tests__/arpa_reporter/server/services/validate-upload.spec.js
+++ b/packages/server/__tests__/arpa_reporter/server/services/validate-upload.spec.js
@@ -322,7 +322,7 @@ describe('findRecipientInDatabase', () => {
 describe('validateIdentifier for IAA', () => {
     const validateIdentifier = validateUploadModule.__get__('validateIdentifier');
     describe('when subrecipient exists in the database', () => {
-        it('should return an error if IAA has no UEI or TIN', () => {
+        it('should return no errors if IAA has no UEI or TIN', () => {
             const recipient = {
                 Entity_Type_2__c: 'IAA',
                 Unique_Entity_Identifier__c: null,
@@ -334,7 +334,7 @@ describe('validateIdentifier for IAA', () => {
         });
     });
     describe('when subrecipient does not exist in the database', () => {
-        it('should return an error if IAA has no UEI or TIN', () => {
+        it('should return no errors if IAA has no UEI or TIN', () => {
             const recipient = {
                 Entity_Type_2__c: 'IAA',
                 Unique_Entity_Identifier__c: null,

--- a/packages/server/migrations/20240918183745_drop_constraints_to_arpa_subrecipients.js
+++ b/packages/server/migrations/20240918183745_drop_constraints_to_arpa_subrecipients.js
@@ -1,0 +1,21 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function (knex) {
+    return knex.schema.alterTable('arpa_subrecipients', (table) => {
+        table.dropUnique(['tenant_id', 'uei']);
+        table.dropUnique(['tenant_id', 'tin']);
+    });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function (knex) {
+    return knex.schema.alterTable('arpa_subrecipients', (table) => {
+        table.unique(['tenant_id', 'uei']);
+        table.unique(['tenant_id', 'tin']);
+    });
+};

--- a/packages/server/migrations/20240918183745_drop_constraints_to_arpa_subrecipients.js
+++ b/packages/server/migrations/20240918183745_drop_constraints_to_arpa_subrecipients.js
@@ -2,17 +2,48 @@
  * @param { import("knex").Knex } knex
  * @returns { Promise<void> }
  */
-exports.up = function (knex) {
-    return knex.schema.alterTable('arpa_subrecipients', (table) => {
+exports.up = async function (knex) {
+    await knex.schema.alterTable('arpa_subrecipients', (table) => {
         table.dropUnique(['tenant_id', 'uei']);
-        table.index(['tenant_id', 'uei'], 'idx_arpa_subrecipients_tenant_id_uei_unique', {
-            predicate: knex.whereNotNull('uei'),
-        });
         table.dropUnique(['tenant_id', 'tin']);
-        table.index(['tenant_id', 'tin'], 'idx_arpa_subrecipients_tenant_id_tin_unique', {
-            predicate: knex.whereNotNull('tin'),
-        });
+
+        // table.index(
+        //     ['tenant_id', 'uei'],
+        //     'idx_arpa_subrecipients_tenant_id_uei_unique',
+        //     {
+        //         predicate: knex.whereNotNull('uei'),
+        //     },
+        // );
+        // table.index(
+        //     ['tenant_id', 'tin'],
+        //     'idx_arpa_subrecipients_tenant_id_tin_unique',
+        //     {
+        //         predicate: knex.whereNotNull('tin'),
+        //     },
+        // );
+        // table.unique(
+        //     ['tenant_id', 'uei'],
+        //     {
+        //         indexName: 'idx_arpa_subrecipients_tenant_id_uei_unique',
+        //         predicate: knex.whereNotNull('uei'),
+        //         useConstraint: false,
+        //     },
+        // );
+        // table.unique(
+        //     ['tenant_id', 'tin'],
+        //     {
+        //         indexName: 'idx_arpa_subrecipients_tenant_id_tin_unique',
+        //         predicate: knex.whereNotNull('tin'),
+        //         useConstraint: false,
+        //     },
+        // );
     });
+    await knex.raw(
+        'CREATE UNIQUE INDEX idx_arpa_subrecipients_tenant_id_uei_unique ON arpa_subrecipients (tenant_id, uei) WHERE uei IS NOT NULL',
+    );
+    await knex.raw(
+        'CREATE UNIQUE INDEX idx_arpa_subrecipients_tenant_id_tin_unique ON arpa_subrecipients (tenant_id, tin) WHERE tin IS NOT NULL',
+    );
 };
 
 /**
@@ -21,9 +52,17 @@ exports.up = function (knex) {
  */
 exports.down = function (knex) {
     return knex.schema.alterTable('arpa_subrecipients', (table) => {
+        // option 1
+        // table.dropIndex([], 'idx_arpa_subrecipients_tenant_id_tin_unique');
+        // table.dropIndex([], 'idx_arpa_subrecipients_tenant_id_uei_unique');
+        // option 2
+        // table.dropUnique([], 'idx_arpa_subrecipients_tenant_id_tin_unique');
+        // table.dropUnique([], 'idx_arpa_subrecipients_tenant_id_uei_unique');
+        // option 3
         table.dropIndex([], 'idx_arpa_subrecipients_tenant_id_tin_unique');
-        table.unique(['tenant_id', 'tin']);
         table.dropIndex([], 'idx_arpa_subrecipients_tenant_id_uei_unique');
+
+        table.unique(['tenant_id', 'tin']);
         table.unique(['tenant_id', 'uei']);
     });
 };

--- a/packages/server/migrations/20240918183745_drop_constraints_to_arpa_subrecipients.js
+++ b/packages/server/migrations/20240918183745_drop_constraints_to_arpa_subrecipients.js
@@ -6,37 +6,6 @@ exports.up = async function (knex) {
     await knex.schema.alterTable('arpa_subrecipients', (table) => {
         table.dropUnique(['tenant_id', 'uei']);
         table.dropUnique(['tenant_id', 'tin']);
-
-        // table.index(
-        //     ['tenant_id', 'uei'],
-        //     'idx_arpa_subrecipients_tenant_id_uei_unique',
-        //     {
-        //         predicate: knex.whereNotNull('uei'),
-        //     },
-        // );
-        // table.index(
-        //     ['tenant_id', 'tin'],
-        //     'idx_arpa_subrecipients_tenant_id_tin_unique',
-        //     {
-        //         predicate: knex.whereNotNull('tin'),
-        //     },
-        // );
-        // table.unique(
-        //     ['tenant_id', 'uei'],
-        //     {
-        //         indexName: 'idx_arpa_subrecipients_tenant_id_uei_unique',
-        //         predicate: knex.whereNotNull('uei'),
-        //         useConstraint: false,
-        //     },
-        // );
-        // table.unique(
-        //     ['tenant_id', 'tin'],
-        //     {
-        //         indexName: 'idx_arpa_subrecipients_tenant_id_tin_unique',
-        //         predicate: knex.whereNotNull('tin'),
-        //         useConstraint: false,
-        //     },
-        // );
     });
     await knex.raw(
         'CREATE UNIQUE INDEX idx_arpa_subrecipients_tenant_id_uei_unique ON arpa_subrecipients (tenant_id, uei) WHERE uei IS NOT NULL',
@@ -52,13 +21,6 @@ exports.up = async function (knex) {
  */
 exports.down = function (knex) {
     return knex.schema.alterTable('arpa_subrecipients', (table) => {
-        // option 1
-        // table.dropIndex([], 'idx_arpa_subrecipients_tenant_id_tin_unique');
-        // table.dropIndex([], 'idx_arpa_subrecipients_tenant_id_uei_unique');
-        // option 2
-        // table.dropUnique([], 'idx_arpa_subrecipients_tenant_id_tin_unique');
-        // table.dropUnique([], 'idx_arpa_subrecipients_tenant_id_uei_unique');
-        // option 3
         table.dropIndex([], 'idx_arpa_subrecipients_tenant_id_tin_unique');
         table.dropIndex([], 'idx_arpa_subrecipients_tenant_id_uei_unique');
 

--- a/packages/server/migrations/20240918183745_drop_constraints_to_arpa_subrecipients.js
+++ b/packages/server/migrations/20240918183745_drop_constraints_to_arpa_subrecipients.js
@@ -5,13 +5,11 @@
 exports.up = function (knex) {
     return knex.schema.alterTable('arpa_subrecipients', (table) => {
         table.dropUnique(['tenant_id', 'uei']);
-        table.unique(['tenant_id', 'uei'], {
-            indexName: 'idx_arpa_subrecipients_tenant_id_uei_unique',
+        table.index(['tenant_id', 'uei'], 'idx_arpa_subrecipients_tenant_id_uei_unique', {
             predicate: knex.whereNotNull('uei'),
         });
         table.dropUnique(['tenant_id', 'tin']);
-        table.unique(['tenant_id', 'tin'], {
-            indexName: 'idx_arpa_subrecipients_tenant_id_tin_unique',
+        table.index(['tenant_id', 'tin'], 'idx_arpa_subrecipients_tenant_id_tin_unique', {
             predicate: knex.whereNotNull('tin'),
         });
     });
@@ -23,9 +21,9 @@ exports.up = function (knex) {
  */
 exports.down = function (knex) {
     return knex.schema.alterTable('arpa_subrecipients', (table) => {
-        table.dropUnique([], 'idx_arpa_subrecipients_tenant_id_tin_unique');
+        table.dropIndex([], 'idx_arpa_subrecipients_tenant_id_tin_unique');
         table.unique(['tenant_id', 'tin']);
-        table.dropUnique([], 'idx_arpa_subrecipients_tenant_id_uei_unique');
+        table.dropIndex([], 'idx_arpa_subrecipients_tenant_id_uei_unique');
         table.unique(['tenant_id', 'uei']);
     });
 };

--- a/packages/server/migrations/20240918183745_drop_constraints_to_arpa_subrecipients.js
+++ b/packages/server/migrations/20240918183745_drop_constraints_to_arpa_subrecipients.js
@@ -5,7 +5,15 @@
 exports.up = function (knex) {
     return knex.schema.alterTable('arpa_subrecipients', (table) => {
         table.dropUnique(['tenant_id', 'uei']);
+        table.unique(['tenant_id', 'uei'], {
+            indexName: 'idx_arpa_subrecipients_tenant_id_uei_unique',
+            predicate: knex.whereNotNull('uei'),
+        });
         table.dropUnique(['tenant_id', 'tin']);
+        table.unique(['tenant_id', 'tin'], {
+            indexName: 'idx_arpa_subrecipients_tenant_id_tin_unique',
+            predicate: knex.whereNotNull('tin'),
+        });
     });
 };
 
@@ -15,7 +23,9 @@ exports.up = function (knex) {
  */
 exports.down = function (knex) {
     return knex.schema.alterTable('arpa_subrecipients', (table) => {
-        table.unique(['tenant_id', 'uei']);
+        table.dropUnique([], 'idx_arpa_subrecipients_tenant_id_tin_unique');
         table.unique(['tenant_id', 'tin']);
+        table.dropUnique([], 'idx_arpa_subrecipients_tenant_id_uei_unique');
+        table.unique(['tenant_id', 'uei']);
     });
 };

--- a/packages/server/migrations/20240918183915_add_name_to_arpa_subrecipients.js
+++ b/packages/server/migrations/20240918183915_add_name_to_arpa_subrecipients.js
@@ -1,0 +1,19 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function (knex) {
+    return knex.schema.table('arpa_subrecipients', (table) => {
+        table.text('name');
+    });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function (knex) {
+    return knex.schema.table('arpa_subrecipients', (table) => {
+        table.text('name');
+    });
+};

--- a/packages/server/migrations/20240918183915_add_name_to_arpa_subrecipients.js
+++ b/packages/server/migrations/20240918183915_add_name_to_arpa_subrecipients.js
@@ -9,16 +9,23 @@ exports.up = async function (knex) {
     await knex.raw(
         'CREATE UNIQUE INDEX idx_arpa_subrecipients_tenant_id_name_unique ON arpa_subrecipients (tenant_id, name) WHERE name is not null and uei is null and tin is null',
     );
+    await knex.raw(
+        'ALTER TABLE arpa_subrecipients ADD CONSTRAINT chk_at_least_one_of_uei_tin_name_not_null CHECK (num_nonnulls(uei, tin, name) > 0)',
+    );
 };
 
 /**
  * @param { import("knex").Knex } knex
  * @returns { Promise<void> }
  */
-exports.down = function (knex) {
-    return knex.schema.table('arpa_subrecipients', (table) => {
+exports.down = async function (knex) {
+    await knex.schema.table('arpa_subrecipients', (table) => {
         table.dropIndex([], 'idx_arpa_subrecipients_tenant_id_name_unique');
 
         table.dropColumn('name');
     });
+
+    await knex.raw(
+        'ALTER TABLE arpa_subrecipients DROP CONSTRAINT chk_at_least_one_of_uei_tin_name_not_null',
+    );
 };

--- a/packages/server/migrations/20240918183915_add_name_to_arpa_subrecipients.js
+++ b/packages/server/migrations/20240918183915_add_name_to_arpa_subrecipients.js
@@ -5,6 +5,10 @@
 exports.up = function (knex) {
     return knex.schema.table('arpa_subrecipients', (table) => {
         table.text('name');
+        table.unique(['tenant_id', 'name'], {
+            indexName: 'idx_arpa_subrecipients_tenant_id_name_unique',
+            predicate: knex.whereRaw('name is not null and uei is null and tin is null'),
+        });
     });
 };
 
@@ -14,6 +18,7 @@ exports.up = function (knex) {
  */
 exports.down = function (knex) {
     return knex.schema.table('arpa_subrecipients', (table) => {
-        table.text('name');
+        table.dropUnique([], 'idx_arpa_subrecipients_tenant_id_name_unique');
+        table.dropColumn('name');
     });
 };

--- a/packages/server/migrations/20240918183915_add_name_to_arpa_subrecipients.js
+++ b/packages/server/migrations/20240918183915_add_name_to_arpa_subrecipients.js
@@ -5,24 +5,6 @@
 exports.up = async function (knex) {
     await knex.schema.table('arpa_subrecipients', (table) => {
         table.text('name');
-        // option 1
-        // table.index(
-        //     ['tenant_id', 'name'],
-        //     'idx_arpa_subrecipients_tenant_id_name_unique',
-        //     {
-        //         predicate: knex.whereRaw('name is not null and uei is null and tin is null'),
-        //     },
-        // );
-        // option 2
-        // table.unique(
-        //     ['tenant_id', 'name'],
-        //     {
-        //         indexName: 'idx_arpa_subrecipients_tenant_id_name_unique',
-        //         predicate: knex.whereRaw('name is not null and uei is null and tin is null'),
-        //         useConstraint: false,
-        //     },
-        // );
-        // option 3
     });
     await knex.raw(
         'CREATE UNIQUE INDEX idx_arpa_subrecipients_tenant_id_name_unique ON arpa_subrecipients (tenant_id, name) WHERE name is not null and uei is null and tin is null',
@@ -35,11 +17,6 @@ exports.up = async function (knex) {
  */
 exports.down = function (knex) {
     return knex.schema.table('arpa_subrecipients', (table) => {
-        // option 1
-        // table.dropIndex([], 'idx_arpa_subrecipients_tenant_id_name_unique');
-        // option 2
-        // table.dropUnique([], 'idx_arpa_subrecipients_tenant_id_name_unique');
-        // option 3
         table.dropIndex([], 'idx_arpa_subrecipients_tenant_id_name_unique');
 
         table.dropColumn('name');

--- a/packages/server/migrations/20240918183915_add_name_to_arpa_subrecipients.js
+++ b/packages/server/migrations/20240918183915_add_name_to_arpa_subrecipients.js
@@ -5,8 +5,7 @@
 exports.up = function (knex) {
     return knex.schema.table('arpa_subrecipients', (table) => {
         table.text('name');
-        table.unique(['tenant_id', 'name'], {
-            indexName: 'idx_arpa_subrecipients_tenant_id_name_unique',
+        table.index(['tenant_id', 'name'], 'idx_arpa_subrecipients_tenant_id_name_unique', {
             predicate: knex.whereRaw('name is not null and uei is null and tin is null'),
         });
     });
@@ -18,7 +17,7 @@ exports.up = function (knex) {
  */
 exports.down = function (knex) {
     return knex.schema.table('arpa_subrecipients', (table) => {
-        table.dropUnique([], 'idx_arpa_subrecipients_tenant_id_name_unique');
+        table.dropIndex([], 'idx_arpa_subrecipients_tenant_id_name_unique');
         table.dropColumn('name');
     });
 };

--- a/packages/server/migrations/20240918183915_add_name_to_arpa_subrecipients.js
+++ b/packages/server/migrations/20240918183915_add_name_to_arpa_subrecipients.js
@@ -2,13 +2,31 @@
  * @param { import("knex").Knex } knex
  * @returns { Promise<void> }
  */
-exports.up = function (knex) {
-    return knex.schema.table('arpa_subrecipients', (table) => {
+exports.up = async function (knex) {
+    await knex.schema.table('arpa_subrecipients', (table) => {
         table.text('name');
-        table.index(['tenant_id', 'name'], 'idx_arpa_subrecipients_tenant_id_name_unique', {
-            predicate: knex.whereRaw('name is not null and uei is null and tin is null'),
-        });
+        // option 1
+        // table.index(
+        //     ['tenant_id', 'name'],
+        //     'idx_arpa_subrecipients_tenant_id_name_unique',
+        //     {
+        //         predicate: knex.whereRaw('name is not null and uei is null and tin is null'),
+        //     },
+        // );
+        // option 2
+        // table.unique(
+        //     ['tenant_id', 'name'],
+        //     {
+        //         indexName: 'idx_arpa_subrecipients_tenant_id_name_unique',
+        //         predicate: knex.whereRaw('name is not null and uei is null and tin is null'),
+        //         useConstraint: false,
+        //     },
+        // );
+        // option 3
     });
+    await knex.raw(
+        'CREATE UNIQUE INDEX idx_arpa_subrecipients_tenant_id_name_unique ON arpa_subrecipients (tenant_id, name) WHERE name is not null and uei is null and tin is null',
+    );
 };
 
 /**
@@ -17,7 +35,13 @@ exports.up = function (knex) {
  */
 exports.down = function (knex) {
     return knex.schema.table('arpa_subrecipients', (table) => {
+        // option 1
+        // table.dropIndex([], 'idx_arpa_subrecipients_tenant_id_name_unique');
+        // option 2
+        // table.dropUnique([], 'idx_arpa_subrecipients_tenant_id_name_unique');
+        // option 3
         table.dropIndex([], 'idx_arpa_subrecipients_tenant_id_name_unique');
+
         table.dropColumn('name');
     });
 };

--- a/packages/server/src/arpa_reporter/db/arpa-subrecipients.js
+++ b/packages/server/src/arpa_reporter/db/arpa-subrecipients.js
@@ -100,16 +100,17 @@ async function createRecipient(recipient, trns = knex) {
             .returning('*')
             .then((rows) => rows[0]);
     } catch (error) {
-        if (error.constraint === 'chk_at_least_one_of_uei_tin_name_not_null') {
-            throw new Error('recipient row must include a `uei`, `tin`, or `name` field');
-        } else if (error.constraint === 'idx_arpa_subrecipients_tenant_id_uei_unique') {
-            throw new Error('A recipient with this UEI already exists');
-        } else if (error.constraint === 'idx_arpa_subrecipients_tenant_id_tin_unique') {
-            throw new Error('A recipient with this TIN already exists');
-        } else if (error.constraint === 'idx_arpa_subrecipients_tenant_id_name_unique') {
-            throw new Error('A recipient with this name already exists');
-        } else {
-            throw error;
+        switch (error.constraint) {
+            case 'chk_at_least_one_of_uei_tin_name_not_null':
+                throw new Error('recipient row must include a `uei`, `tin`, or `name` field');
+            case 'idx_arpa_subrecipients_tenant_id_uei_unique':
+                throw new Error('A recipient with this UEI already exists');
+            case 'idx_arpa_subrecipients_tenant_id_tin_unique':
+                throw new Error('A recipient with this TIN already exists');
+            case 'idx_arpa_subrecipients_tenant_id_name_unique':
+                throw new Error('A recipient with this name already exists');
+            default:
+                throw error;
         }
     }
 

--- a/packages/server/src/arpa_reporter/db/arpa-subrecipients.js
+++ b/packages/server/src/arpa_reporter/db/arpa-subrecipients.js
@@ -72,14 +72,16 @@ async function getRecipient(id, trns = knex) {
         .then((rows) => rows[0]);
 }
 
-async function findRecipient(uei = null, tin = null, trns = knex) {
+async function findRecipient(fieldType = null, value = null, trns = knex) {
     const tenantId = useTenantId();
     const query = baseQuery(trns).where('arpa_subrecipients.tenant_id', tenantId);
 
-    if (uei) {
-        query.where('arpa_subrecipients.uei', uei);
-    } else if (tin) {
-        query.where('arpa_subrecipients.tin', tin);
+    if (fieldType === 'uei') {
+        query.where('arpa_subrecipients.uei', value);
+    } else if (fieldType === 'tin') {
+        query.where('arpa_subrecipients.tin', value);
+    } else if (fieldType === 'name') {
+        query.where('arpa_subrecipients.name', value);
     } else {
         return null;
     }

--- a/packages/server/src/arpa_reporter/db/arpa-subrecipients.js
+++ b/packages/server/src/arpa_reporter/db/arpa-subrecipients.js
@@ -60,6 +60,19 @@ async function getRecipient(id, trns = knex) {
         .then((rows) => rows[0]);
 }
 
+const SUPPORTED_QUERY_FIELD_TYPES = {
+    UEI: 'uei',
+    TIN: 'tin',
+    NAME: 'name',
+};
+
+/**
+ *
+ * @param { SUPPORTED_QUERY_FIELDS_TYPES } fieldType - the field type to search for
+ * @param { string } value - the value to search for
+ * @param { * } trns - knex transaction
+ * @return {Promise<Subrecipient>} The subrecipient object
+ */
 async function findRecipient(fieldType = null, value = null, trns = knex) {
     const tenantId = useTenantId();
     const query = baseQuery(trns).where('arpa_subrecipients.tenant_id', tenantId);
@@ -125,6 +138,7 @@ module.exports = {
     updateRecipient,
     listRecipients,
     listRecipientsForReportingPeriod,
+    SUPPORTED_QUERY_FIELD_TYPES,
 };
 
 // NOTE: This file was copied from src/server/db/arpa-subrecipients.js (git @ ada8bfdc98) in the arpa-reporter repo on 2022-09-23T20:05:47.735Z

--- a/packages/server/src/arpa_reporter/db/arpa-subrecipients.js
+++ b/packages/server/src/arpa_reporter/db/arpa-subrecipients.js
@@ -84,7 +84,7 @@ async function findRecipient(fieldType = null, value = null, trns = knex) {
     } else if (fieldType === 'name') {
         query.where('arpa_subrecipients.name', value);
     } else {
-        return null;
+        throw new Error('Cannot query for recipient without a valid field type');
     }
 
     return query.then((rows) => rows[0]);

--- a/packages/server/src/arpa_reporter/db/arpa-subrecipients.js
+++ b/packages/server/src/arpa_reporter/db/arpa-subrecipients.js
@@ -79,8 +79,8 @@ async function findRecipient(fieldType = null, value = null, trns = knex) {
 
 async function createRecipient(recipient, trns = knex) {
     const tenantId = useTenantId();
-    if (!(recipient.uei || recipient.tin)) {
-        throw new Error('recipient row must include a `uei` or a `tin` field');
+    if (!(recipient.uei || recipient.tin || recipient.name)) {
+        throw new Error('recipient row must include a `uei`, `tin`, or `name` field');
     }
 
     if (recipient.uei) {
@@ -88,10 +88,17 @@ async function createRecipient(recipient, trns = knex) {
         if (existingRecipient) {
             throw new Error('A recipient with this UEI already exists');
         }
-    } else if (recipient.tin) {
+    }
+    if (recipient.tin) {
         const existingRecipient = await findRecipient('tin', recipient.tin, trns);
         if (existingRecipient) {
             throw new Error('A recipient with this TIN already exists');
+        }
+    }
+    if (!recipient.tin && !recipient.uei && recipient.name) {
+        const existingRecipient = await findRecipient('name', recipient.name, trns);
+        if (existingRecipient) {
+            throw new Error('A recipient with this name already exists');
         }
     }
 

--- a/packages/server/src/arpa_reporter/services/validate-upload.js
+++ b/packages/server/src/arpa_reporter/services/validate-upload.js
@@ -169,7 +169,6 @@ function validateIdentifier(recipient, recipientExists) {
     const isContractor = entityType.includes('Contractor');
     const isBeneficiary = entityType.includes('Beneficiary');
     const isSubrecipient = entityType.includes('Subrecipient');
-    const isIAA = entityType.includes('IAA');
 
     if (isSubrecipient && !recipientExists && !hasUEI) {
         errors.push(new ValidationError(
@@ -200,11 +199,6 @@ function validateIdentifier(recipient, recipientExists) {
         errors.push(new ValidationError(
             'You must enter a TIN for this subrecipient',
             { col: 'D', severity: 'err' },
-        ));
-    } else if (isIAA && !hasUEI && !hasTIN) {
-        errors.push(new ValidationError(
-            'IAA subrecipients without UEI or TIN are valid but temporarily not supported by USDR',
-            { col: 'C, D', severity: 'err' },
         ));
     }
 

--- a/packages/server/src/arpa_reporter/services/validate-upload.js
+++ b/packages/server/src/arpa_reporter/services/validate-upload.js
@@ -130,7 +130,7 @@ async function findRecipientInDatabase({ recipient, trns }) {
         ? await findRecipient('tin', recipient.EIN__c, trns)
         : null;
     let byName = null;
-    if (recipient.Entity_Type_2__c.includes('IAA') && !recipient.Unique_Entity_Identifier__c && !recipient.EIN__c) {
+    if (recipient.Entity_Type_2__c?.includes('IAA') && !recipient.Unique_Entity_Identifier__c && !recipient.EIN__c) {
         byName = await findRecipient('name', recipient.Name, trns);
     }
 

--- a/packages/server/src/arpa_reporter/services/validate-upload.js
+++ b/packages/server/src/arpa_reporter/services/validate-upload.js
@@ -234,6 +234,7 @@ async function updateOrCreateRecipient(existingRecipient, newRecipient, trns, up
         }
     } else {
         await createRecipient({
+            name: newRecipient.Name,
             uei: newRecipient.Unique_Entity_Identifier__c,
             tin: newRecipient.EIN__c,
             record: newRecipient,

--- a/packages/server/src/arpa_reporter/services/validate-upload.js
+++ b/packages/server/src/arpa_reporter/services/validate-upload.js
@@ -124,13 +124,17 @@ async function findRecipientInDatabase({ recipient, trns }) {
     // There are two types of identifiers, UEI and TIN.
     // A given recipient may have either or both of these identifiers.
     const byUei = recipient.Unique_Entity_Identifier__c
-        ? await findRecipient(recipient.Unique_Entity_Identifier__c, null, trns)
+        ? await findRecipient('uei', recipient.Unique_Entity_Identifier__c, trns)
         : null;
     const byTin = recipient.EIN__c
-        ? await findRecipient(null, recipient.EIN__c, trns)
+        ? await findRecipient('ein', recipient.EIN__c, trns)
         : null;
+    let byName = null;
+    if (recipient.Entity_Type_2__c.includes('IAA') && !recipient.Unique_Entity_Identifier__c && !recipient.EIN__c) {
+        byName = await findRecipient('name', recipient.Name, trns);
+    }
 
-    return byUei || byTin;
+    return byUei || byTin || byName;
 }
 
 /**

--- a/packages/server/src/arpa_reporter/services/validate-upload.js
+++ b/packages/server/src/arpa_reporter/services/validate-upload.js
@@ -127,7 +127,7 @@ async function findRecipientInDatabase({ recipient, trns }) {
         ? await findRecipient('uei', recipient.Unique_Entity_Identifier__c, trns)
         : null;
     const byTin = recipient.EIN__c
-        ? await findRecipient('ein', recipient.EIN__c, trns)
+        ? await findRecipient('tin', recipient.EIN__c, trns)
         : null;
     let byName = null;
     if (recipient.Entity_Type_2__c.includes('IAA') && !recipient.Unique_Entity_Identifier__c && !recipient.EIN__c) {

--- a/packages/server/src/arpa_reporter/services/validate-upload.js
+++ b/packages/server/src/arpa_reporter/services/validate-upload.js
@@ -2,7 +2,12 @@ const {
     setEcCode, markValidated, markNotValidated, markInvalidated,
 } = require('../db/uploads');
 const knex = require('../../db/connection');
-const { createRecipient, findRecipient, updateRecipient } = require('../db/arpa-subrecipients');
+const {
+    createRecipient,
+    findRecipient,
+    updateRecipient,
+    SUPPORTED_QUERY_FIELD_TYPES,
+} = require('../db/arpa-subrecipients');
 
 const { recordsForUpload, TYPE_TO_SHEET_NAME } = require('./records');
 const { getRules } = require('./validation-rules');
@@ -124,14 +129,14 @@ async function findRecipientInDatabase({ recipient, trns }) {
     // There are two types of identifiers, UEI and TIN.
     // A given recipient may have either or both of these identifiers.
     const byUei = recipient.Unique_Entity_Identifier__c
-        ? await findRecipient('uei', recipient.Unique_Entity_Identifier__c, trns)
+        ? await findRecipient(SUPPORTED_QUERY_FIELD_TYPES.UEI, recipient.Unique_Entity_Identifier__c, trns)
         : null;
     const byTin = recipient.EIN__c
-        ? await findRecipient('tin', recipient.EIN__c, trns)
+        ? await findRecipient(SUPPORTED_QUERY_FIELD_TYPES.TIN, recipient.EIN__c, trns)
         : null;
     let byName = null;
     if (recipient.Entity_Type_2__c?.includes('IAA') && !recipient.Unique_Entity_Identifier__c && !recipient.EIN__c) {
-        byName = await findRecipient('name', recipient.Name, trns);
+        byName = await findRecipient(SUPPORTED_QUERY_FIELD_TYPES.NAME, recipient.Name, trns);
     }
 
     return byUei || byTin || byName;


### PR DESCRIPTION
### Ticket #3372
## Description
This PR adds support for the new IAA subrecipient field. The goal here is to ensure that we can add subrecipients that do not have either a UEI or TIN value. In order to do this the PR does the following:

1. Adds a new `name` field to `arpa_subrecipients` table and a corresponding `unique index` that ensures that when both `uei` and `tin` are missing, that we do not create duplicate subrecipients with the same `name`.
2. Adds application-layer validation when `createSubrecipient` function is called.
3. Removes `unique` constraint on `uei` and `tin` fields and replaces with a `unique` index that only applies when these fields are `NOT NULL`.

## Screenshots / Demo Video
### State Before migrations
```
usdr_grants=# \d arpa_subrecipients
                                          Table "public.arpa_subrecipients"
      Column       |           Type           | Collation | Nullable |                    Default                     
-------------------+--------------------------+-----------+----------+------------------------------------------------
 id                | integer                  |           | not null | nextval('arpa_subrecipients_id_seq'::regclass)
 tenant_id         | integer                  |           | not null | 
 created_at        | timestamp with time zone |           | not null | CURRENT_TIMESTAMP
 updated_at        | timestamp with time zone |           |          | 
 updated_by        | integer                  |           |          | 
 uei               | text                     |           |          | 
 tin               | text                     |           |          | 
 record            | text                     |           |          | 
 upload_id         | uuid                     |           |          | 
 treasury_id       | text                     |           |          | 
 has_been_reported | boolean                  |           | not null | false
 archived_at       | timestamp with time zone |           |          | 
Indexes:
    "arpa_subrecipients_pkey" PRIMARY KEY, btree (id)
    "arpa_subrecipients_tenant_id_tin_unique" UNIQUE CONSTRAINT, btree (tenant_id, tin)
    "arpa_subrecipients_tenant_id_treasury_id_unique" UNIQUE CONSTRAINT, btree (tenant_id, treasury_id)
    "arpa_subrecipients_tenant_id_uei_unique" UNIQUE CONSTRAINT, btree (tenant_id, uei)
Foreign-key constraints:
    "arpa_subrecipients_tenant_id_foreign" FOREIGN KEY (tenant_id) REFERENCES tenants(id)
    "arpa_subrecipients_updated_by_foreign" FOREIGN KEY (updated_by) REFERENCES users(id)
    "arpa_subrecipients_upload_id_foreign" FOREIGN KEY (upload_id) REFERENCES uploads(id) ON DELETE CASCADE

```
### State After Migrations
```
fdcc06a80a69:/app/packages/server# yarn db:migrate
yarn run v1.22.19
$ knex migrate:latest
Using environment: development
Batch 2 run: 3 migrations
Done in 0.92s.
fdcc06a80a69:/app/packages/server# 

usdr_grants=# \d arpa_subrecipients
                                          Table "public.arpa_subrecipients"
      Column       |           Type           | Collation | Nullable |                    Default                     
-------------------+--------------------------+-----------+----------+------------------------------------------------
 id                | integer                  |           | not null | nextval('arpa_subrecipients_id_seq'::regclass)
 tenant_id         | integer                  |           | not null | 
 created_at        | timestamp with time zone |           | not null | CURRENT_TIMESTAMP
 updated_at        | timestamp with time zone |           |          | 
 updated_by        | integer                  |           |          | 
 uei               | text                     |           |          | 
 tin               | text                     |           |          | 
 record            | text                     |           |          | 
 upload_id         | uuid                     |           |          | 
 treasury_id       | text                     |           |          | 
 has_been_reported | boolean                  |           | not null | false
 archived_at       | timestamp with time zone |           |          | 
 name              | text                     |           |          | 
Indexes:
    "arpa_subrecipients_pkey" PRIMARY KEY, btree (id)
    "arpa_subrecipients_tenant_id_treasury_id_unique" UNIQUE CONSTRAINT, btree (tenant_id, treasury_id)
    "idx_arpa_subrecipients_tenant_id_name_unique" UNIQUE, btree (tenant_id, name) WHERE name IS NOT NULL AND uei IS NULL AND tin IS NULL
    "idx_arpa_subrecipients_tenant_id_tin_unique" UNIQUE, btree (tenant_id, tin) WHERE tin IS NOT NULL
    "idx_arpa_subrecipients_tenant_id_uei_unique" UNIQUE, btree (tenant_id, uei) WHERE uei IS NOT NULL
Check constraints:
    "chk_at_least_one_of_uei_tin_name_not_null" CHECK (num_nonnulls(uei, tin, name) > 0)
Foreign-key constraints:
    "arpa_subrecipients_tenant_id_foreign" FOREIGN KEY (tenant_id) REFERENCES tenants(id)
    "arpa_subrecipients_updated_by_foreign" FOREIGN KEY (updated_by) REFERENCES users(id)
    "arpa_subrecipients_upload_id_foreign" FOREIGN KEY (upload_id) REFERENCES uploads(id) ON DELETE CASCADE
```

### Confirming that Rollback works
```
fdcc06a80a69:/app/packages/server# yarn db:rollback
yarn run v1.22.19
$ knex migrate:rollback
Using environment: development
Batch 2 rolled back: 3 migrations
Done in 0.87s.
fdcc06a80a69:/app/packages/server# 

```

## Testing

### Automated and Unit Tests
- [x] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [x] Provided ticket and description
- [x] Provided screenshots/demo
- [x] Provided testing information
- [x] Provided adequate test coverage for all new code
- [x] Added PR reviewers