### PR TITLE
Fix duplicate entries in FFE zipfiles

### DIFF
--- a/arpa-exporter/src/lib/logging.py
+++ b/arpa-exporter/src/lib/logging.py
@@ -23,7 +23,7 @@ shared_processors: List[Callable] = [
 ]
 
 processors: List[Callable] = shared_processors + []
-if sys.stderr.isatty():
+if sys.stderr.isatty():  # pragma: nocover
     processors += [
         structlog.dev.ConsoleRenderer(),
     ]

--- a/arpa-exporter/src/worker.py
+++ b/arpa-exporter/src/worker.py
@@ -324,7 +324,12 @@ def process_sqs_message_request(
     if zip_has_updates:
         try:
             local_file.seek(0)
-            s3.upload_fileobj(local_file, s3_bucket, s3_key, ExtraArgs={"ServerSideEncryption": "AES256"})
+            s3.upload_fileobj(
+                local_file,
+                s3_bucket,
+                s3_key,
+                ExtraArgs={"ServerSideEncryption": "AES256"},
+            )
             logger.info("zip file uploaded to s3")
         except:
             logger.exception("error uploading zip archive to s3")

--- a/arpa-exporter/tests/conftest.py
+++ b/arpa-exporter/tests/conftest.py
@@ -7,6 +7,7 @@ import moto.ses
 import moto.ses.models
 import pytest
 
+os.environ.setdefault("DD_TRACE_ENABLED", "false")
 os.environ.setdefault("TASK_QUEUE_URL", "https://example.com/queue")
 os.environ.setdefault("TASK_QUEUE_RECEIVE_TIMEOUT", "1")
 os.environ.setdefault(

--- a/packages/server/__tests__/arpa_reporter/server/services/full-file-export.spec.js
+++ b/packages/server/__tests__/arpa_reporter/server/services/full-file-export.spec.js
@@ -69,7 +69,7 @@ describe('FullFileExport', () => {
                 upload_id: '00000000-0000-0000-0000-000000000000',
                 original_filename: 'test-filename-1.xlsm',
                 filename_in_zip: 'test-filename-1--00000000-0000-0000-0000-000000000000.xlsm',
-                path_in_zip: '/Quarterly 1/Final Treasury/test-filename-1--00000000-0000-0000-0000-000000000000.xlsm',
+                path_in_zip: 'Quarterly 1/Final Treasury/test-filename-1--00000000-0000-0000-0000-000000000000.xlsm',
                 agency_name: 'State Board of Accountancy',
                 ec_code: 'EC1.1',
                 reporting_period_name: 'Quarterly 1',
@@ -79,7 +79,7 @@ describe('FullFileExport', () => {
                 upload_id: '00000000-0000-0000-0000-000000000098',
                 original_filename: '1.134 Signed Off Report. ARPA Projects.xls',
                 filename_in_zip: '1.134 Signed Off Report. ARPA Projects--00000000-0000-0000-0000-000000000098.xls',
-                path_in_zip: '/Quarterly 1/Final Treasury/1.134 Signed Off Report. ARPA Projects--00000000-0000-0000-0000-000000000098.xls',
+                path_in_zip: 'Quarterly 1/Final Treasury/1.134 Signed Off Report. ARPA Projects--00000000-0000-0000-0000-000000000098.xls',
                 agency_name: 'State Board of Accountancy',
                 ec_code: 'EC1.134',
                 reporting_period_name: 'Quarterly 1',
@@ -89,7 +89,7 @@ describe('FullFileExport', () => {
                 upload_id: '00000000-0000-0000-0000-000000000099',
                 original_filename: '1.1456 Report XLSX Type Example.xlsx',
                 filename_in_zip: '1.1456 Report XLSX Type Example--00000000-0000-0000-0000-000000000099.xlsx',
-                path_in_zip: '/Quarterly 1/Final Treasury/1.1456 Report XLSX Type Example--00000000-0000-0000-0000-000000000099.xlsx',
+                path_in_zip: 'Quarterly 1/Final Treasury/1.1456 Report XLSX Type Example--00000000-0000-0000-0000-000000000099.xlsx',
                 agency_name: 'State Board of Accountancy',
                 ec_code: 'EC1.1456',
                 reporting_period_name: 'Quarterly 1',
@@ -100,7 +100,7 @@ describe('FullFileExport', () => {
                 upload_id: '00000000-0000-0000-0000-000000000001',
                 original_filename: 'test-filename-2.xlsm',
                 filename_in_zip: 'test-filename-2--00000000-0000-0000-0000-000000000001.xlsm',
-                path_in_zip: '/Quarterly 1/Not Final Treasury/Invalid files/test-filename-2--00000000-0000-0000-0000-000000000001.xlsm',
+                path_in_zip: 'Quarterly 1/Not Final Treasury/Invalid files/test-filename-2--00000000-0000-0000-0000-000000000001.xlsm',
                 agency_name: 'State Board of Accountancy',
                 ec_code: 'EC1.1',
                 reporting_period_name: 'Quarterly 1',
@@ -111,7 +111,7 @@ describe('FullFileExport', () => {
                 upload_id: '00000000-0000-0000-0000-000000000003',
                 original_filename: 'test-filename-4.xlsm',
                 filename_in_zip: 'test-filename-4--00000000-0000-0000-0000-000000000003.xlsm',
-                path_in_zip: '/Quarterly 1/Not Final Treasury/Invalid files/test-filename-4--00000000-0000-0000-0000-000000000003.xlsm',
+                path_in_zip: 'Quarterly 1/Not Final Treasury/Invalid files/test-filename-4--00000000-0000-0000-0000-000000000003.xlsm',
                 agency_name: 'State Board of Accountancy',
                 ec_code: 'EC1.1',
                 reporting_period_name: 'Quarterly 1',
@@ -122,7 +122,7 @@ describe('FullFileExport', () => {
                 upload_id: '00000000-0000-0000-0000-000000000004',
                 original_filename: 'test-filename-5.xlsm',
                 filename_in_zip: 'test-filename-5--00000000-0000-0000-0000-000000000004.xlsm',
-                path_in_zip: '/Quarterly 2/Not Final Treasury/Invalid files/test-filename-5--00000000-0000-0000-0000-000000000004.xlsm',
+                path_in_zip: 'Quarterly 2/Not Final Treasury/Invalid files/test-filename-5--00000000-0000-0000-0000-000000000004.xlsm',
                 agency_name: 'State Board of Accountancy',
                 ec_code: 'EC1.1',
                 reporting_period_name: 'Quarterly 2',
@@ -164,7 +164,7 @@ describe('FullFileExport', () => {
             {
                 upload_id: 'abcdef',
                 original_filename: 'Approved File.xlsm',
-                path_in_zip: '/Quarter 1/Approved File_abcdef.xlsm',
+                path_in_zip: 'Quarter 1/Approved File_abcdef.xlsm',
                 agency_name: 'Agency 1, with comma',
                 ec_code: '99.1',
                 reporting_period_name: 'Quarter 1, with comma',
@@ -172,7 +172,7 @@ describe('FullFileExport', () => {
             },
         ];
         const expectedCSV = `upload_id,original_filename,path_in_zip,agency_name,ec_code,reporting_period_name,validity
-abcdef,Approved File.xlsm,/Quarter 1/Approved File_abcdef.xlsm,"Agency 1, with comma",99.1,"Quarter 1, with comma",Validated on 2025-01-01 by person@example.com`;
+abcdef,Approved File.xlsm,Quarter 1/Approved File_abcdef.xlsm,"Agency 1, with comma",99.1,"Quarter 1, with comma",Validated on 2025-01-01 by person@example.com`;
 
         // stub S3 client and PutObjectCommand
         const uploadFake = sandbox.fake.returns('just s3');

--- a/packages/server/src/arpa_reporter/services/full-file-export.js
+++ b/packages/server/src/arpa_reporter/services/full-file-export.js
@@ -35,13 +35,13 @@ function getPathInZip(upload, filename_in_zip) {
     let path_in_zip = '';
 
     if (upload.invalidated_at) {
-        path_in_zip = path.join('/', upload.reporting_period_name, 'Not Final Treasury', 'Invalid files', filename_in_zip);
+        path_in_zip = path.join(upload.reporting_period_name, 'Not Final Treasury', 'Invalid files', filename_in_zip);
     } else if (upload.is_included_in_treasury_export) {
-        path_in_zip = path.join('/', upload.reporting_period_name, 'Final Treasury', filename_in_zip);
+        path_in_zip = path.join(upload.reporting_period_name, 'Final Treasury', filename_in_zip);
     } else if (upload.validated_at && !upload.is_included_in_treasury_export) {
-        path_in_zip = path.join('/', upload.reporting_period_name, 'Not Final Treasury', 'Valid files', filename_in_zip);
+        path_in_zip = path.join(upload.reporting_period_name, 'Not Final Treasury', 'Valid files', filename_in_zip);
     } else {
-        path_in_zip = path.join('/', upload.reporting_period_name, 'Not Final Treasury', 'Invalid files', filename_in_zip);
+        path_in_zip = path.join(upload.reporting_period_name, 'Not Final Treasury', 'Invalid files', filename_in_zip);
     }
 
     return path_in_zip;


### PR DESCRIPTION
## Description

This PR fixes a bug that is currently resulting in duplicate entries being created in FFE zipfiles produced by `arpa-exporter`. Currently, we attempt to avoid writing duplicate files by checking for the presence of the zip path (from CSV metadata's `path_in_zip` value) in the existing contents of the zipfile. However, Python performs some amount of normalization to these values when writing entries, so files that require normalization (i.e. are not zip-compatible) are considered missing. Since zip files allow for duplicate entries, one current problem is that subsequent runs of `arpa-exporter` will (at minimum) duplicate the size of the zip file.

In our case, this problem is manifesting because we check for absolute paths in the zipfile, but zipfiles normalize absolute paths to relative (to the root of the zipfile) when these entries are written.

The solution provided by this PR is twofold:
1. Pre-normalize zip entry paths before checking whether an entry with that path already exists, so we're comparing apples to apples. 
2. Tweak the Full File Export metadata CSV generation logic so that `path_in_zip` column values are not formatted as absolute paths (that is, we remove the leading `/` slash from these values).