### PR TITLE
Feature: Grant Activity digest notification preference

### DIFF
--- a/packages/client/src/views/MyProfileView.spec.js
+++ b/packages/client/src/views/MyProfileView.spec.js
@@ -15,6 +15,7 @@ describe('MyProfileView.vue', () => {
           GRANT_INTEREST: 'SUBSCRIBED',
           GRANT_DIGEST: 'SUBSCRIBED',
           GRANT_FINDER_UPDATES: 'SUBSCRIBED',
+          GRANT_ACTIVITY: 'SUBSCRIBED',
         },
       }),
     },
@@ -59,6 +60,21 @@ describe('MyProfileView.vue', () => {
       expect(text).toContain('Shared Grants');
       expect(text).toContain(
         'Send me an email notification when someone shares a grant with my team.',
+      );
+    });
+  });
+
+  describe('grant activity preference', () => {
+    it('should show grant activity terminology', () => {
+      const wrapper = shallowMount(MyProfileView, {
+        global: {
+          plugins: [store],
+        },
+      });
+      const text = wrapper.text();
+      expect(text).toContain('Grant Activity');
+      expect(text).toContain(
+        'Send me a daily summary of new activity for grants that I follow.',
       );
     });
   });

--- a/packages/client/src/views/MyProfileView.vue
+++ b/packages/client/src/views/MyProfileView.vue
@@ -98,6 +98,11 @@ export default {
           key: 'GRANT_ASSIGNMENT',
           description: shareTerminologyEnabledFlag ? grantShareDescription : grantAssignmentDescription,
         },
+        {
+          name: 'Grant Activity',
+          key: 'GRANT_ACTIVITY',
+          description: 'Send me a daily summary of new activity for grants that I follow.',
+        },
       ],
       breadcrumb_items: [
         {

--- a/packages/server/migrations/20241004230649_add_grant_activity_to_email_subscriptions_notification_type.js
+++ b/packages/server/migrations/20241004230649_add_grant_activity_to_email_subscriptions_notification_type.js
@@ -1,0 +1,29 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function (knex) {
+    return knex.schema.raw(
+        `
+              -- Drop the existing stale constraint
+              ALTER TABLE email_subscriptions DROP CONSTRAINT email_subscriptions_notification_type_check;
+              -- Add new updated constraint
+              ALTER TABLE email_subscriptions ADD CONSTRAINT email_subscriptions_notification_type_check CHECK (notification_type IN ('GRANT_ASSIGNMENT', 'GRANT_INTEREST', 'GRANT_DIGEST', 'GRANT_FINDER_UPDATES', 'GRANT_ACTIVITY'));
+        `,
+    );
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function (knex) {
+    return knex.schema.raw(
+        `
+              -- Drop the existing stale constraint
+              ALTER TABLE email_subscriptions DROP CONSTRAINT email_subscriptions_notification_type_check;
+              -- Add new updated constraint
+              ALTER TABLE email_subscriptions ADD CONSTRAINT email_subscriptions_notification_type_check CHECK (notification_type IN ('GRANT_ASSIGNMENT', 'GRANT_INTEREST', 'GRANT_DIGEST', 'GRANT_FINDER_UPDATES'));
+        `,
+    );
+};

--- a/packages/server/src/lib/email/constants.js
+++ b/packages/server/src/lib/email/constants.js
@@ -4,6 +4,7 @@ const notificationType = Object.freeze({
     grantInterest: 'GRANT_INTEREST',
     grantDigest: 'GRANT_DIGEST',
     grantFinderUpdates: 'GRANT_FINDER_UPDATES',
+    grantActivity: 'GRANT_ACTIVITY',
 });
 
 const emailSubscriptionStatus = Object.freeze({


### PR DESCRIPTION
### Ticket #3570 

## Description
On a users My Profile page, a Grant Activity toggle will be available and it will save the GRANT_ACTIVITY email preference

## Screenshots / Demo Video
<img width="1235" alt="image" src="https://github.com/user-attachments/assets/b090c297-1e57-49af-a82b-1f5d7a9111eb">

![2024-10-04_19-25-05 (1)](https://github.com/user-attachments/assets/acdd474d-ee1b-4867-b41c-b1e0325aa878)


## Testing

### Automated and Unit Tests
- [ X ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [ ] Provided ticket and description
- [ ] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers