### PR TITLE
Reduce automation noise

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,6 +30,9 @@ updates:
       timezone: "America/New_York"
     commit-message:
       prefix: 'Chore [deps:terraform]'
+    ignore:
+      - dependency-name: cloudposse/*
+      - dependency-name: terraform-aws-modules/*
   # Dependabot can't inspect nested directories so we need to list all local modules individually.
   # TODO: Consider switching to Rennovate.
   - package-ecosystem: "terraform"
@@ -40,6 +43,9 @@ updates:
       timezone: "America/New_York"
     commit-message:
       prefix: 'Chore [deps:terraform]'
+    ignore:
+      - dependency-name: cloudposse/*
+      - dependency-name: terraform-aws-modules/*
   - package-ecosystem: "terraform"
     directory: "/terraform/modules/gost_consume_grants"
     schedule:
@@ -48,6 +54,9 @@ updates:
       timezone: "America/New_York"
     commit-message:
       prefix: 'Chore [deps:terraform]'
+    ignore:
+      - dependency-name: cloudposse/*
+      - dependency-name: terraform-aws-modules/*
   - package-ecosystem: "terraform"
     directory: "/terraform/modules/gost_website"
     schedule:
@@ -56,6 +65,9 @@ updates:
       timezone: "America/New_York"
     commit-message:
       prefix: 'Chore [deps:terraform]'
+    ignore:
+      - dependency-name: cloudposse/*
+      - dependency-name: terraform-aws-modules/*
   - package-ecosystem: "terraform"
     directory: "/terraform/modules/gost_postgres"
     schedule:
@@ -64,6 +76,9 @@ updates:
       timezone: "America/New_York"
     commit-message:
       prefix: 'Chore [deps:terraform]'
+    ignore:
+      - dependency-name: cloudposse/*
+      - dependency-name: terraform-aws-modules/*
   - package-ecosystem: "terraform"
     directory: "/terraform/modules/scheduled_ecs_task"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,6 +44,7 @@ updates:
     commit-message:
       prefix: 'Chore [deps:terraform]'
     ignore:
+      # These should be un-ignored if/when the Terraform AWS provider is updated to a more recent version
       - dependency-name: cloudposse/*
       - dependency-name: terraform-aws-modules/*
   - package-ecosystem: "terraform"

--- a/.github/workflows/code-scanning.yml
+++ b/.github/workflows/code-scanning.yml
@@ -55,6 +55,10 @@ jobs:
         with:
           languages: javascript-typescript
           queries: security-extended,security-and-quality
+          config: |
+            query-filters:
+              - exclude:
+                  id: js/missing-rate-limiting  # We manage this in our infra
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@8e0b1c74b1d5a0077b04d064c76ee714d3da7637 # v2.14.6
         with:


### PR DESCRIPTION
This PR reduces noise from DevOps automations. Specifically:
1. Disables Dependabot upgrades for certain Terraform dependencies (`cloudposse/*` and `terraform-aws-modules/*`). Given that upgrading the Terraform AWS provider is a prerequisite for upgrading these dependencies, we should ignore individual updates until that work is complete. 
See also: #2379.
2. Disables CodeQL errors related to rate-limiting detection in `packages/api` JS code. We handle this at the infrastructure level rather than in runtime code, so these errors are not useful. 