### PR TITLE
fix: add arpa-exporter-image details to prod

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -76,6 +76,7 @@ jobs:
       server-image: "${{ github.sha }}@${{ needs.build.outputs.server-image-digest }}"
       website-artifacts-key: ${{ needs.build.outputs.website-artifacts-key }}
       website-artifacts-path: ${{ needs.build.outputs.website-artifacts-path }}
+      arpa-exporter-image: "${{ github.sha }}@${{ needs.build.outputs.arpa-exporter-image-digest }}"
       aws-region: us-west-2
       environment-key: production
       tf-backend-config-file: prod.s3.tfbackend

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -177,23 +177,32 @@ jobs:
         with:
           name: ${{ needs.build.outputs.website-artifacts-key }}
           path: ${{ needs.build.outputs.website-artifacts-path }}
-      - name: Download docker build attestation artifacts
+      - name: Download docker server image build attestation artifacts
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           name: ${{ needs.build.outputs.server-attestation-artifacts-key }}
           path: ${{ needs.build.outputs.server-attestation-artifacts-path }}
+      - name: Download docker arpa-exporter build attestation artifacts
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        with:
+          name: ${{ needs.build.outputs.arpa-exporter-attestation-artifacts-key }}
+          path: ${{ needs.build.outputs.arpa-exporter-attestation-artifacts-path }}
       - name: Upload release assets
         run: |
           WEBSITE_TAR_FILE="client-dist.tar.gz"
           tar -czf "$WEBSITE_TAR_FILE" -C $(dirname "$WEBSITE_DIST_PATH") ./dist
           gh release upload --clobber "$RELEASE_TAG" \
             "$WEBSITE_TAR_FILE#Client website bundle" \
-            "$PROVENANCE_FILE#Server Docker image provenance attestations" \
-            "$SBOM_FILE#Server Docker image SBOM attestations"
+            "$SERVER_PROVENANCE_FILE#Server Docker image provenance attestations" \
+            "$SERVER_SBOM_FILE#Server Docker image SBOM attestations" \
+            "$ARPA_EXPORTER_PROVENANCE_FILE#Full File Export Docker image provenance attestations" \
+            "$ARPA_EXPORTER_SBOM_FILE#Full File Export image SBOM attestations" \
         env:
           WEBSITE_DIST_PATH: ${{ needs.build.outputs.website-artifacts-path }}
-          PROVENANCE_FILE: ${{ needs.build.outputs.server-attestation-artifacts-path }}/provenance.json
-          SBOM_FILE: ${{ needs.build.outputs.server-attestation-artifacts-path }}/sbom.sdpx.json
+          SERVER_PROVENANCE_FILE: ${{ needs.build.outputs.server-attestation-artifacts-path }}/provenance.json
+          SERVER_SBOM_FILE: ${{ needs.build.outputs.server-attestation-artifacts-path }}/sbom.sdpx.json
+          ARPA_EXPORTER_PROVENANCE_FILE: ${{ needs.build.outputs.arpa-exporter-attestation-artifacts-path }}/provenance.json
+          ARPA_EXPORTER_SBOM_FILE: ${{ needs.build.outputs.arpa-exporter-attestation-artifacts-path }}/sbom.sdpx.json
       - name: Get release notes
         id: get
         continue-on-error: true

--- a/terraform/datadog_monitors.tf
+++ b/terraform/datadog_monitors.tf
@@ -106,3 +106,35 @@ resource "datadog_monitor" "arpa_treasury_report-task_failed" {
   evaluation_delay = local.dd_monitor_default_evaluation_delay
   tags             = local.dd_monitor_default_tags
 }
+
+resource "datadog_monitor" "arpa_exporter-task_failed" {
+  count = var.datadog_monitors_enabled ? 1 : 0
+
+  name = "${local.dd_monitor_name_prefix}: ARPA Full File Export job failed"
+  type = "metric alert"
+  message = join("\n", [
+    "{{#is_alert}}",
+    "Alert: One or more ARPA Full File Export requests were received from the SQS source queue but several attempts to handle them have failed.",
+    "As a result, failing SQS messages have been redirected to the SQS dead-letter queue (DLQ).",
+    "Investigate the issue (especially by checking arpa_exporter ECS task logs).",
+    "Once the issue is resolved, redrive the DLQ messages back to the source queue and/or delete DLQ messages if they are no longer needed.",
+    "This monitor will not return to normal while there are messages in the DLQ.",
+    "IMPORTANT: DLQ messages are not retained indefinitely; investigation and remediation is time-sensitive.",
+    "{{/is_alert}}",
+    "{{#is_recovery}}",
+    "Recovery: There are no longer messages in the DLQ.",
+    "{{/is_recovery}}",
+    "Notify: ${local.dd_monitor_default_notify}",
+  ])
+
+  query = join("", [
+    "min(last_1h):avg:",
+    "aws.sqs.approximate_number_of_messages_visible",
+    "{env:${var.env},queuename:${module.arpa_exporter.sqs_dlq_name}}",
+    " > 0"
+  ])
+
+  notify_no_data   = false
+  evaluation_delay = local.dd_monitor_default_evaluation_delay
+  tags             = local.dd_monitor_default_tags
+}


### PR DESCRIPTION
### Ticket #3910 
## Description
- Full File export is not getting kicked-off in production due to the following error:
```
Stopped reason
InternalError: failed to create container model: failed to normalize image reference "ghcr.io/usdigitalresponse/usdr-gost-arpa-exporter:". Launch a new task to retry.
Stopped: 37 minutes ago
```

The issue is the image reference is incorrect. This PR updates that reference.

## Screenshots / Demo Video

## Testing

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [ ] Provided ticket and description
- [ ] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers