### PR TITLE
Allow ARPA Exporter tasks to ListBucket

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -283,6 +283,16 @@ data "aws_iam_policy_document" "arpa_audit_report_rw_reports_bucket" {
   }
 }
 
+data "aws_iam_policy_document" "arpa_audit_report_list_bucket" {
+  statement {
+    sid = "ListBucketObjects"
+    actions = [
+      "s3:ListBucket",
+    ]
+    resources = [module.api.arpa_audit_reports_bucket_arn]
+  }
+}
+
 module "arpa_audit_report" {
   source                   = "./modules/sqs_consumer_task"
   namespace                = "${var.namespace}-arpa_audit_report"
@@ -491,8 +501,9 @@ module "arpa_exporter" {
     access_point_id = module.api.efs_data_volume_access_point_id
   }]
   additional_task_role_json_policies = {
-    rw-audit-reports-bucket = data.aws_iam_policy_document.arpa_audit_report_rw_reports_bucket.json
-    send-emails             = module.api.send_emails_policy_json
+    list-audit-reports-bucket = data.aws_iam_policy_document.arpa_audit_report_list_bucket.json
+    rw-audit-reports-bucket   = data.aws_iam_policy_document.arpa_audit_report_rw_reports_bucket.json
+    send-emails               = module.api.send_emails_policy_json
   }
 
   # Task resource configuration


### PR DESCRIPTION
## Description

This PR adds `ListBucket` permissions on the audit report bucket to FFE tasks. It's intended (along with the previous addition of `HeadObject` permissions in #4040) to fix the "Forbidden" error that these tasks are getting when running `download_fileobj()`.