### PR TITLE
Fix: allow `HeadObject` to report bucket on ARPA tasks

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -319,8 +319,8 @@ module "arpa_audit_report" {
     access_point_id = module.api.efs_data_volume_access_point_id
   }]
   additional_task_role_json_policies = {
-    rw-audit-reports-bucket   = data.aws_iam_policy_document.arpa_audit_report_rw_reports_bucket.json
-    send-emails               = module.api.send_emails_policy_json
+    rw-audit-reports-bucket = data.aws_iam_policy_document.arpa_audit_report_rw_reports_bucket.json
+    send-emails             = module.api.send_emails_policy_json
   }
 
   # Task resource configuration

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -276,6 +276,7 @@ data "aws_iam_policy_document" "arpa_audit_report_rw_reports_bucket" {
     sid = "ReadWriteBucketObjects"
     actions = [
       "s3:GetObject",
+      "s3:HeadObject",
       "s3:PutObject",
     ]
     resources = ["${module.api.arpa_audit_reports_bucket_arn}/*"]

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -283,16 +283,6 @@ data "aws_iam_policy_document" "arpa_audit_report_rw_reports_bucket" {
   }
 }
 
-data "aws_iam_policy_document" "arpa_audit_report_list_bucket" {
-  statement {
-    sid = "ListBucketObjects"
-    actions = [
-      "s3:ListBucket",
-    ]
-    resources = [module.api.arpa_audit_reports_bucket_arn]
-  }
-}
-
 module "arpa_audit_report" {
   source                   = "./modules/sqs_consumer_task"
   namespace                = "${var.namespace}-arpa_audit_report"
@@ -329,7 +319,6 @@ module "arpa_audit_report" {
     access_point_id = module.api.efs_data_volume_access_point_id
   }]
   additional_task_role_json_policies = {
-    list-audit-reports-bucket = data.aws_iam_policy_document.arpa_audit_report_list_bucket.json
     rw-audit-reports-bucket   = data.aws_iam_policy_document.arpa_audit_report_rw_reports_bucket.json
     send-emails               = module.api.send_emails_policy_json
   }


### PR DESCRIPTION
## Description

This PR reverts 166f981f4fa5a31aa78f3d7c3c5af79e54a0398a and adjusts the `arpa_audit_report_rw_reports_bucket` policy document to add `HeadObject` permissions for the audit report bucket. This is intended to fix a permissions issue encountered by FFE tasks:
```
botocore.exceptions.ClientError: An error occurred (403) when calling the HeadObject operation: Forbidden
```