### PR TITLE
Fix: Allow API tasks to publish to arpa_exporter queue

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -521,6 +521,20 @@ module "arpa_exporter" {
   postgres_enabled = false
 }
 
+data "aws_iam_policy_document" "publish_to_arpa_exporter_queue" {
+  statement {
+    sid       = "AllowPublishToQueue"
+    actions   = ["sqs:SendMessage"]
+    resources = [module.arpa_exporter.sqs_queue_arn]
+  }
+}
+
+resource "aws_iam_role_policy" "api_task-publish_to_arpa_exporter_queue" {
+  name_prefix = "send-arpa-audit-report-requests"
+  role        = module.api.ecs_task_role_name
+  policy      = data.aws_iam_policy_document.publish_to_arpa_exporter_queue.json
+}
+
 module "postgres" {
   enabled                  = var.postgres_enabled
   source                   = "./modules/gost_postgres"


### PR DESCRIPTION
### Ticket #3908
## Description

Fixes an issue where the gost API tasks in ECS fargate don't have permission to publish to the `arpa_exporter` SQS queue, which prevents them from kicking off full file export tasks.

[Example error log in datadog.](https://app.datadoghq.com/logs?query=status%3Aerror&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AwAAAZUqVCI5zZEghAAAABhBWlVxVkRJMEFBQnpwbGdaZkxKRUZBQUQAAAAkMDE5NTJhNTQtNDNlMy00YzYyLWJjNWMtM2Q5MGE5ZjczZGU0AAAABw&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1740171040691&to_ts=1740171940691&live=true)