### PR TITLE
fix: ensure arpa exporter task is able to list objects within audit-reports bucket

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -282,6 +282,16 @@ data "aws_iam_policy_document" "arpa_audit_report_rw_reports_bucket" {
   }
 }
 
+data "aws_iam_policy_document" "arpa_audit_report_list_bucket" {
+  statement {
+    sid = "ListBucketObjects"
+    actions = [
+      "s3:ListBucket",
+    ]
+    resources = [module.api.arpa_audit_reports_bucket_arn]
+  }
+}
+
 module "arpa_audit_report" {
   source                   = "./modules/sqs_consumer_task"
   namespace                = "${var.namespace}-arpa_audit_report"
@@ -318,8 +328,9 @@ module "arpa_audit_report" {
     access_point_id = module.api.efs_data_volume_access_point_id
   }]
   additional_task_role_json_policies = {
-    rw-audit-reports-bucket = data.aws_iam_policy_document.arpa_audit_report_rw_reports_bucket.json
-    send-emails             = module.api.send_emails_policy_json
+    list-audit-reports-bucket = data.aws_iam_policy_document.arpa_audit_report_list_bucket.json
+    rw-audit-reports-bucket   = data.aws_iam_policy_document.arpa_audit_report_rw_reports_bucket.json
+    send-emails               = module.api.send_emails_policy_json
   }
 
   # Task resource configuration


### PR DESCRIPTION
### Ticket #3910
## Description
- While testing the arpa exporter functionality in staging I noticed the following error.
```
"parsed_response": "\"{'Error': {'Code': '403', 'Message': 'Forbidden'}, 'ResponseMetadata': {'Request\"+439", "error_info": "{'Code': '403', 'Message': 'Forbidden'}", "error_code": "'403'", "error_class": "<class 'botocore.exceptions.ClientError'>"}}]}], "msg": "error downloading S3 object"}
```

This PR fixes the above error.

## Screenshots / Demo Video
N/A

## Testing
N/A

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [ ] Provided ticket and description
- [ ] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers