### PR TITLE
Fix: cascade delete `users` to grant notes and follows

### DIFF
--- a/packages/server/migrations/20241118203005_cascade-delete-grant-notes-for-user.js
+++ b/packages/server/migrations/20241118203005_cascade-delete-grant-notes-for-user.js
@@ -1,0 +1,21 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function (knex) {
+    await knex.schema.table('grant_notes', (table) => {
+        table.dropForeign('user_id');
+        table.foreign('user_id').references('users.id').onDelete('CASCADE');
+    });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async function (knex) {
+    await knex.schema.table('grant_notes', (table) => {
+        table.dropForeign('user_id');
+        table.foreign('user_id').references('users.id');
+    });
+};

--- a/packages/server/migrations/20241118203302_cascade-delete-followed-grants-for-user.js
+++ b/packages/server/migrations/20241118203302_cascade-delete-followed-grants-for-user.js
@@ -1,0 +1,21 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function (knex) {
+    await knex.schema.table('grant_followers', (table) => {
+        table.dropForeign('user_id');
+        table.foreign('user_id').references('users.id').onDelete('CASCADE');
+    });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async function (knex) {
+    await knex.schema.table('grant_followers', (table) => {
+        table.dropForeign('user_id');
+        table.foreign('user_id').references('users.id');
+    });
+};


### PR DESCRIPTION
## Description

Adds `ON DELETE CASCADE` to FK references so that when a user is deleted, associated rows in `grant_notes` and `grant_followers` tables are also deleted.