### PR TITLE
chore: bump up the container memory and cpu temporarily to handle large volume of requests

### DIFF
--- a/terraform/modules/gost_api/task.tf
+++ b/terraform/modules/gost_api/task.tf
@@ -155,7 +155,7 @@ resource "aws_ecs_task_definition" "default" {
   requires_compatibilities = ["FARGATE"]
 
   # Valid configurations here:
-  # https://docs.aws.amazon.com/AmazonECS/latest/developerguide/AWS_Fargate.html#fargate-tasks-size
+  # https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#task_size
   cpu    = 512
   memory = 2048
 

--- a/terraform/modules/gost_api/task.tf
+++ b/terraform/modules/gost_api/task.tf
@@ -156,8 +156,8 @@ resource "aws_ecs_task_definition" "default" {
 
   # Valid configurations here:
   # https://docs.aws.amazon.com/AmazonECS/latest/developerguide/AWS_Fargate.html#fargate-tasks-size
-  cpu    = 256
-  memory = 512
+  cpu    = 512
+  memory = 2048
 
   runtime_platform {
     operating_system_family = "LINUX"


### PR DESCRIPTION
### Ticket 
Fix for: <img width="339" alt="image" src="https://github.com/user-attachments/assets/69f23e87-bd00-489c-9469-c379beb02f36">

## Description
We received numerous reports of the reporter tool and finder tool not being accessible and returning a "Service Unavailable" error. Upon digging further there was no clear indication as to why these errors were caused and the current hypothesis is that it is due to the container running out of memory.

This change bumps up the memory of the container with the hope that there is a lesser chance of this happening again.

Note: the correct fix for this issue is likely the combination of these two tickets but they will be implemented separately:
#3622 
#3621 


## Screenshots / Demo Video
N/A

## Testing
N/A

### Automated and Unit Tests
No unit tests for terraform code.
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [x] Provided ticket and description
- [ ] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [x] Added PR reviewers