### PR TITLE
fix: ensure s3 put-object has the correct encryption specified

### DIFF
--- a/arpa-exporter/src/worker.py
+++ b/arpa-exporter/src/worker.py
@@ -311,7 +311,7 @@ def process_sqs_message_request(
     if zip_has_updates:
         try:
             local_file.seek(0)
-            s3.upload_fileobj(local_file, s3_bucket, s3_key)
+            s3.upload_fileobj(local_file, s3_bucket, s3_key, ExtraArgs={"ServerSideEncryption": "AES256"})
             logger.info("zip file uploaded to s3")
         except:
             logger.exception("error uploading zip archive to s3")


### PR DESCRIPTION
### Ticket #3910
## Description
Fixes error:
```
botocore.exceptions.ClientError: An error occurred (AccessDenied) when calling the PutObject operation: User: arn:aws:sts::357150818708:assumed-role/gost-staging-arpa_exporter-Task-20250221195902062300000003/c2595ec184cb4eb19b3ccb00f671b778 is not authorized to perform: s3:PutObject on resource: "arn:aws:s3:::gost-staging-arpaauditreports-357150818708-us-west-2-api/full-file-export/org_13/archive.zip" with an explicit deny in a resource-based policy
```

## Screenshots / Demo Video

## Testing

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [ ] Provided ticket and description
- [ ] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers