### PR TITLE
Guard inclusion of `grant.followed_by_agencies` array data during CSV generation

### DIFF
--- a/packages/server/src/routes/grants.js
+++ b/packages/server/src/routes/grants.js
@@ -147,9 +147,9 @@ router.get('/exportCSVNew', requireUser, async (req, res) => {
             : grant.viewed_by_agencies
                 .map((v) => v.agency_abbreviation)
                 .join(', '),
-        followed_by_agencies: grant.followed_by_agencies
+        followed_by_agencies: process.env.ENABLE_FOLLOW_NOTES === 'true' ? grant.followed_by_agencies
             .map((v) => v.agency_name)
-            .join(', '),
+            .join(', ') : [],
         open_date: new Date(grant.open_date).toLocaleDateString('en-US', { timeZone: 'UTC' }),
         close_date: new Date(grant.close_date).toLocaleDateString('en-US', { timeZone: 'UTC' }),
         url: `https://www.grants.gov/search-results-detail/${grant.grant_id}`,


### PR DESCRIPTION
### Ticket #3856 
## Description

This PR attempts to fix the issue described in #3856, which is causing CSV export requests for Grants search results to result in a 500 response (only in Staging environment).

The issue is captured in Datadog [here](https://app.datadoghq.com/error-tracking/issue/ae08c734-cc4e-11ef-b282-da7ad0900002?query=env%3Astaging%20service%3Agost&from_ts=1736107423790&to_ts=1736193823789&live=true), with a specific error trace of:
```
TypeError: Cannot read properties of undefined (reading 'map')
    at /app/src/routes/grants.js:151:14
    at Array.map (<anonymous>)
    at /app/src/routes/grants.js:137:32
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
```

The above error indicates that `grant.followed_by_agencies` is `undefined` rather than an empty array. This is because the `followed_by_agencies` property is conditionally defined in `enhanceGrantData()` of `packages/server/src/db/index.js` when `process.env.ENABLE_FOLLOW_NOTES === 'true'`; if that expression is false, then the `followed_by_agencies` property does not exist when grants are being mapped to CSV data structures.

To resolve the issue, this PR makes the `grant.followed_by_agencies.map()` operation conditional on the same feature flag check, so that it is only called when `process.env.ENABLE_FOLLOW_NOTES === 'true'` (otherwise, an empty array is substituted).