### PR TITLE
fix: ensure that we are using the correct digest for the arpa exporter image url

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -71,7 +71,7 @@ jobs:
       server-image: "${{ github.sha }}@${{ needs.build.outputs.server-image-digest }}"
       website-artifacts-key: ${{ needs.build.outputs.website-artifacts-key }}
       website-artifacts-path: ${{ needs.build.outputs.website-artifacts-path }}
-      arpa-exporter-image: "${{ github.sha }}@${{ needs.build.outputs.server-image-digest }}"
+      arpa-exporter-image: "${{ github.sha }}@${{ needs.build.outputs.arpa-exporter-image-digest }}"
       aws-region: us-west-2
       environment-key: staging
       tf-backend-config-file: staging.s3.tfbackend


### PR DESCRIPTION
### Ticket #3910
## Description
This PR fixes the following error
```
Stopped reason
CannotPullContainerError: pull image manifest has been retried 1 time(s): failed to resolve ref ghcr.io/usdigitalresponse/usdr-gost-arpa-exporter:9f3f04ba74d338f28372c252c68e0e2eb8a65185@sha256:cca4a767de7ae6d33db8dcc9bb0452db96d042327c37a85515fe8612881477f7: ghcr.io/usdigitalresponse/usdr-gost-arpa-exporter:9f3f04ba74d338f28372c252c68e0e2eb8a65185@sha256:cca4a767de7ae6d33db8dcc9bb0452db96d042327c37a85515fe8612881477f7: not found
Stopped: 22 minutes ago
```

## Screenshots / Demo Video

## Testing

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [ ] Provided ticket and description
- [ ] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers