### PR TITLE
Fix: Ensure release artifacts have unique filenames

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -190,10 +190,10 @@ jobs:
       - name: Ensure attestation artifacts have unique (base) filenames
         # Uploads with conflicting filenames are rejected by GitHub with a 404 response
         run: |
-          mv "$SERVER_PATH/provenance.json" "$SERVER_PATH/server.provenance.json"
-          mv "$SERVER_PATH/sbom.sdpx.json" "$SERVER_PATH/server.sbom.sdpx.json"
-          mv "$ARPA_EXPORTER_PATH/provenance.json" "$ARPA_EXPORTER_PATH/arpa-exporter.provenance.json"
-          mv "$ARPA_EXPORTER_PATH/sbom.sdpx.json" "$ARPA_EXPORTER_PATH/arpa-exporter.sbom.sdpx.json"
+          mv "$SERVER_PATH/provenance.json" "$SERVER_PATH/usdr-gost-api.provenance.json"
+          mv "$SERVER_PATH/sbom.sdpx.json" "$SERVER_PATH/usdr-gost-api.sbom.sdpx.json"
+          mv "$ARPA_EXPORTER_PATH/provenance.json" "$ARPA_EXPORTER_PATH/usdr-gost-arpa-exporter.provenance.json"
+          mv "$ARPA_EXPORTER_PATH/sbom.sdpx.json" "$ARPA_EXPORTER_PATH/usdr-gost-arpa-exporter.sbom.sdpx.json"
         env:
           SERVER_PATH: ${{ needs.build.outputs.server-attestation-artifacts-path }}
           ARPA_EXPORTER_PATH: ${{ needs.build.outputs.arpa-exporter-attestation-artifacts-path }}

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -187,6 +187,16 @@ jobs:
         with:
           name: ${{ needs.build.outputs.arpa-exporter-attestation-artifacts-key }}
           path: ${{ needs.build.outputs.arpa-exporter-attestation-artifacts-path }}
+      - name: Ensure attestation artifacts have unique (base) filenames
+        # Uploads with conflicting filenames are rejected by GitHub with a 404 response
+        run: |
+          mv "$SERVER_PATH/provenance.json" "$SERVER_PATH/server.provenance.json"
+          mv "$SERVER_PATH/sbom.sdpx.json" "$SERVER_PATH/server.sbom.sdpx.json"
+          mv "$ARPA_EXPORTER_PATH/provenance.json" "$ARPA_EXPORTER_PATH/arpa-exporter.provenance.json"
+          mv "$ARPA_EXPORTER_PATH/sbom.sdpx.json" "$ARPA_EXPORTER_PATH/arpa-exporter.sbom.sdpx.json"
+        env:
+          SERVER_PATH: ${{ needs.build.outputs.server-attestation-artifacts-path }}
+          ARPA_EXPORTER_PATH: ${{ needs.build.outputs.arpa-exporter-attestation-artifacts-path }}
       - name: Upload release assets
         run: |
           WEBSITE_TAR_FILE="client-dist.tar.gz"
@@ -199,10 +209,10 @@ jobs:
             "$ARPA_EXPORTER_SBOM_FILE#Full File Export image SBOM attestations"
         env:
           WEBSITE_DIST_PATH: ${{ needs.build.outputs.website-artifacts-path }}
-          SERVER_PROVENANCE_FILE: ${{ needs.build.outputs.server-attestation-artifacts-path }}/provenance.json
-          SERVER_SBOM_FILE: ${{ needs.build.outputs.server-attestation-artifacts-path }}/sbom.sdpx.json
-          ARPA_EXPORTER_PROVENANCE_FILE: ${{ needs.build.outputs.arpa-exporter-attestation-artifacts-path }}/provenance.json
-          ARPA_EXPORTER_SBOM_FILE: ${{ needs.build.outputs.arpa-exporter-attestation-artifacts-path }}/sbom.sdpx.json
+          SERVER_PROVENANCE_FILE: ${{ needs.build.outputs.server-attestation-artifacts-path }}/server.provenance.json
+          SERVER_SBOM_FILE: ${{ needs.build.outputs.server-attestation-artifacts-path }}/server.sbom.sdpx.json
+          ARPA_EXPORTER_PROVENANCE_FILE: ${{ needs.build.outputs.arpa-exporter-attestation-artifacts-path }}/arpa-exporter.provenance.json
+          ARPA_EXPORTER_SBOM_FILE: ${{ needs.build.outputs.arpa-exporter-attestation-artifacts-path }}/arpa-exporter.sbom.sdpx.json
       - name: Get release notes
         id: get
         continue-on-error: true

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -209,10 +209,10 @@ jobs:
             "$ARPA_EXPORTER_SBOM_FILE#Full File Export image SBOM attestations"
         env:
           WEBSITE_DIST_PATH: ${{ needs.build.outputs.website-artifacts-path }}
-          SERVER_PROVENANCE_FILE: ${{ needs.build.outputs.server-attestation-artifacts-path }}/server.provenance.json
-          SERVER_SBOM_FILE: ${{ needs.build.outputs.server-attestation-artifacts-path }}/server.sbom.sdpx.json
-          ARPA_EXPORTER_PROVENANCE_FILE: ${{ needs.build.outputs.arpa-exporter-attestation-artifacts-path }}/arpa-exporter.provenance.json
-          ARPA_EXPORTER_SBOM_FILE: ${{ needs.build.outputs.arpa-exporter-attestation-artifacts-path }}/arpa-exporter.sbom.sdpx.json
+          SERVER_PROVENANCE_FILE: ${{ needs.build.outputs.server-attestation-artifacts-path }}/usdr-gost-api.provenance.json
+          SERVER_SBOM_FILE: ${{ needs.build.outputs.server-attestation-artifacts-path }}/usdr-gost-api.sbom.sdpx.json
+          ARPA_EXPORTER_PROVENANCE_FILE: ${{ needs.build.outputs.arpa-exporter-attestation-artifacts-path }}/usdr-gost-arpa-exporter.provenance.json
+          ARPA_EXPORTER_SBOM_FILE: ${{ needs.build.outputs.arpa-exporter-attestation-artifacts-path }}/usdr-gost-arpa-exporter.sbom.sdpx.json
       - name: Get release notes
         id: get
         continue-on-error: true


### PR DESCRIPTION
## Description

This issue fixes a bug that is [currently](https://github.com/usdigitalresponse/usdr-gost/actions/runs/13571210991/job/37937042995) causing our [Deploy to Production](https://github.com/usdigitalresponse/usdr-gost/actions/workflows/deploy-production.yml) workflows to fail during the "Update release" job. Although the deployment is successful, this final step (which uploads and associates artifacts with the GitHub release) fails because the base names of the artifacts are not unique (although they are located in unique directories in the GitHub Actions runner, so the naming clash is only related to the upload). The bug was introduced in #4049 due to the inclusion of artifacts for `usdr-gost-arpa-exporter` Docker images, which currently have the same filenames as the `usdr-gost-api` ("server") image. Confusingly, the [error](https://github.com/usdigitalresponse/usdr-gost/actions/runs/13571210991/job/37937042995#step:8:1) this produced manifested as a 404 response from the GitHub API. 

Thankfully, the fix is straightforward: we simply rename the build artifacts during the "Update release" job before they are uploaded to GitHub. The new naming convention prefixes the name of the artifact (as produced during builds) with the name of the Docker image they are associated with, e.g. `usdr-gost-api.provenance.json` for the JSON provenance file associated with the `usdr-gost-api` Docker image. 