### PR TITLE
fix: upload file path definition

### DIFF
--- a/arpa-exporter/src/worker.py
+++ b/arpa-exporter/src/worker.py
@@ -28,7 +28,6 @@ if typing.TYPE_CHECKING:  # pragma: nocover
 TASK_QUEUE_URL = os.environ["TASK_QUEUE_URL"]
 TASK_QUEUE_RECEIVE_TIMEOUT = int(os.getenv("TASK_QUEUE_RECEIVE_TIMEOUT", 20))
 DATA_DIR = os.environ["DATA_DIR"]
-METADATA_DIR = os.path.join(DATA_DIR, "archive_metadata")
 DOWNLOAD_URL_EXPIRATION_SECONDS = int(datetime.timedelta(hours=24).total_seconds())
 API_DOMAIN = os.environ["API_DOMAIN"]
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -486,7 +486,7 @@ module "arpa_exporter" {
   consumer_container_environment = {
     API_DOMAIN                    = "https://${local.api_domain_name}"
     ARPA_DATA_EXPORT_BUCKET       = module.api.arpa_audit_reports_bucket_id
-    DATA_DIR                      = "/var/data"
+    DATA_DIR                      = "/var/data/uploads"
     LOG_LEVEL                     = "INFO"
     NOTIFICATIONS_EMAIL           = "grants-notifications@${var.website_domain_name}"
     SES_CONFIGURATION_SET_DEFAULT = aws_sesv2_configuration_set.default.configuration_set_name


### PR DESCRIPTION
### Ticket #3910 
## Description
- The data directory is supposed to be `/var/data/uploads` however, the task was looking for files within `/var/data` instead.
- This PR updates this `DATA_DIR` variable definition.

## Screenshots / Demo Video

## Testing

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [ ] Provided ticket and description
- [ ] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers