### PR TITLE
Add autolabeler rules for a11y PRs

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -128,6 +128,12 @@ autolabeler:
     files:
       - '.github/**'
       - '**/.gitignore'
+  - label: accessibility
+    branch:
+      - '/^accessibility\/.+$/i'
+      - '/^a11y\/.+$/i'
+    title:
+      - '/\ba11y\b/i'
 change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
 change-title-escapes: '\<*_&'
 no-contributors-template: >-


### PR DESCRIPTION
This PR is a simple update to our automation for automatically labeling pull requests. With these changes, the ["Label pull requests" CI job](https://github.com/usdigitalresponse/usdr-gost/blob/167e5abf96c5559eccbf5938ca899c426372788c/.github/workflows/release-drafter.yml#L18) will apply the `accessibility` label to any PR that matches the following (case-insensitive) detection rules:
1. Branch name starts with `accessibility/` or `a11y/`
2. PR title contains the word `a11y`

Note that no rules are defined that glob-match any changed files/paths, since I couldn't think of any specific files that would reliably be changed solely for accessibility purposes. Let me know if that's not the case!