### PR TITLE
Fix: updates the IAM permissions as well as report generation functionality to handle S3ServiceException

### DIFF
--- a/packages/server/__tests__/arpa_reporter/server/services/full-file-export.spec.js
+++ b/packages/server/__tests__/arpa_reporter/server/services/full-file-export.spec.js
@@ -115,7 +115,7 @@ describe('FullFileExport', () => {
         expect(command.Bucket).to.equal(process.env.AUDIT_REPORT_BUCKET);
     });
 
-    it('shouldRecreateArchive should return false if the S3 client throws an unknown error', async () => {
+    it('shouldRecreateArchive throw an error if the S3 client throws an unknown error', async () => {
         const uploads = [
             fixtures.uploads.upload1,
             fixtures.uploads.upload2,
@@ -130,8 +130,7 @@ describe('FullFileExport', () => {
         const s3Fake = sandbox.fake.returns(uploadFake);
         sandbox.replace(aws, 'getS3Client', s3Fake);
 
-        const result = await full_file_export.shouldRecreateArchive(fixtures.TENANT_ID, uploads);
-        expect(result).to.equal(false);
+        await expect(full_file_export.shouldRecreateArchive(fixtures.TENANT_ID, uploads)).to.be.rejectedWith(S3ServiceException);
 
         // Checks to make sure s3 client was called with correct parameters
         expect(uploadFake.send.calledOnce).to.equal(true);

--- a/packages/server/__tests__/arpa_reporter/server/services/full-file-export.spec.js
+++ b/packages/server/__tests__/arpa_reporter/server/services/full-file-export.spec.js
@@ -115,7 +115,7 @@ describe('FullFileExport', () => {
         expect(command.Bucket).to.equal(process.env.AUDIT_REPORT_BUCKET);
     });
 
-    it('shouldRecreateArchive raises an error if the S3 client throws an unknown error', async () => {
+    it('shouldRecreateArchive should return false if the S3 client throws an unknown error', async () => {
         const uploads = [
             fixtures.uploads.upload1,
             fixtures.uploads.upload2,
@@ -130,7 +130,8 @@ describe('FullFileExport', () => {
         const s3Fake = sandbox.fake.returns(uploadFake);
         sandbox.replace(aws, 'getS3Client', s3Fake);
 
-        await expect(full_file_export.shouldRecreateArchive(fixtures.TENANT_ID, uploads)).to.be.rejectedWith(S3ServiceException);
+        const result = await full_file_export.shouldRecreateArchive(fixtures.TENANT_ID, uploads);
+        expect(result).to.equal(false);
 
         // Checks to make sure s3 client was called with correct parameters
         expect(uploadFake.send.calledOnce).to.equal(true);

--- a/packages/server/src/arpa_reporter/services/full-file-export.js
+++ b/packages/server/src/arpa_reporter/services/full-file-export.js
@@ -1,5 +1,7 @@
 const { SendMessageCommand } = require('@aws-sdk/client-sqs');
-const { HeadObjectCommand, PutObjectCommand, NotFound } = require('@aws-sdk/client-s3');
+const {
+    HeadObjectCommand, PutObjectCommand, NotFound, S3ServiceException,
+} = require('@aws-sdk/client-s3');
 const converter = require('json-2-csv');
 const path = require('path');
 const moment = require('moment');
@@ -79,6 +81,7 @@ async function getMetadataLastModified(organizationId, logger = log) {
     const s3 = aws.getS3Client();
     const Key = metadataFileKey(organizationId);
     const baseParams = { Bucket: process.env.AUDIT_REPORT_BUCKET, Key };
+    logger.child(baseParams);
 
     let headObject;
 
@@ -89,7 +92,10 @@ async function getMetadataLastModified(organizationId, logger = log) {
             logger.info('metadata file does not exist');
             return null;
         }
-        logger.error(error, 'failed to get existing metadata file');
+        if (error instanceof S3ServiceException) {
+            logger.error(error, 'failed to get metadata file due to an exception with s3');
+            return null;
+        }
         throw error;
     }
 

--- a/packages/server/src/arpa_reporter/services/full-file-export.js
+++ b/packages/server/src/arpa_reporter/services/full-file-export.js
@@ -1,6 +1,6 @@
 const { SendMessageCommand } = require('@aws-sdk/client-sqs');
 const {
-    HeadObjectCommand, PutObjectCommand, NotFound, S3ServiceException,
+    HeadObjectCommand, PutObjectCommand, NotFound,
 } = require('@aws-sdk/client-s3');
 const converter = require('json-2-csv');
 const path = require('path');
@@ -92,10 +92,7 @@ async function getMetadataLastModified(organizationId, logger = log) {
             logger.info('metadata file does not exist');
             return null;
         }
-        if (error instanceof S3ServiceException) {
-            logger.error(error, 'failed to get metadata file due to an exception with s3');
-            return null;
-        }
+        logger.error(error, 'failed to get metadata file due to an exception with s3');
         throw error;
     }
 

--- a/terraform/modules/gost_api/storage.tf
+++ b/terraform/modules/gost_api/storage.tf
@@ -67,7 +67,6 @@ module "access_arpa_reports_bucket_policy" {
           actions = [
             "s3:PutObject",
             "s3:GetObject",
-            "s3:HeadObject",
           ]
           resources = ["${module.arpa_audit_reports_bucket.bucket_arn}/*"]
         },
@@ -82,7 +81,7 @@ module "access_arpa_reports_bucket_policy" {
             {
               test     = "StringLike"
               variable = "s3:prefix"
-              values   = ["full-file-export"]
+              values   = ["full-file-export/*"]
             }
           ]
         }

--- a/terraform/modules/gost_api/storage.tf
+++ b/terraform/modules/gost_api/storage.tf
@@ -82,7 +82,7 @@ module "access_arpa_reports_bucket_policy" {
             {
               test     = "StringLike"
               variable = "s3:prefix"
-              values   = ["full-file-export/"]
+              values   = ["full-file-export"]
             }
           ]
         }


### PR DESCRIPTION
### Ticket #4065 
## Description

This PR does the following:
1. It attempts to test out the new S3 IAM policy configuration to see if it fixes the 403 error issue.
2. It doesn't block the rest of the process of creating the file-export in the event that S3 throws an exception. The reason for this is to unblock testing the rest of the functionality while we're debugging the permissions issue.

## Screenshots / Demo Video

## Testing

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [ ] Provided ticket and description
- [ ] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers