### PR TITLE
Fix regression in release-drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -19,6 +19,7 @@ tag-prefix: 'release/'
 version-resolver:
   default: minor
 prerelease: true
+include-pre-releases: true
 categories:
   - title: 🚀 New features and enhancements
     collapse-after: 10


### PR DESCRIPTION
## Description

This PR fixes the regression introduced in https://github.com/release-drafter/release-drafter v6.1.0. See [this issue](https://github.com/release-drafter/release-drafter/issues/1425) for more information on the nature of the problem.

Specifically, this PR resolves the problems we've been having with duplicate draft pre-releases being created when commits are pushed to `main`.