### PR TITLE
Address outdated package.json files

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,7 @@
 {
-  "name": "cares-grant-opportunities",
+  "name": "usdr-gost",
   "version": "1.0.0",
   "main": "index.js",
-  "repository": "https://github.com/usdigitalresponse/cares-grant-opportunities.git",
-  "author": "Pol Abellas, Rafael A <rafael.polabellas@dematic.com>",
   "license": "Apache-2.0",
   "private": true,
   "workspaces": [

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -2,8 +2,6 @@
   "name": "server",
   "version": "1.0.0",
   "main": "index.js",
-  "repository": "https://github.com/usdigitalresponse/cares-grant-opportunities.git",
-  "author": "Pol Abellas, Rafael A <rafael.polabellas@dematic.com>",
   "license": "Apache-2.0",
   "engines": {
     "node": "20.11.1",


### PR DESCRIPTION
This no-op PR is a long-overdue tweak that updates our `package.json` files to reflect the actual state of the world. Specifically, it removes `author` and `repository` fields. Both of the previous values in both files were inaccurate, and furthermore are unnecessary in projects that do not provide distributable software (i.e. libraries).