### PR TITLE
FFE: Add tags and use SES config set when sending emails

### DIFF
--- a/arpa-exporter/src/lib/email.py
+++ b/arpa-exporter/src/lib/email.py
@@ -33,6 +33,7 @@ if typing.TYPE_CHECKING:  # pragma: nocover
 
 CHARSET = "UTF-8"
 TEMPLATES_DIR = os.path.abspath("src/static/email_templates")
+DEFAULT_CONFIGURATION_SET_NAME = os.getenv("SES_CONFIGURATION_SET_DEFAULT")
 NOTIFICATIONS_EMAIL = os.environ["NOTIFICATIONS_EMAIL"]
 
 
@@ -192,6 +193,10 @@ def send_email(
             },
         },
     }
+
+    if DEFAULT_CONFIGURATION_SET_NAME:
+        message["ConfigurationSetName"] = DEFAULT_CONFIGURATION_SET_NAME
+
     response = email_client.send_email(
         **tag_ses_message(message, "full_file_export", **additional_tags)
     )

--- a/arpa-exporter/src/lib/email.py
+++ b/arpa-exporter/src/lib/email.py
@@ -29,7 +29,7 @@ from ddtrace import tracer
 
 if typing.TYPE_CHECKING:  # pragma: nocover
     from mypy_boto3_ses import SESClient
-    from mypy_boto3_ses.type_defs import SendEmailRequestRequestTypeDef
+    from mypy_boto3_ses.type_defs import SendEmailRequestTypeDef
 
 CHARSET = "UTF-8"
 TEMPLATES_DIR = os.path.abspath("src/static/email_templates")
@@ -106,10 +106,10 @@ def generate_email(
 
 
 def tag_ses_message(
-    message: SendEmailRequestRequestTypeDef,
+    message: SendEmailRequestTypeDef,
     notification_type: str,
     **extra: typing.Any,
-) -> SendEmailRequestRequestTypeDef:
+) -> SendEmailRequestTypeDef:
     """Adds/updates the "Tags" param on configuration for an outgoing SES message
     with the (gost-standard) ``notification_type`` tag and any given ``extra``
     key/value pairs.
@@ -182,7 +182,7 @@ def send_email(
     Returns:
         The SES message ID generated for the outgoing email.
     """
-    message: SendEmailRequestRequestTypeDef = {
+    message: SendEmailRequestTypeDef = {
         "Source": NOTIFICATIONS_EMAIL_SENDER,
         "Destination": {"ToAddresses": [dest_email]},
         "Message": {

--- a/arpa-exporter/src/lib/email.py
+++ b/arpa-exporter/src/lib/email.py
@@ -35,6 +35,12 @@ CHARSET = "UTF-8"
 TEMPLATES_DIR = os.path.abspath("src/static/email_templates")
 DEFAULT_CONFIGURATION_SET_NAME = os.getenv("SES_CONFIGURATION_SET_DEFAULT")
 NOTIFICATIONS_EMAIL = os.environ["NOTIFICATIONS_EMAIL"]
+NOTIFICATIONS_EMAIL_DISPLAY_NAME = os.getenv(
+    "NOTIFICATIONS_EMAIL_DISPLAY_NAME", "USDR ARPA Reporter"
+)
+NOTIFICATIONS_EMAIL_SENDER = (
+    f"{NOTIFICATIONS_EMAIL_DISPLAY_NAME} <{NOTIFICATIONS_EMAIL}>"
+)
 
 
 def generate_email(
@@ -174,7 +180,7 @@ def send_email(
         The SES message ID generated for the outgoing email.
     """
     message: SendEmailRequestTypeDef = {
-        "Source": NOTIFICATIONS_EMAIL,
+        "Source": NOTIFICATIONS_EMAIL_SENDER,
         "Destination": {"ToAddresses": [dest_email]},
         "Message": {
             "Subject": {

--- a/arpa-exporter/src/lib/email.py
+++ b/arpa-exporter/src/lib/email.py
@@ -25,9 +25,11 @@ import os
 import typing
 
 import chevron
+from ddtrace import tracer
 
 if typing.TYPE_CHECKING:  # pragma: nocover
     from mypy_boto3_ses import SESClient
+    from mypy_boto3_ses.type_defs import SendEmailRequestTypeDef
 
 CHARSET = "UTF-8"
 TEMPLATES_DIR = os.path.abspath("src/static/email_templates")
@@ -96,12 +98,65 @@ def generate_email(
     return email_html, email_plaintext, subject
 
 
+def tag_ses_message(
+    message: SendEmailRequestTypeDef,
+    notification_type: str,
+    **extra: str,
+) -> SendEmailRequestTypeDef:
+    """Adds/updates the "Tags" param on configuration for an outgoing SES message
+    with the (gost-standard) ``notification_type`` tag and any given ``extra``
+    key/value pairs.
+
+    The following tags are conditionally added for observability:
+    - ``dd_trace_id`` and ``dd_span_id`` are added if a trace is active at call-time
+    - Universal service monitoring tags ``service``, ``env``, and ``version``
+        from ``DD_SERVICE``, ``DD_ENV``, and ``DD_VERSION`` environment variables,
+        respectively, as long as the corresponding env var is defined.
+
+    Notes:
+        - When a tag that is automatically added by this function has the same name
+            as a tag provided as a keyword argument in ``**extra``,
+            the value provided for the keyword argument takes precedence.
+        - The given ``message`` dict is both updated in-place and returned
+            by this function.
+
+    Args:
+        message: Configuration parameters for calling ``SESClient.send_email()``.
+        notification_type: The name of this email notification, i.e. which disambiguates
+            email events for Full-File Export emails from others sent on behalf
+            of the gost service.
+
+    Returns:
+        The config dict of parameters provided in the ``message`` argument,
+            updated with new tag definitions.
+    """
+    tags = {"notification_type": notification_type}
+    if span := tracer.current_span():
+        tags.update(dd_trace_id=span.trace_id, dd_span_id=span.span_id)
+    tags.update(
+        **{
+            k: v
+            for k, v in {
+                "service": os.getenv("DD_SERVICE"),
+                "env": os.getenv("DD_ENV"),
+                "version": os.getenv("DD_VERSION"),
+            }.items()
+            if v is not None
+        }
+    )
+    tags.update(**extra)
+    message["Tags"] = message.get("Tags", [])
+    message["Tags"] += [{"Name": k, "Value": str(v)} for k, v in tags.items()]
+    return message
+
+
 def send_email(
     email_client: SESClient,
     dest_email: str,
     email_html: str,
     email_text: str,
     subject: str,
+    additional_tags: dict[str, str] = None,
 ) -> str:
     """Sends an email to a single recipient via SES.
 
@@ -112,14 +167,15 @@ def send_email(
         email_text: Alternative plaintext content generated for the email body
             (for compatibility with recipient email clients that do not support HTML).
         subject: Subject line for the outgoing email.
+        additional_tags: Key/value pairs to add as tags on the outgoing SES email.
 
     Returns:
         The SES message ID generated for the outgoing email.
     """
-    response = email_client.send_email(
-        Source=NOTIFICATIONS_EMAIL,
-        Destination={"ToAddresses": [dest_email]},
-        Message={
+    message: SendEmailRequestTypeDef = {
+        "Source": NOTIFICATIONS_EMAIL,
+        "Destination": {"ToAddresses": [dest_email]},
+        "Message": {
             "Subject": {
                 "Charset": CHARSET,
                 "Data": subject,
@@ -135,6 +191,9 @@ def send_email(
                 },
             },
         },
+    }
+    response = email_client.send_email(
+        **tag_ses_message(message, "full_file_export", **additional_tags)
     )
     return response["MessageId"]
 

--- a/arpa-exporter/src/worker.py
+++ b/arpa-exporter/src/worker.py
@@ -255,6 +255,9 @@ def notify_user(
             email_html=email_html,
             email_text=email_text,
             subject=subject,
+            additional_tags={
+                "organization_id": user_organization_id,
+            },
         )
         logger.info("email notification sent", ses_message_id=message_id)
     except:

--- a/arpa-exporter/tests/conftest.py
+++ b/arpa-exporter/tests/conftest.py
@@ -18,6 +18,7 @@ os.environ.setdefault(
     "NOTIFICATIONS_EMAIL", "grants-notifications@usdigitalresponse.org"
 )
 os.environ.setdefault("API_DOMAIN", "https://api.example.org")
+os.environ.setdefault("SES_CONFIGURATION_SET_DEFAULT", "test-ses-configuration-set")
 
 # Configure mock AWS SDK and fixtures
 AWS_REGION = "us-west-2"

--- a/arpa-exporter/tests/src/lib/test_email.py
+++ b/arpa-exporter/tests/src/lib/test_email.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-import os
+import copy
 import typing
+from unittest import mock
 
 from src.lib import email
 
@@ -28,18 +29,75 @@ class TestEmail:
         email_text = "Test"
         subject = "Test"
         user_email = "foo@example.com"
+        additional_tags = {"test_tag": "some_value"}
 
-        message_id = email.send_email(
-            email_client=ses,
-            dest_email=user_email,
-            email_html=email_html,
-            email_text=email_text or "",
-            subject=subject or "",
-        )
+        with mock.patch(
+            "src.lib.email.tag_ses_message", wraps=email.tag_ses_message
+        ) as mock_tag_ses_message:
+            message_id = email.send_email(
+                email_client=ses,
+                dest_email=user_email,
+                email_html=email_html,
+                email_text=email_text or "",
+                subject=subject or "",
+                additional_tags=additional_tags,
+            )
 
         assert len(ses_sent_messages) == 1
         sent_message = ses_sent_messages[0]
         assert sent_message.id == message_id
         assert sent_message.body == email_html
-        assert sent_message.source == os.environ["NOTIFICATIONS_EMAIL"]
+        assert sent_message.source == email.NOTIFICATIONS_EMAIL_SENDER
         assert sent_message.destinations["ToAddresses"] == [user_email]
+        mock_tag_ses_message.assert_called_once_with(
+            mock.ANY, "full_file_export", **additional_tags
+        )
+
+    def test_tag_ses_message(self, monkeypatch):
+        test_msg = {
+            "Source": "sender@example.org",
+            "Destination": {"ToAddresses": ["recipient@example.org"]},
+            "Message": {
+                "Subject": {"Charset": "UTF-8", "Data": "testing 123"},
+                "Body": {
+                    "Html": {
+                        "Charset": "UTF-8",
+                        "Data": "<html>content</html>",
+                    },
+                    "Text": {"Charset": "UTF-8", "Data": "content"},
+                },
+            },
+        }
+        test_original_msg_copy = copy.deepcopy(test_msg)
+        for k, v in {
+            "DD_SERVICE": "my-service",
+            "DD_ENV": "testing",
+            "DD_VERSION": "test",
+        }.items():
+            monkeypatch.setenv(k, v)
+        tagged_msg = email.tag_ses_message(
+            test_msg, "some_fake_notification", **{"something": "else"}
+        )
+
+        # Ensure parameter dict was both returned and modified in-place
+        assert test_msg is tagged_msg
+
+        # Ensure expected tags were added
+        tags_result = tagged_msg["Tags"]
+        assert {"Name": "service", "Value": "my-service"} in tags_result
+        assert {"Name": "env", "Value": "testing"} in tags_result
+        assert {"Name": "version", "Value": "test"} in tags_result
+        assert {
+            "Name": "notification_type",
+            "Value": "some_fake_notification",
+        } in tags_result
+        assert {"Name": "something", "Value": "else"} in tags_result
+
+        # Ensure starting message params are unmodified
+        for expect_key, expect_val in test_original_msg_copy.items():
+            assert expect_key in tagged_msg.keys(), (
+                "message parameter unexpectedly missing after tagging"
+            )
+            assert expect_val == tagged_msg[expect_key], (
+                "message parameter value unexpectedly modified after tagging"
+            )


### PR DESCRIPTION
## Description

This PR makes a few minor improvements to Full File Export email notifications sent by `arpa-exporter` task workers, mostly aimed at bringing parity to emails sent by other (Node.js) parts of gost:
1. It adds a configurable display name to the `From` header on emails so that modern inboxes display the sender as (default) `USDR ARPA Reporter`, which matches other ARPA-related emails sent by gost.
2. SES emails are sent under the configuration set named by the `SES_CONFIGURATION_SET_DEFAULT` env varPrimarily, this ensures that SES email events for Full File Export are propagated to Datadog logs and metrics, which is also the behavior for other gost emails. 
3. SES emails are tagged so that logs and metrics can be used to debug and analyze FFE email behavior, which also allowing these them to be correlated to traces. 