### PR TITLE
fix: ensure that the file-export keys are consistent

### DIFF
--- a/packages/server/__tests__/arpa_reporter/server/routes/exports.spec.js
+++ b/packages/server/__tests__/arpa_reporter/server/routes/exports.spec.js
@@ -215,7 +215,7 @@ describe('/api/exports', () => {
             expect(response.status).to.equal(302);
             expect(response.headers.location).to.equal(signedUrl);
             expect(getSignedUrlFake.calledOnce).to.be.true;
-            expect(getSignedUrlFake.lastCall.args[1].input.Key).to.equal('fullFileExport/0/archive.zip');
+            expect(getSignedUrlFake.lastCall.args[1].input.Key).to.equal('full-file-export/org_0/archive.zip');
             expect(getSignedUrlFake.lastCall.args[1].input.Bucket).to.equal(process.env.AUDIT_REPORT_BUCKET);
             expect(getSignedUrlFake.lastCall.args[1].input.ResponseContentDisposition).to.equal(
                 'attachment; filename="FullFileExport-01.02.2025.03.04.05.zip"',
@@ -238,7 +238,7 @@ describe('/api/exports', () => {
             expect(response.status).to.equal(302);
             expect(response.headers.location).to.equal(signedUrl);
             expect(getSignedUrlFake.calledOnce).to.be.true;
-            expect(getSignedUrlFake.lastCall.args[1].input.Key).to.equal('fullFileExport/0/archive_metadata.csv');
+            expect(getSignedUrlFake.lastCall.args[1].input.Key).to.equal('full-file-export/org_0/metadata.csv');
             expect(getSignedUrlFake.lastCall.args[1].input.Bucket).to.equal(process.env.AUDIT_REPORT_BUCKET);
             expect(getSignedUrlFake.lastCall.args[1].input.ResponseContentDisposition).to.equal(
                 'attachment; filename="FullFileExportMetadata-01.02.2025.03.04.05.csv"',

--- a/packages/server/__tests__/arpa_reporter/server/services/full-file-export.spec.js
+++ b/packages/server/__tests__/arpa_reporter/server/services/full-file-export.spec.js
@@ -138,7 +138,6 @@ abcdef,Approved File.xlsm,/Quarter 1/Approved File_abcdef.xlsm,Agency 1,99.1,Qua
         expect(uploadFake.send.calledOnce).to.equal(true);
         const command = uploadFake.send.firstCall.firstArg.input;
         expect(command.Key).to.equal(s3Key);
-        expect(command.ContentType).to.equal('text/plain');
         expect(command.Bucket).to.equal(process.env.AUDIT_REPORT_BUCKET);
         expect(command.Body.toString()).to.equal(expectedCSV);
         expect(command.ServerSideEncryption).to.equal('AES256');

--- a/packages/server/src/arpa_reporter/routes/exports.js
+++ b/packages/server/src/arpa_reporter/routes/exports.js
@@ -128,8 +128,8 @@ router.get('/getFullFileExport/:downloadType(archive|metadata)', requireUser, as
     const { downloadType } = req.params;
     let logger = req.log.child({ S3Bucket: process.env.AUDIT_REPORT_BUCKET, downloadType });
 
-    const archiveS3Key = `fullFileExport/${user.tenant_id}/archive.zip`;
-    const metadataS3Key = `fullFileExport/${user.tenant_id}/archive_metadata.csv`;
+    const archiveS3Key = fullFileExport.zipFileKey(user.tenant_id);
+    const metadataS3Key = fullFileExport.metadataFileKey(user.tenant_id);
     let downloadS3Key;
     let downloadFilenameBase;
     let downloadExtension;

--- a/packages/server/src/arpa_reporter/services/full-file-export.js
+++ b/packages/server/src/arpa_reporter/services/full-file-export.js
@@ -4,7 +4,7 @@ const knex = require('../../db/connection');
 const aws = require('../../lib/gost-aws');
 const { log } = require('../../lib/logging');
 
-const metadataFsName = (organizationId) => `full-file-export/org_${organizationId}/metadata.csv`;
+const metadataFileKey = (organizationId) => `full-file-export/org_${organizationId}/metadata.csv`;
 const zipFileKey = (organizationId) => `full-file-export/org_${organizationId}/archive.zip`;
 
 async function getUploadsForArchive(organizationId) {
@@ -70,7 +70,6 @@ async function generateAndUploadMetadata(organizationId, s3Key, logger = log) {
         Bucket: process.env.AUDIT_REPORT_BUCKET,
         Key: s3Key,
         Body: Buffer.from(data),
-        ContentType: 'text/plain',
         ServerSideEncryption: 'AES256',
     };
 
@@ -86,7 +85,7 @@ async function generateAndUploadMetadata(organizationId, s3Key, logger = log) {
 
 async function addMessageToQueue(organizationId, email, logger = log) {
     const archiveKey = zipFileKey(organizationId);
-    const metadataKey = metadataFsName(organizationId);
+    const metadataKey = metadataFileKey(organizationId);
     logger.child({ archiveKey, metadataKey });
 
     await module.exports.generateAndUploadMetadata(organizationId, metadataKey, logger);
@@ -116,4 +115,6 @@ module.exports = {
     addMessageToQueue,
     getUploadsForArchive,
     generateAndUploadMetadata,
+    metadataFileKey,
+    zipFileKey,
 };


### PR DESCRIPTION
### Ticket #3910 
## Description
- The s3-key used by the endpoint to get signed URL is using a different key than the one used by the python-task.
- This PR ensures that all keys are consistent.


## Screenshots / Demo Video

## Testing

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [ ] Provided ticket and description
- [ ] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers