### PR TITLE
Enable container runtime metrics

### DIFF
--- a/terraform/prod.tfvars
+++ b/terraform/prod.tfvars
@@ -13,6 +13,11 @@ datadog_monitor_notification_handles = [
   "asridhar@usdigitalresponse.org",
 ]
 ses_datadog_events_enabled = true
+default_datadog_environment_variables = {
+  DD_LOGS_INJECTION          = true
+  DD_PROFILING_ENABLED       = true
+  DD_RUNTIME_METRICS_ENABLED = true
+}
 
 // Website
 website_enabled     = true
@@ -69,12 +74,9 @@ api_enable_new_team_terminology        = true
 api_enable_saved_search_grants_digest  = true
 api_enable_grant_digest_scheduled_task = true
 api_log_retention_in_days              = 30
-api_datadog_environment_variables = {
-  DD_PROFILING_ENABLED = true,
-}
 api_container_environment = {
-  NEW_GRANT_DETAILS_PAGE_ENABLED = true,
-  SHARE_TERMINOLOGY_ENABLED      = true,
+  NEW_GRANT_DETAILS_PAGE_ENABLED = true
+  SHARE_TERMINOLOGY_ENABLED      = true
 }
 
 // Postgres
@@ -86,9 +88,6 @@ postgres_ca_cert_identifier        = "rds-ca-rsa2048-g1"
 
 // Grant events consumer
 consume_grants_source_event_bus_name = "default"
-consume_grants_datadog_environment_variables = {
-  DD_PROFILING_ENABLED = true,
-}
 
 // Email
 email_enable_tracking = true

--- a/terraform/staging.tfvars
+++ b/terraform/staging.tfvars
@@ -12,6 +12,10 @@ datadog_monitor_notification_handles   = []
 ses_datadog_events_enabled             = true
 datadog_email_pipeline_enabled         = true
 datadog_email_pipeline_metrics_enabled = true
+default_datadog_environment_variables = {
+  DD_LOGS_INJECTION    = true
+  DD_PROFILING_ENABLED = true
+}
 
 // Website
 website_enabled     = true
@@ -68,9 +72,6 @@ api_enable_new_team_terminology        = true
 api_enable_saved_search_grants_digest  = true
 api_enable_grant_digest_scheduled_task = true
 api_log_retention_in_days              = 14
-api_datadog_environment_variables = {
-  DD_PROFILING_ENABLED = true,
-}
 api_container_environment = {
   NEW_GRANT_DETAILS_PAGE_ENABLED = true,
   SHARE_TERMINOLOGY_ENABLED      = true,
@@ -86,9 +87,6 @@ postgres_ca_cert_identifier        = "rds-ca-rsa2048-g1"
 
 // Grant events consumer
 consume_grants_source_event_bus_name = "default"
-consume_grants_datadog_environment_variables = {
-  DD_PROFILING_ENABLED = true,
-}
 
 // Email
 email_enable_tracking = true

--- a/terraform/staging.tfvars
+++ b/terraform/staging.tfvars
@@ -13,8 +13,9 @@ ses_datadog_events_enabled             = true
 datadog_email_pipeline_enabled         = true
 datadog_email_pipeline_metrics_enabled = true
 default_datadog_environment_variables = {
-  DD_LOGS_INJECTION    = true
-  DD_PROFILING_ENABLED = true
+  DD_LOGS_INJECTION          = true
+  DD_PROFILING_ENABLED       = true
+  DD_RUNTIME_METRICS_ENABLED = true
 }
 
 // Website

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -66,6 +66,12 @@ variable "datadog_email_pipeline_metrics_enabled" {
   default     = false
 }
 
+variable "default_datadog_environment_variables" {
+  description = "Default environment variables for Datadog configuration. May be overwritten by container-specific variables."
+  type        = map(string)
+  default     = {}
+}
+
 // Common
 variable "permissions_boundary_policy_name" {
   description = "Name of the permissions boundary for service roles"


### PR DESCRIPTION
## Description

This PR sets the environment variable `DD_RUNTIME_METRICS_ENABLED = true` in Staging and Production environments, which enables [runtime metrics](https://docs.datadoghq.com/tracing/metrics/runtime_metrics/nodejs/?tab=environmentvariables) in Datadog APM. Typically, we observe metrics related to CPU and memory usage (as well as others) at the container level; collecting runtime metrics from the tracer itself should allow more granular inspection at the Node process level, and should make it easier to identify specific trace spans that contribute to high resource usage.

Additionally, this PR provides a new Terraform input variable, `default_datadog_environment_variables`, which helps consolidate Datadog configuration options that are generally common to all ECS tasks. Although it is useful to be able to override these options on a per-task basis (which is still possible), most of the time we want Datadog to be configured consistently.