### PR TITLE
feat(grants): forecasted UI seed data - MERGE AFTER PR # 3456

### DIFF
--- a/packages/server/__tests__/db/db.test.js
+++ b/packages/server/__tests__/db/db.test.js
@@ -435,7 +435,7 @@ describe('db', () => {
         });
         it('gets grants with agency codes', async () => {
             const result = await db.getGrantsNew(
-                { agencyCode: 'HHS' },
+                { agencyCode: 'HHS', opportunityStatuses: ['posted', 'closed'] },
                 { currentPage: 1, perPage: 10, isLengthAware: true },
                 { orderBy: 'open_date', orderDesc: 'true' },
                 fixtures.tenants.SBA.id,
@@ -460,7 +460,7 @@ describe('db', () => {
         });
         it('gets grants that either have or do not have cost sharing', async () => {
             const result = await db.getGrantsNew(
-                { costSharing: 'Yes' },
+                { costSharing: 'Yes', opportunityStatuses: ['posted', 'closed'] },
                 { currentPage: 1, perPage: 10, isLengthAware: true },
                 { orderBy: 'open_date', orderDesc: 'true' },
                 fixtures.tenants.SBA.id,
@@ -471,7 +471,7 @@ describe('db', () => {
             expect(result.pagination.lastPage).to.equal(0);
 
             const result2 = await db.getGrantsNew(
-                { costSharing: 'No' },
+                { costSharing: 'No', opportunityStatuses: ['posted', 'closed'] },
                 { currentPage: 1, perPage: 3, isLengthAware: true },
                 { orderBy: 'open_date', orderDesc: 'true' },
                 fixtures.tenants.SBA.id,
@@ -483,7 +483,7 @@ describe('db', () => {
         });
         it('gets grants with a specific opportunity categories', async () => {
             const result = await db.getGrantsNew(
-                { opportunityCategories: ['Mandatory', 'Continuation'] },
+                { opportunityCategories: ['Mandatory', 'Continuation'], opportunityStatuses: ['posted', 'closed'] },
                 { currentPage: 1, perPage: 10, isLengthAware: true },
                 { orderBy: 'open_date', orderDesc: 'true' },
                 fixtures.tenants.SBA.id,
@@ -494,7 +494,7 @@ describe('db', () => {
             expect(result.pagination.lastPage).to.equal(0);
 
             const result2 = await db.getGrantsNew(
-                { opportunityCategories: ['Discretionary', 'Other'] },
+                { opportunityCategories: ['Discretionary', 'Other'], opportunityStatuses: ['posted', 'closed'] },
                 { currentPage: 1, perPage: 4, isLengthAware: true },
                 { orderBy: 'open_date', orderDesc: 'true' },
                 fixtures.tenants.SBA.id,
@@ -533,7 +533,7 @@ describe('db', () => {
         });
         it('gets grants that have any of the eligibility codes', async () => {
             const result = await db.getGrantsNew(
-                { eligibilityCodes: ['11', '07'] },
+                { eligibilityCodes: ['11', '07'], opportunityStatuses: ['posted', 'closed'] },
                 { currentPage: 1, perPage: 10, isLengthAware: true },
                 { orderBy: 'open_date', orderDesc: 'true' },
                 fixtures.tenants.SBA.id,
@@ -612,6 +612,7 @@ describe('db', () => {
             let result = await db.getGrantsNew(
                 {
                     includeKeywords: ['community', 'health'],
+                    opportunityStatuses: ['posted', 'closed'],
                 },
                 { currentPage: 1, perPage: 10, isLengthAware: true },
                 { orderBy: 'open_date', orderDesc: true },
@@ -626,6 +627,7 @@ describe('db', () => {
                 {
                     includeKeywords: ['community', 'health'],
                     excludeKeywords: ['covid'],
+                    opportunityStatuses: ['posted', 'closed'],
                 },
                 { currentPage: 1, perPage: 10, isLengthAware: true },
                 { orderBy: 'open_date', orderDesc: true },
@@ -646,7 +648,7 @@ describe('db', () => {
         });
         it('check award_ceiling ordering is correct for blank and zero award ceiling desc', async () => {
             const result = await db.getGrantsNew(
-                { agencyCode: 'HHS' },
+                { agencyCode: 'HHS', opportunityStatuses: ['posted', 'closed'] },
                 { currentPage: 1, perPage: 10, isLengthAware: true },
                 { orderBy: 'award_ceiling', orderDesc: 'true' },
                 fixtures.tenants.SBA.id,
@@ -658,7 +660,7 @@ describe('db', () => {
         });
         it('check award_ceiling ordering is correct for blank and zero award ceiling asc', async () => {
             const result = await db.getGrantsNew(
-                { agencyCode: 'HHS' },
+                { agencyCode: 'HHS', opportunityStatuses: ['posted', 'closed'] },
                 { currentPage: 1, perPage: 10, isLengthAware: true },
                 { orderBy: 'award_ceiling', orderDesc: 'false' },
                 fixtures.tenants.SBA.id,
@@ -1117,6 +1119,25 @@ describe('db', () => {
             const usdrUserViewedRecord = viewedRecords.find((record) => record.user_id === fixtures.users.usdrUser.id);
             expect(subStaffUserViewedRecord.updated_at.getTime()).to.equal(new Date('2024-01-01').getTime());
             expect(usdrUserViewedRecord.updated_at.getTime()).to.equal(new Date('2024-01-01').getTime());
+        });
+    });
+
+    context('forecasted grants', () => {
+        it('gets grants with opportunity forecasted', async () => {
+            const result = await db.getGrants({
+                tenantId: fixtures.users.staffUser.tenant_id,
+                filters: {
+                    opportunityStatuses: ['forecasted'],
+                },
+                perPage: 50,
+                currentPage: 1,
+            });
+
+            expect(result).to.have.property('data').with.lengthOf(4);
+            expect(result.data[0].close_date).to.be.null;
+            expect(result.data[0].close_date_explanation).to.equal('Sample text for null close_date');
+            expect(result.data[2].close_date).to.be.null;
+            expect(result.data[2].open_date).to.be.null;
         });
     });
 });

--- a/packages/server/__tests__/db/seeds/fixtures.js
+++ b/packages/server/__tests__/db/seeds/fixtures.js
@@ -448,6 +448,220 @@ const grants = {
     },
 };
 
+const forecastedGrants = {
+    hasCloseDateExplanation: {
+        status: 'inbox',
+        grant_id: '284822',
+        grant_number: 'CDC-RFA-PS16-1606',
+        agency_code: 'HHS-CDC-NCHHSTP',
+        award_ceiling: '325000',
+        cost_sharing: 'No',
+        title: 'Comprehensive High-Impact HIV Prevention Projects for Young Men of Color Who Have Sex with Men and Young Transgender Persons of Color',
+        cfda_list: '47.050',
+        open_date: '2055-08-11',
+        close_date: null,
+        close_date_explanation: 'Sample text for null close_date',
+        notes: 'auto-inserted by script',
+        search_terms: '[in title/desc]+',
+        reviewer_name: 'none',
+        opportunity_category: 'Discretionary',
+        description: '<p class="MsoNormal">The Centers for Disease Control and Prevention announces the availability of fiscal year 2055 funds for a cooperative agreement program for community-based organizations (CBOs) to develop and implement High-Impact Human Immunodeficiency Virus (HIV) Prevention Programs.</p>',
+        eligibility_codes: '12',
+        funding_activity_category_codes: 'HL',
+        opportunity_status: 'forecasted',
+        raw_body_json: {
+            opportunity: {
+                id: '284822',
+                number: 'CDC-RFA-PS16-1606',
+                title: 'Comprehensive High-Impact HIV Prevention Projects for Young Men of Color Who Have Sex with Men and Young Transgender Persons of Color',
+                description: '<p class="MsoNormal">The Centers for Disease Control and Prevention announces the availability of fiscal year 2055 funds for a cooperative agreement program for community-based organizations (CBOs) to develop and implement High-Impact Human Immunodeficiency Virus (HIV) Prevention Programs.</p>',
+                milestones: {
+                    post_date: '2055-08-11',
+                    close: {
+                        date: null,
+                    },
+                },
+                category: { code: 'D', name: 'Discretionary' },
+            },
+            agency: { code: 'HHS-CDC-NCHHSTP' },
+            award: { ceiling: '325000' },
+            cost_sharing_or_matching_requirement: false,
+            cfda_numbers: ['47.050'],
+            eligible_applicants: [
+                { code: '12' },
+            ],
+            funding_activity: {
+                categories: [
+                    {
+                        name: 'Health',
+                        code: 'HL',
+                    },
+                ],
+            },
+        },
+        created_at: '2021-08-11 11:30:38.89828-07',
+        updated_at: '2021-08-11 12:30:39.531-07',
+    },
+    hasCloseAndOpenDates: {
+        status: 'inbox',
+        grant_id: '284810',
+        grant_number: 'HHS-2016-IHS-UIHP1-0001',
+        agency_code: 'HHS-IHS',
+        award_ceiling: '500000',
+        cost_sharing: 'No',
+        title: 'Office of Urban Indian Health Program - Title V HIV/AIDS',
+        cfda_list: '93.193',
+        open_date: '2056-08-05',
+        close_date: '2076-09-06',
+        notes: 'auto-inserted by script',
+        search_terms: '[in title/desc]+',
+        reviewer_name: 'none',
+        opportunity_category: 'Discretionary',
+        description: '<p>The Indian Health Service is accepting limited competitive grant applications for the Office of Urban Indian Health Programs Title V HIV/AIDS program. </p>',
+        eligibility_codes: '11 07 25',
+        funding_activity_category_codes: 'HL',
+        opportunity_status: 'forecasted',
+        raw_body_json: {
+            opportunity: {
+                id: '284810',
+                number: 'HHS-2016-IHS-UIHP1-0001',
+                title: 'Office of Urban Indian Health Program - Title V HIV/AIDS',
+                description: '<p>The Indian Health Service is accepting limited competitive grant applications for the Office of Urban Indian Health Programs Title V HIV/AIDS program. </p>',
+                milestones: {
+                    post_date: '2056-08-05',
+                },
+                category: { code: 'D', name: 'Discretionary' },
+            },
+            agency: { code: 'HHS-IHS' },
+            award: { ceiling: '500000' },
+            cost_sharing_or_matching_requirement: false,
+            cfda_numbers: ['93.193'],
+            eligible_applicants: [
+                { code: '11' }, { code: '07' }, { code: '25' },
+            ],
+            funding_activity: {
+                categories: [
+                    {
+                        name: 'Health',
+                        code: 'HL',
+                    },
+                ],
+            },
+            revision: { id: 'c3' },
+        },
+        created_at: '2021-08-06 16:03:53.57025-07',
+        updated_at: '2021-08-11 12:35:42.562-07',
+        revision_id: 'c3',
+    },
+    nullOpenAndCloseDates: {
+        status: 'inbox',
+        grant_id: '284793',
+        grant_number: 'TI-16-005',
+        agency_code: 'HHS-SAMHS',
+        award_ceiling: '500000',
+        cost_sharing: 'No',
+        title: 'Cooperative Agreement to Support the Establishment of a Ukraine HIV International Addiction Technology Transfer Center (UHATTC)',
+        cfda_list: '93.243',
+        open_date: null,
+        close_date: null,
+        notes: 'auto-inserted by script',
+        search_terms: '[in title/desc]+',
+        reviewer_name: 'none',
+        opportunity_category: 'Discretionary',
+        description: '<p>The purpose of this program is to establish an internationally-based ATTC in Ukraine that primarily builds the capacity and increases the skills and abilities of healthcare providers of the national Ukraine HIV/AIDS program/</p>',
+        eligibility_codes: '25',
+        funding_activity_category_codes: 'HL ISS',
+        opportunity_status: 'forecasted',
+        raw_body_json: {
+            opportunity: {
+                id: '284793',
+                number: 'TI-16-005',
+                title: 'Cooperative Agreement to Support the Establishment of a Ukraine HIV International Addiction Technology Transfer Center (UHATTC)',
+                description: '<p>The purpose of this program is to establish an internationally-based ATTC in Ukraine that primarily builds the capacity and increases the skills and abilities of healthcare providers of the national Ukraine HIV/AIDS program/</p>',
+                milestones: {
+                    post_date: '2021-08-05',
+                },
+                category: { code: 'D', name: 'Discretionary' },
+            },
+            agency: { code: 'HHS-SAMHS' },
+            award: { ceiling: '250000' },
+            cost_sharing_or_matching_requirement: false,
+            cfda_numbers: ['93.243'],
+            eligible_applicants: [
+                { code: '25' },
+            ],
+            funding_activity: {
+                categories: [
+                    {
+                        name: 'Health',
+                        code: 'HL',
+                    },
+                    {
+                        name: 'Income Security and Social Services',
+                        code: 'ISS',
+                    },
+                ],
+            },
+            revision: { id: 'c3' },
+        },
+        created_at: '2021-08-06 16:03:53.57025-07',
+        updated_at: '2021-08-11 12:35:42.562-07',
+        revision_id: 'c3',
+    },
+    validOpenAndCloseDates: {
+        status: 'inbox',
+        grant_id: '284769',
+        grant_number: 'PA-FPT-002',
+        agency_code: 'HHS-OPHS',
+        award_ceiling: '4000000',
+        cost_sharing: 'No',
+        title: 'Anticipated Availability of funds for Title X Family Planning Training Cooperative Agreements',
+        cfda_list: '93.260',
+        open_date: '2046-08-05',
+        close_date: '2046-09-06',
+        close_date_explanation: 'Sample text - close_date has valid date',
+        notes: 'auto-inserted by script',
+        search_terms: '[in title/desc]+',
+        reviewer_name: 'none',
+        opportunity_category: 'Discretionary',
+        description: ' <p>The overarching goal of these training and technical assistance projects is to improve reproductive health outcomes for men, women and adolescents by reducing unplanned pregnancies, improving efforts to plan and space pregnancies through counseling, lower the rates of STDs, and improving birth outcomes. <p>',
+        eligibility_codes: '11 07 25',
+        funding_activity_category_codes: 'HL',
+        opportunity_status: 'forecasted',
+        raw_body_json: {
+            opportunity: {
+                id: '284769',
+                number: 'PA-FPT-002',
+                title: 'Anticipated Availability of funds for Title X Family Planning Training Cooperative Agreements',
+                description: ' <p>The overarching goal of these training and technical assistance projects is to improve reproductive health outcomes for men, women and adolescents by reducing unplanned pregnancies, improving efforts to plan and space pregnancies through counseling, lower the rates of STDs, and improving birth outcomes. <p>',
+                milestones: {
+                    post_date: '2021-08-05',
+                },
+                category: { code: 'D', name: 'Discretionary' },
+            },
+            agency: { code: 'HHS-OPHS' },
+            award: { ceiling: '4000000' },
+            cost_sharing_or_matching_requirement: false,
+            cfda_numbers: ['93.260'],
+            eligible_applicants: [
+                { code: '00' }, { code: '01' }, { code: '02' },
+            ],
+            funding_activity: {
+                categories: [
+                    {
+                        name: 'Health',
+                        code: 'HL',
+                    },
+                ],
+            },
+            revision: { id: 'c3' },
+        },
+        created_at: '2021-08-06 16:03:53.57025-07',
+        updated_at: '2021-08-11 12:35:42.562-07',
+        revision_id: 'c3',
+    },
+};
+
 const grantsInterested = {
     entry1: {
         agency_id: agencies.accountancy.id,
@@ -581,4 +795,5 @@ module.exports.seed = async (knex) => {
     await knex(TABLES.grants_interested).insert(Object.values(grantsInterested));
     await knex(TABLES.grants_saved_searches).insert(Object.values(grantsSavedSearches));
     await knex(TABLES.grants_viewed).insert(Object.values(grantsViewed));
+    await knex(TABLES.grants).insert(Object.values(forecastedGrants));
 };

--- a/packages/server/seeds/dev/03_add_forecasted_grants.js
+++ b/packages/server/seeds/dev/03_add_forecasted_grants.js
@@ -1,0 +1,14 @@
+// require('dotenv').config();
+
+const {
+    forecastedGrants, assignedForecastedGrantsAgency,
+} = require('./ref/forecastedGrants');
+
+const seed = async (knex) => {
+    await knex('grants').insert(forecastedGrants);
+    await knex('assigned_grants_agency').insert(assignedForecastedGrantsAgency);
+};
+
+module.exports = {
+    seed,
+};

--- a/packages/server/seeds/dev/ref/forecastedGrants.js
+++ b/packages/server/seeds/dev/ref/forecastedGrants.js
@@ -8,9 +8,9 @@ const forecastedGrants = [
     {
         status: 'inbox',
         grant_id: '284822',
-        grant_number: '21-605',
-        agency_code: 'NSF',
-        award_ceiling: '6500',
+        grant_number: 'CDC-RFA-PS16-1606',
+        agency_code: 'HHS-CDC-NCHHSTP',
+        award_ceiling: '325000',
         cost_sharing: 'No',
         title: 'Comprehensive High-Impact HIV Prevention Projects for Young Men of Color Who Have Sex with Men and Young Transgender Persons of Color',
         cfda_list: '47.050',
@@ -22,13 +22,13 @@ const forecastedGrants = [
         reviewer_name: 'none',
         opportunity_category: 'Discretionary',
         description: '<p class="MsoNormal">The Centers for Disease Control and Prevention announces the availability of fiscal year 2055 funds for a cooperative agreement program for community-based organizations (CBOs) to develop and implement High-Impact Human Immunodeficiency Virus (HIV) Prevention Programs.</p>',
-        eligibility_codes: '25',
-        funding_activity_category_codes: 'ST',
+        eligibility_codes: '12',
+        funding_activity_category_codes: 'HL',
         opportunity_status: 'forecasted',
         raw_body_json: {
             opportunity: {
-                id: '335255',
-                number: '21-605',
+                id: '284822',
+                number: 'CDC-RFA-PS16-1606',
                 title: 'Comprehensive High-Impact HIV Prevention Projects for Young Men of Color Who Have Sex with Men and Young Transgender Persons of Color',
                 description: '<p class="MsoNormal">The Centers for Disease Control and Prevention announces the availability of fiscal year 2055 funds for a cooperative agreement program for community-based organizations (CBOs) to develop and implement High-Impact Human Immunodeficiency Virus (HIV) Prevention Programs.</p>',
                 milestones: {
@@ -49,8 +49,8 @@ const forecastedGrants = [
             funding_activity: {
                 categories: [
                     {
-                        name: 'Health and Human Services and Center For Disease Control and Prevention',
-                        code: 'HHS',
+                        name: 'Health',
+                        code: 'HL',
                     },
                 ],
             },
@@ -60,13 +60,13 @@ const forecastedGrants = [
     },
     {
         status: 'inbox',
-        grant_id: '444816',
-        grant_number: 'HHS-2021-IHS-TPI-0001',
+        grant_id: '284810',
+        grant_number: 'HHS-2016-IHS-UIHP1-0001',
         agency_code: 'HHS-IHS',
         award_ceiling: '500000',
         cost_sharing: 'No',
         title: 'Office of Urban Indian Health Program - Title V HIV/AIDS',
-        cfda_list: '93.382',
+        cfda_list: '93.193',
         open_date: '2056-08-05',
         close_date: '2076-09-06',
         notes: 'auto-inserted by script',
@@ -75,12 +75,12 @@ const forecastedGrants = [
         opportunity_category: 'Discretionary',
         description: '<p>The Indian Health Service is accepting limited competitive grant applications for the Office of Urban Indian Health Programs Title V HIV/AIDS program. </p>',
         eligibility_codes: '11 07 25',
-        funding_activity_category_codes: 'HL ISS',
+        funding_activity_category_codes: 'HL',
         opportunity_status: 'forecasted',
         raw_body_json: {
             opportunity: {
-                id: '333816',
-                number: 'HHS-2021-IHS-TPI-0001',
+                id: '284810',
+                number: 'HHS-2016-IHS-UIHP1-0001',
                 title: 'Office of Urban Indian Health Program - Title V HIV/AIDS',
                 description: '<p>The Indian Health Service is accepting limited competitive grant applications for the Office of Urban Indian Health Programs Title V HIV/AIDS program. </p>',
                 milestones: {
@@ -91,7 +91,7 @@ const forecastedGrants = [
             agency: { code: 'HHS-IHS' },
             award: { ceiling: '500000' },
             cost_sharing_or_matching_requirement: false,
-            cfda_numbers: ['93.382'],
+            cfda_numbers: ['93.193'],
             eligible_applicants: [
                 { code: '11' }, { code: '07' }, { code: '25' },
             ],
@@ -100,10 +100,6 @@ const forecastedGrants = [
                     {
                         name: 'Health',
                         code: 'HL',
-                    },
-                    {
-                        name: 'Income Security and Social Services',
-                        code: 'ISS',
                     },
                 ],
             },
@@ -115,13 +111,13 @@ const forecastedGrants = [
     },
     {
         status: 'inbox',
-        grant_id: '444824',
-        grant_number: 'HHS-2021-IHS-TPI-0001',
-        agency_code: 'HHS-IHS',
+        grant_id: '284793',
+        grant_number: 'TI-16-005',
+        agency_code: 'HHS-SAMHS',
         award_ceiling: '500000',
         cost_sharing: 'No',
         title: 'Cooperative Agreement to Support the Establishment of a Ukraine HIV International Addiction Technology Transfer Center (UHATTC)',
-        cfda_list: '93.382',
+        cfda_list: '93.243',
         open_date: null,
         close_date: null,
         notes: 'auto-inserted by script',
@@ -129,13 +125,13 @@ const forecastedGrants = [
         reviewer_name: 'none',
         opportunity_category: 'Discretionary',
         description: '<p>The purpose of this program is to establish an internationally-based ATTC in Ukraine that primarily builds the capacity and increases the skills and abilities of healthcare providers of the national Ukraine HIV/AIDS program/</p>',
-        eligibility_codes: '11 07 25',
+        eligibility_codes: '25',
         funding_activity_category_codes: 'HL ISS',
         opportunity_status: 'forecasted',
         raw_body_json: {
             opportunity: {
-                id: '333816',
-                number: 'HHS-2021-IHS-TPI-0001',
+                id: '284793',
+                number: 'TI-16-005',
                 title: 'Cooperative Agreement to Support the Establishment of a Ukraine HIV International Addiction Technology Transfer Center (UHATTC)',
                 description: '<p>The purpose of this program is to establish an internationally-based ATTC in Ukraine that primarily builds the capacity and increases the skills and abilities of healthcare providers of the national Ukraine HIV/AIDS program/</p>',
                 milestones: {
@@ -143,12 +139,12 @@ const forecastedGrants = [
                 },
                 category: { code: 'D', name: 'Discretionary' },
             },
-            agency: { code: 'HHS-IHS' },
-            award: { ceiling: '500000' },
+            agency: { code: 'HHS-SAMHS' },
+            award: { ceiling: '250000' },
             cost_sharing_or_matching_requirement: false,
-            cfda_numbers: ['93.382'],
+            cfda_numbers: ['93.243'],
             eligible_applicants: [
-                { code: '11' }, { code: '07' }, { code: '25' },
+                { code: '25' },
             ],
             funding_activity: {
                 categories: [
@@ -170,13 +166,13 @@ const forecastedGrants = [
     },
     {
         status: 'inbox',
-        grant_id: '444836',
-        grant_number: 'HHS-2021-IHS-TPI-0001',
-        agency_code: 'HHS-IHS',
-        award_ceiling: '500000',
+        grant_id: '284769',
+        grant_number: 'PA-FPT-002',
+        agency_code: 'HHS-OPHS',
+        award_ceiling: '4000000',
         cost_sharing: 'No',
         title: 'Anticipated Availability of funds for Title X Family Planning Training Cooperative Agreements',
-        cfda_list: '93.382',
+        cfda_list: '93.260',
         open_date: '2046-08-05',
         close_date: '2046-09-06',
         close_date_explanation: 'Sample text - close_date has valid date',
@@ -186,12 +182,12 @@ const forecastedGrants = [
         opportunity_category: 'Discretionary',
         description: ' <p>The overarching goal of these training and technical assistance projects is to improve reproductive health outcomes for men, women and adolescents by reducing unplanned pregnancies, improving efforts to plan and space pregnancies through counseling, lower the rates of STDs, and improving birth outcomes. <p>',
         eligibility_codes: '11 07 25',
-        funding_activity_category_codes: 'HL ISS',
+        funding_activity_category_codes: 'HL',
         opportunity_status: 'forecasted',
         raw_body_json: {
             opportunity: {
-                id: '333816',
-                number: 'HHS-2021-IHS-TPI-0001',
+                id: '284769',
+                number: 'PA-FPT-002',
                 title: 'Anticipated Availability of funds for Title X Family Planning Training Cooperative Agreements',
                 description: ' <p>The overarching goal of these training and technical assistance projects is to improve reproductive health outcomes for men, women and adolescents by reducing unplanned pregnancies, improving efforts to plan and space pregnancies through counseling, lower the rates of STDs, and improving birth outcomes. <p>',
                 milestones: {
@@ -199,22 +195,18 @@ const forecastedGrants = [
                 },
                 category: { code: 'D', name: 'Discretionary' },
             },
-            agency: { code: 'HHS-IHS' },
-            award: { ceiling: '500000' },
+            agency: { code: 'HHS-OPHS' },
+            award: { ceiling: '4000000' },
             cost_sharing_or_matching_requirement: false,
-            cfda_numbers: ['93.382'],
+            cfda_numbers: ['93.260'],
             eligible_applicants: [
-                { code: '11' }, { code: '07' }, { code: '25' },
+                { code: '00' }, { code: '01' }, { code: '02' },
             ],
             funding_activity: {
                 categories: [
                     {
                         name: 'Health',
                         code: 'HL',
-                    },
-                    {
-                        name: 'Income Security and Social Services',
-                        code: 'ISS',
                     },
                 ],
             },

--- a/packages/server/seeds/dev/ref/forecastedGrants.js
+++ b/packages/server/seeds/dev/ref/forecastedGrants.js
@@ -1,0 +1,255 @@
+const agencies = require('./agencies');
+
+const usdr = agencies.find((a) => a.abbreviation === 'USDR').id;
+const nevada = agencies.find((a) => a.abbreviation === 'NV').id;
+const asd = agencies.find((a) => a.abbreviation === 'ASD').id;
+
+const forecastedGrants = [
+    {
+        status: 'inbox',
+        grant_id: '284822',
+        grant_number: '21-605',
+        agency_code: 'NSF',
+        award_ceiling: '6500',
+        cost_sharing: 'No',
+        title: 'Comprehensive High-Impact HIV Prevention Projects for Young Men of Color Who Have Sex with Men and Young Transgender Persons of Color',
+        cfda_list: '47.050',
+        open_date: '2055-08-11',
+        close_date: null,
+        close_date_explanation: 'Sample text for null close_date',
+        notes: 'auto-inserted by script',
+        search_terms: '[in title/desc]+',
+        reviewer_name: 'none',
+        opportunity_category: 'Discretionary',
+        description: '<p class="MsoNormal">The Centers for Disease Control and Prevention announces the availability of fiscal year 2055 funds for a cooperative agreement program for community-based organizations (CBOs) to develop and implement High-Impact Human Immunodeficiency Virus (HIV) Prevention Programs.</p>',
+        eligibility_codes: '25',
+        funding_activity_category_codes: 'ST',
+        opportunity_status: 'forecasted',
+        raw_body_json: {
+            opportunity: {
+                id: '335255',
+                number: '21-605',
+                title: 'Comprehensive High-Impact HIV Prevention Projects for Young Men of Color Who Have Sex with Men and Young Transgender Persons of Color',
+                description: '<p class="MsoNormal">The Centers for Disease Control and Prevention announces the availability of fiscal year 2055 funds for a cooperative agreement program for community-based organizations (CBOs) to develop and implement High-Impact Human Immunodeficiency Virus (HIV) Prevention Programs.</p>',
+                milestones: {
+                    post_date: '2055-08-11',
+                    close: {
+                        date: null,
+                    },
+                },
+                category: { code: 'D', name: 'Discretionary' },
+            },
+            agency: { code: 'HHS-CDC-NCHHSTP' },
+            award: { ceiling: '325000' },
+            cost_sharing_or_matching_requirement: false,
+            cfda_numbers: ['47.050'],
+            eligible_applicants: [
+                { code: '12' },
+            ],
+            funding_activity: {
+                categories: [
+                    {
+                        name: 'Health and Human Services and Center For Disease Control and Prevention',
+                        code: 'HHS',
+                    },
+                ],
+            },
+        },
+        created_at: '2021-08-11 11:30:38.89828-07',
+        updated_at: '2021-08-11 12:30:39.531-07',
+    },
+    {
+        status: 'inbox',
+        grant_id: '444816',
+        grant_number: 'HHS-2021-IHS-TPI-0001',
+        agency_code: 'HHS-IHS',
+        award_ceiling: '500000',
+        cost_sharing: 'No',
+        title: 'Office of Urban Indian Health Program - Title V HIV/AIDS',
+        cfda_list: '93.382',
+        open_date: '2056-08-05',
+        close_date: '2076-09-06',
+        notes: 'auto-inserted by script',
+        search_terms: '[in title/desc]+',
+        reviewer_name: 'none',
+        opportunity_category: 'Discretionary',
+        description: '<p>The Indian Health Service is accepting limited competitive grant applications for the Office of Urban Indian Health Programs Title V HIV/AIDS program. </p>',
+        eligibility_codes: '11 07 25',
+        funding_activity_category_codes: 'HL ISS',
+        opportunity_status: 'forecasted',
+        raw_body_json: {
+            opportunity: {
+                id: '333816',
+                number: 'HHS-2021-IHS-TPI-0001',
+                title: 'Office of Urban Indian Health Program - Title V HIV/AIDS',
+                description: '<p>The Indian Health Service is accepting limited competitive grant applications for the Office of Urban Indian Health Programs Title V HIV/AIDS program. </p>',
+                milestones: {
+                    post_date: '2056-08-05',
+                },
+                category: { code: 'D', name: 'Discretionary' },
+            },
+            agency: { code: 'HHS-IHS' },
+            award: { ceiling: '500000' },
+            cost_sharing_or_matching_requirement: false,
+            cfda_numbers: ['93.382'],
+            eligible_applicants: [
+                { code: '11' }, { code: '07' }, { code: '25' },
+            ],
+            funding_activity: {
+                categories: [
+                    {
+                        name: 'Health',
+                        code: 'HL',
+                    },
+                    {
+                        name: 'Income Security and Social Services',
+                        code: 'ISS',
+                    },
+                ],
+            },
+            revision: { id: 'c3' },
+        },
+        created_at: '2021-08-06 16:03:53.57025-07',
+        updated_at: '2021-08-11 12:35:42.562-07',
+        revision_id: 'c3',
+    },
+    {
+        status: 'inbox',
+        grant_id: '444824',
+        grant_number: 'HHS-2021-IHS-TPI-0001',
+        agency_code: 'HHS-IHS',
+        award_ceiling: '500000',
+        cost_sharing: 'No',
+        title: 'Cooperative Agreement to Support the Establishment of a Ukraine HIV International Addiction Technology Transfer Center (UHATTC)',
+        cfda_list: '93.382',
+        open_date: null,
+        close_date: null,
+        notes: 'auto-inserted by script',
+        search_terms: '[in title/desc]+',
+        reviewer_name: 'none',
+        opportunity_category: 'Discretionary',
+        description: '<p>The purpose of this program is to establish an internationally-based ATTC in Ukraine that primarily builds the capacity and increases the skills and abilities of healthcare providers of the national Ukraine HIV/AIDS program/</p>',
+        eligibility_codes: '11 07 25',
+        funding_activity_category_codes: 'HL ISS',
+        opportunity_status: 'forecasted',
+        raw_body_json: {
+            opportunity: {
+                id: '333816',
+                number: 'HHS-2021-IHS-TPI-0001',
+                title: 'Cooperative Agreement to Support the Establishment of a Ukraine HIV International Addiction Technology Transfer Center (UHATTC)',
+                description: '<p>The purpose of this program is to establish an internationally-based ATTC in Ukraine that primarily builds the capacity and increases the skills and abilities of healthcare providers of the national Ukraine HIV/AIDS program/</p>',
+                milestones: {
+                    post_date: '2021-08-05',
+                },
+                category: { code: 'D', name: 'Discretionary' },
+            },
+            agency: { code: 'HHS-IHS' },
+            award: { ceiling: '500000' },
+            cost_sharing_or_matching_requirement: false,
+            cfda_numbers: ['93.382'],
+            eligible_applicants: [
+                { code: '11' }, { code: '07' }, { code: '25' },
+            ],
+            funding_activity: {
+                categories: [
+                    {
+                        name: 'Health',
+                        code: 'HL',
+                    },
+                    {
+                        name: 'Income Security and Social Services',
+                        code: 'ISS',
+                    },
+                ],
+            },
+            revision: { id: 'c3' },
+        },
+        created_at: '2021-08-06 16:03:53.57025-07',
+        updated_at: '2021-08-11 12:35:42.562-07',
+        revision_id: 'c3',
+    },
+    {
+        status: 'inbox',
+        grant_id: '444836',
+        grant_number: 'HHS-2021-IHS-TPI-0001',
+        agency_code: 'HHS-IHS',
+        award_ceiling: '500000',
+        cost_sharing: 'No',
+        title: 'Anticipated Availability of funds for Title X Family Planning Training Cooperative Agreements',
+        cfda_list: '93.382',
+        open_date: '2046-08-05',
+        close_date: '2046-09-06',
+        close_date_explanation: 'Sample text - close_date has valid date',
+        notes: 'auto-inserted by script',
+        search_terms: '[in title/desc]+',
+        reviewer_name: 'none',
+        opportunity_category: 'Discretionary',
+        description: ' <p>The overarching goal of these training and technical assistance projects is to improve reproductive health outcomes for men, women and adolescents by reducing unplanned pregnancies, improving efforts to plan and space pregnancies through counseling, lower the rates of STDs, and improving birth outcomes. <p>',
+        eligibility_codes: '11 07 25',
+        funding_activity_category_codes: 'HL ISS',
+        opportunity_status: 'forecasted',
+        raw_body_json: {
+            opportunity: {
+                id: '333816',
+                number: 'HHS-2021-IHS-TPI-0001',
+                title: 'Anticipated Availability of funds for Title X Family Planning Training Cooperative Agreements',
+                description: ' <p>The overarching goal of these training and technical assistance projects is to improve reproductive health outcomes for men, women and adolescents by reducing unplanned pregnancies, improving efforts to plan and space pregnancies through counseling, lower the rates of STDs, and improving birth outcomes. <p>',
+                milestones: {
+                    post_date: '2021-08-05',
+                },
+                category: { code: 'D', name: 'Discretionary' },
+            },
+            agency: { code: 'HHS-IHS' },
+            award: { ceiling: '500000' },
+            cost_sharing_or_matching_requirement: false,
+            cfda_numbers: ['93.382'],
+            eligible_applicants: [
+                { code: '11' }, { code: '07' }, { code: '25' },
+            ],
+            funding_activity: {
+                categories: [
+                    {
+                        name: 'Health',
+                        code: 'HL',
+                    },
+                    {
+                        name: 'Income Security and Social Services',
+                        code: 'ISS',
+                    },
+                ],
+            },
+            revision: { id: 'c3' },
+        },
+        created_at: '2021-08-06 16:03:53.57025-07',
+        updated_at: '2021-08-11 12:35:42.562-07',
+        revision_id: 'c3',
+    },
+];
+
+const assignedForecastedGrantsAgency = [
+    {
+        grant_id: forecastedGrants[0].grant_id,
+        agency_id: usdr,
+        assigned_by: 1,
+    },
+    {
+        grant_id: forecastedGrants[0].grant_id,
+        agency_id: asd,
+        assigned_by: 13,
+    },
+    {
+        grant_id: forecastedGrants[0].grant_id,
+        agency_id: nevada,
+        assigned_by: 7,
+    },
+    {
+        grant_id: forecastedGrants[1].grant_id,
+        agency_id: nevada,
+        assigned_by: 6,
+    },
+];
+
+module.exports = {
+    forecastedGrants,
+    assignedForecastedGrantsAgency,
+};

--- a/packages/server/src/db/index.js
+++ b/packages/server/src/db/index.js
@@ -548,6 +548,7 @@ function grantsQuery(queryBuilder, filters, agencyId, orderingParams, pagination
             CASE
             WHEN grants.archive_date <= now() THEN 'archived'
             WHEN grants.close_date <= now() THEN 'closed'
+            WHEN grants.open_date > now() OR grants.opportunity_status = 'forecasted' THEN 'forecasted'
             ELSE 'posted'
             END IN (${Array(filters.opportunityStatuses.length).fill('?').join(',')})`, filters.opportunityStatuses);
     }
@@ -751,6 +752,7 @@ async function getGrantsNew(filters, paginationParams, orderingParams, tenantId,
             CASE
             WHEN grants.archive_date <= now() THEN 'archived'
             WHEN grants.close_date <= now() THEN 'closed'
+            WHEN grants.open_date > now() OR grants.opportunity_status = 'forecasted' THEN 'forecasted'
             ELSE 'posted'
             END as opportunity_status
         `))


### PR DESCRIPTION
## Blocked from merging
* Blocked by - [PR #3456]( https://github.com/usdigitalresponse/usdr-gost/pull/3456) - Hide forecasted grants while UI is being developed to support forecasted grants

----

### Ticket #3645 
## Description

Working towards seed implementation as per this slack post
[Ty's slack recommendation for seed data](https://usdigitalresponse.slack.com/archives/C05GD4B55J9/p1728338921988529?thread_ts=1728315190.343049&cid=C05GD4B55J9)

From the Git issue

> We want forecasted grants that meet the following scenarios:
> 
> estimated post date and estimated application due date both have date values entered
> estimated post date and estimated application due date are both blank
> estimated post date and estimated application due date have content entered that is not a date (i.e. text that says "This is sample text")


## Screenshots / Demo Video
Sreenshot from pgAdmin
![image](https://github.com/user-attachments/assets/ee04da60-6222-4a0c-9520-3e093af27f31)

![image](https://github.com/user-attachments/assets/47882a3c-fb82-4530-8e9c-008f74283060)





## Testing

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [ ] Provided ticket and description
- [ ] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers