### PR TITLE
fix: ensure picklist values are formatted correctly prior to comparison

### DIFF
--- a/packages/server/src/arpa_reporter/services/validate-upload.js
+++ b/packages/server/src/arpa_reporter/services/validate-upload.js
@@ -326,9 +326,9 @@ async function validateRecord({ upload, record, typeRules: rules }) {
                 const lcItems = rule.listVals.map((val) => multiselect(val.toLowerCase()));
 
                 // for pick lists, the value must be one of possible values
-                if (rule.dataType === 'Pick List' && !lcItems.includes(value)) {
+                if (rule.dataType === 'Pick List' && !lcItems.includes(multiselect(value))) {
                     errors.push(new ValidationError(
-                        `Value for ${key} ('${value}') must be one of ${lcItems.length} options in the input template`,
+                        `Value for ${key} ('${value}') must be one of ${lcItems.length} ${JSON.stringify(lcItems)}options in the input template`,
                         { col: rule.columnName, severity: 'err' },
                     ));
                 }

--- a/packages/server/src/arpa_reporter/services/validate-upload.js
+++ b/packages/server/src/arpa_reporter/services/validate-upload.js
@@ -339,7 +339,7 @@ async function validateRecord({ upload, record, typeRules: rules }) {
                     for (const entry of entries) {
                         if (!lcItems.includes(entry)) {
                             errors.push(new ValidationError(
-                                `Entry '${entry}' of ${key} is not one of ${lcItems.length} valid options`,
+                                `Entry '${entry}' of ${key} is not one of ${lcItems.length} valid options (${JSON.stringify(lcItems)})`,
                                 { col: rule.columnName, severity: 'err' },
                             ));
                         }

--- a/packages/server/src/arpa_reporter/services/validate-upload.js
+++ b/packages/server/src/arpa_reporter/services/validate-upload.js
@@ -328,7 +328,7 @@ async function validateRecord({ upload, record, typeRules: rules }) {
                 // for pick lists, the value must be one of possible values
                 if (rule.dataType === 'Pick List' && !lcItems.includes(multiselect(value))) {
                     errors.push(new ValidationError(
-                        `Value for ${key} ('${value}') must be one of ${lcItems.length} ${JSON.stringify(lcItems)}options in the input template`,
+                        `Value for ${key} ('${value}') must be one of ${lcItems.length} valid options in the input template. (${JSON.stringify(lcItems)})`,
                         { col: rule.columnName, severity: 'err' },
                     ));
                 }


### PR DESCRIPTION
### Ticket #3646 
## Description
Picklist values were not being formatted correctly prior to comparison as part of a bug that was introduced in #3398  . This PR fixes it.

## Screenshots / Demo Video

### Before
<img width="882" alt="image" src="https://github.com/user-attachments/assets/9a576c16-2e9d-4acb-9a0e-15bc4774b786">

### After
<img width="898" alt="image" src="https://github.com/user-attachments/assets/5c6b50e4-c43c-4014-be71-032de95713a9">


## Testing
1. Download test file here: https://staging.grants.usdr.dev/arpa_reporter/uploads/0eb8c65d-76e2-47fa-8d05-369144772d7a
2. Try uploading and validating the file in `main` branch and see that the validation error shows up.
3. Go to the same upload after switching branches and click the "Validate" button and notice that no error shows up.

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [ ] Provided ticket and description
- [ ] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers