### PR TITLE
fix: ensure all the fields of subawardBulkUpload.csv are being populated

### DIFF
--- a/packages/server/src/arpa_reporter/services/generate-arpa-report.js
+++ b/packages/server/src/arpa_reporter/services/generate-arpa-report.js
@@ -916,6 +916,14 @@ async function generateSubaward(records) {
                     record.content.Description__c,
                     record.content.Edited_Subaward_Amount_Explanation__c,
                     record.content.Loan_Expiration_Date__c,
+                    record.content.IAA_Basic_Conditions__c,
+                    record.content.IAA_Requirements_Attestation__c,
+                    record.content.Personnel_Cost_Estimates__c,
+                    record.content.Personnel_Estimated_Expended,
+                    record.content.Personnel_Expended_FTE_Count,
+                    record.content.Personnel_Expended_Justification,
+                    record.content.Contract_Estimated_Expended,
+                    record.content.Contract_Expended_Justification,
                 ];
             }
             default:


### PR DESCRIPTION
### Ticket #3913 
## Description
Upon investigating partner complaints of missing data in the treasury report for `Personnel_Estimated_Expended` field. I noticed that they were missing from the mapping entirely.

## Screenshots / Demo Video

### Before
<img width="920" alt="image" src="https://github.com/user-attachments/assets/d387e5d5-4741-4312-9a1f-5f316d1cb9e2" />

### After
<img width="923" alt="image" src="https://github.com/user-attachments/assets/ffa669d1-73b6-4937-a4f6-c3400a006706" />


## Testing

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [ ] Provided ticket and description
- [ ] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers