### PR TITLE
fix: ensure there is guard clause to catch issues when projects are missing EC records

### DIFF
--- a/packages/server/src/arpa_reporter/lib/audit-report.js
+++ b/packages/server/src/arpa_reporter/lib/audit-report.js
@@ -466,7 +466,7 @@ async function createReportsGroupedBySubAward(periodId, tenantId, dateFormat = R
 }
 
 function getMostRecentRecordForProject(records, logger = log) {
-    let mostRecentRecord = {};
+    let mostRecentRecord;
     // Ensures we are only looking at records that are in the EC-tabs rather than the other tabs
     records = records.filter((record) => Object.keys(EXPENDITURE_CATEGORIES).includes(record.type));
 
@@ -478,10 +478,6 @@ function getMostRecentRecordForProject(records, logger = log) {
             logger.debug(`found a more recent record: ${new Date(record.upload.created_at)} is greater than ${new Date(mostRecentRecord.upload.created_at)}`);
             mostRecentRecord = record;
         }
-    }
-
-    if (Object.keys(mostRecentRecord).length === 0) {
-        logger.warn('no records found for project');
     }
 
     logger.debug(`most recent record is: ${JSON.stringify(mostRecentRecord)}`);
@@ -503,6 +499,9 @@ async function createKpiDataGroupedByProject(periodId, tenantId, logger = log) {
             project: { id: projectId, totalRecords: projectRecords.length },
         });
         const mostRecentRecord = getMostRecentRecordForProject(projectRecords, projectLogger);
+        if (!mostRecentRecord) {
+            projectLogger.warn(`project has no EC records ${projectId}`)
+        }
         projectLogger.debug('populating row from records in project');
         const row = {
             'Project ID': projectId,

--- a/packages/server/src/arpa_reporter/lib/audit-report.js
+++ b/packages/server/src/arpa_reporter/lib/audit-report.js
@@ -500,9 +500,9 @@ async function createKpiDataGroupedByProject(periodId, tenantId, logger = log) {
         });
         const mostRecentRecord = getMostRecentRecordForProject(projectRecords, projectLogger);
         if (!mostRecentRecord) {
-            projectLogger.warn(`Unexpected error - project has no EC records ${projectId}`)
+            projectLogger.warn(`Unexpected error - project has no EC records ${projectId}`);
         } else if (!mostRecentRecord.content) {
-            projectLogger.warn(`Unexpected error - project record has no content ${projectId}`)
+            projectLogger.warn(`Unexpected error - project record has no content ${projectId}`);
         }
         projectLogger.debug('populating row from records in project');
         const row = {

--- a/packages/server/src/arpa_reporter/lib/audit-report.js
+++ b/packages/server/src/arpa_reporter/lib/audit-report.js
@@ -471,7 +471,7 @@ function getMostRecentRecordForProject(records, logger = log) {
     records = records.filter((record) => Object.keys(EXPENDITURE_CATEGORIES).includes(record.type));
 
     for (const record of records) {
-        if (Object.keys(mostRecentRecord).length === 0) {
+        if (!mostRecentRecord) {
             logger.debug(`found first record: ${JSON.stringify(record)}`);
             mostRecentRecord = record;
         } else if (new Date(record.upload.created_at) > new Date(mostRecentRecord.upload.created_at)) {

--- a/packages/server/src/arpa_reporter/lib/audit-report.js
+++ b/packages/server/src/arpa_reporter/lib/audit-report.js
@@ -500,14 +500,16 @@ async function createKpiDataGroupedByProject(periodId, tenantId, logger = log) {
         });
         const mostRecentRecord = getMostRecentRecordForProject(projectRecords, projectLogger);
         if (!mostRecentRecord) {
-            projectLogger.warn(`project has no EC records ${projectId}`)
+            projectLogger.warn(`Unexpected error - project has no EC records ${projectId}`)
+        } else if (!mostRecentRecord.content) {
+            projectLogger.warn(`Unexpected error - project record has no content ${projectId}`)
         }
         projectLogger.debug('populating row from records in project');
         const row = {
             'Project ID': projectId,
             'Number of Subawards': 0,
             'Number of Expenditures': 0,
-            'Evidence Based Total Spend': mostRecentRecord?.content.Spending_Allocated_Toward_Evidence_Based_Interventions || 0,
+            'Evidence Based Total Spend': mostRecentRecord?.content?.Spending_Allocated_Toward_Evidence_Based_Interventions || 0,
         };
 
         projectRecords.forEach((r) => {


### PR DESCRIPTION
### Ticket #3802
## Description
I'm not able to reproduce the staging bug locally but these guard clauses will ensure that the value defaults to zero when the project has missing/insufficient data. The rest of the testing instructions supplied below are to generally test to make sure the feature works which still works.

## Screenshots / Demo Video
### After
The latest value of $35,000 is being picked.
<img width="474" alt="image" src="https://github.com/user-attachments/assets/2bee054b-35b7-4b60-9bd6-f64b27c1bb25" />

### Before
The KPI tab is returning the summation of two values $100,000 and $35,000 to return $135,000.
<img width="480" alt="image" src="https://github.com/user-attachments/assets/5a4405d8-2a79-4ffe-8dcd-f88ef9d88046" />


## Testing
1. Retrieve the two uploads needed to test from this directory here: https://drive.google.com/drive/folders/1YCnXLi-j3k8m3qktKrt9MRf20B5YsUDD
2. Upload both workbooks in the order `FIRST_UPLOAD` then `SECOND_UPLOAD` into the app through the Submit Workbook Flow. http://localhost:8080/arpa_reporter/new_upload
3. Verify that both uploads are validated.
4. In a separate tab hit this endpoint to synchronously generate the Audit Report: http://localhost:8080/api/audit_report
5. Verify that the audit report reflects $35,000 when generated from the current branch.
6. Switch to the `main` branch and run the same endpoint: http://localhost:8080/api/audit_report - This time verify that the audit report contains the value $135,000.


### Automated and Unit Tests
- [x] Added Unit tests

### Manual tests for Reviewer
- [x] Added steps to test feature/functionality manually

## Checklist
- [x] Provided ticket and description
- [x] Provided screenshots/demo
- [x] Provided testing information
- [x] Provided adequate test coverage for all new code
- [x] Added PR reviewers