### PR TITLE
fix: allow to pull-in uploads without an agency code

### DIFF
--- a/packages/server/__tests__/arpa_reporter/server/services/full-file-export.spec.js
+++ b/packages/server/__tests__/arpa_reporter/server/services/full-file-export.spec.js
@@ -142,6 +142,34 @@ describe('FullFileExport', () => {
     it('ensures getUploadsForArchive queries the database and returns only uploads for one tenant', async () => {
         await fixtures.seed(knex);
         const testSpecificUploads = {
+            missingAgencyUpload: {
+                filename: '1.9918 Missing Agency Name Upload.xls',
+                reporting_period_id: fixtures.reportingPeriods.q1_2021.id,
+                user_id: fixtures.users.adminUser.id,
+                agency_id: null,
+                ec_code: '1.134',
+                tenant_id: fixtures.TENANT_ID,
+                id: '00000000-0000-0000-0000-000000000096',
+                notes: null,
+                validated_at: null,
+                validated_by: null,
+                invalidated_at: '2021-07-03',
+                invalidated_by: fixtures.users.adminUser.id,
+            },
+            missingECCodeUpload: {
+                filename: '1.7829 Missing EC Code Upload.xlsx',
+                reporting_period_id: fixtures.reportingPeriods.q1_2021.id,
+                user_id: fixtures.users.adminUser.id,
+                agency_id: fixtures.agencies.accountancy.id,
+                ec_code: null,
+                tenant_id: fixtures.TENANT_ID,
+                id: '00000000-0000-0000-0000-000000000097',
+                notes: null,
+                validated_at: '2023-05-01',
+                validated_by: fixtures.users.adminUser.id,
+                invalidated_at: null,
+                invalidated_by: null,
+            },
             xlsUpload: {
                 filename: '1.134 Signed Off Report. ARPA Projects.xls',
                 reporting_period_id: fixtures.reportingPeriods.q1_2021.id,
@@ -187,6 +215,19 @@ describe('FullFileExport', () => {
                 updated_at: moment('2022-01-01').toISOString(),
                 validity: 'Validated at 2022-01-01T00:00:00 by mbroussard+unit-test-admin@usdigitalresponse.org',
             },
+            // missingECCodeUpload
+            {
+                upload_id: '00000000-0000-0000-0000-000000000097',
+                original_filename: '1.7829 Missing EC Code Upload.xlsx',
+                filename_in_zip: '1.7829 Missing EC Code Upload--00000000-0000-0000-0000-000000000097.xlsx',
+                path_in_zip: 'Quarterly 1/Final Treasury/1.7829 Missing EC Code Upload--00000000-0000-0000-0000-000000000097.xlsx',
+                agency_name: 'State Board of Accountancy',
+                ec_code: 'Missing EC code',
+                reporting_period_name: 'Quarterly 1',
+                updated_at: '2023-05-01T00:00:00.000Z',
+                validity: 'Validated at 2023-05-01T00:00:00 by mbroussard+unit-test-admin@usdigitalresponse.org',
+            },
+            // xlsUpload
             {
                 upload_id: '00000000-0000-0000-0000-000000000098',
                 original_filename: '1.134 Signed Off Report. ARPA Projects.xls',
@@ -198,6 +239,7 @@ describe('FullFileExport', () => {
                 updated_at: moment('2022-01-01').toISOString(),
                 validity: 'Validated at 2022-01-01T00:00:00 by mbroussard+unit-test-admin@usdigitalresponse.org',
             },
+            // xlsxUpload
             {
                 upload_id: '00000000-0000-0000-0000-000000000099',
                 original_filename: '1.1456 Report XLSX Type Example.xlsx',
@@ -209,17 +251,17 @@ describe('FullFileExport', () => {
                 updated_at: moment('2022-01-01').toISOString(),
                 validity: 'Validated at 2022-01-01T00:00:00 by mbroussard+unit-test-admin@usdigitalresponse.org',
             },
-            // fixtures.uploads.upload2
+            // missingAgencyUpload
             {
-                upload_id: '00000000-0000-0000-0000-000000000001',
-                original_filename: 'test-filename-2.xlsm',
-                filename_in_zip: 'test-filename-2--00000000-0000-0000-0000-000000000001.xlsm',
-                path_in_zip: 'Quarterly 1/Not Final Treasury/Invalid files/test-filename-2--00000000-0000-0000-0000-000000000001.xlsm',
-                agency_name: 'State Board of Accountancy',
-                ec_code: 'EC1.1',
+                upload_id: '00000000-0000-0000-0000-000000000096',
+                original_filename: '1.9918 Missing Agency Name Upload.xls',
+                filename_in_zip: '1.9918 Missing Agency Name Upload--00000000-0000-0000-0000-000000000096.xls',
+                path_in_zip: 'Quarterly 1/Not Final Treasury/Invalid files/1.9918 Missing Agency Name Upload--00000000-0000-0000-0000-000000000096.xls',
+                agency_name: 'Missing agency name',
+                ec_code: 'EC1.134',
                 reporting_period_name: 'Quarterly 1',
-                updated_at: moment('2023-03-01').toISOString(),
-                validity: `Did not pass validation at 2023-03-01T00:00:00 by mbroussard+unit-test-admin@usdigitalresponse.org`,
+                updated_at: '2021-07-03T00:00:00.000Z',
+                validity: 'Invalidated at 2021-07-03T00:00:00 by mbroussard+unit-test-admin@usdigitalresponse.org',
             },
             // fixtures.uploads.upload4_invalidated
             {
@@ -232,6 +274,18 @@ describe('FullFileExport', () => {
                 reporting_period_name: 'Quarterly 1',
                 updated_at: moment('2023-03-02').toISOString(),
                 validity: 'Invalidated at 2023-03-02T00:00:00 by mbroussard+unit-test-user2@usdigitalresponse.org',
+            },
+            // fixtures.uploads.upload2
+            {
+                upload_id: '00000000-0000-0000-0000-000000000001',
+                original_filename: 'test-filename-2.xlsm',
+                filename_in_zip: 'test-filename-2--00000000-0000-0000-0000-000000000001.xlsm',
+                path_in_zip: 'Quarterly 1/Not Final Treasury/Invalid files/test-filename-2--00000000-0000-0000-0000-000000000001.xlsm',
+                agency_name: 'State Board of Accountancy',
+                ec_code: 'EC1.1',
+                reporting_period_name: 'Quarterly 1',
+                updated_at: moment('2023-03-01').toISOString(),
+                validity: `Did not pass validation at 2023-03-01T00:00:00 by mbroussard+unit-test-admin@usdigitalresponse.org`,
             },
             // fixtures.uploads.upload5_new_quarter
             {

--- a/packages/server/src/arpa_reporter/services/full-file-export.js
+++ b/packages/server/src/arpa_reporter/services/full-file-export.js
@@ -60,13 +60,19 @@ async function addUploadInfo(uploads) {
         const filename_in_zip = getFilenameInZip(upload);
         const path_in_zip = getPathInZip(upload, filename_in_zip);
         const validity = getValidity(upload);
+        let ec_code;
+        if (upload.ec_code) {
+            ec_code = `EC${upload.ec_code}`;
+        } else {
+            ec_code = 'Missing EC code';
+        }
         const uploadInfo = {
             upload_id: upload.upload_id,
             original_filename: upload.original_filename,
             filename_in_zip,
             path_in_zip,
-            agency_name: upload.agency_name,
-            ec_code: upload.ec_code,
+            agency_name: upload.agency_name || 'Missing agency name',
+            ec_code,
             reporting_period_name: upload.reporting_period_name,
             updated_at: getUploadLastUpdate(upload).toISOString(),
             validity,
@@ -134,7 +140,7 @@ async function getUploadsForArchive(organizationId) {
             u1.id as upload_id,
             u1.filename as original_filename,
             a.name AS agency_name,
-            'EC' || u1.ec_code AS ec_code,
+            u1.ec_code AS ec_code,
             rp.name AS reporting_period_name,
             u1.created_at,
             u1.validated_at,
@@ -149,8 +155,8 @@ async function getUploadsForArchive(organizationId) {
             LEFT JOIN users uv ON uv.id = u1.validated_by
             LEFT JOIN users ui ON ui.id = u1.invalidated_by
             LEFT JOIN users uc ON uc.id = u1.user_id
+            LEFT JOIN agencies a ON a.id = u1.agency_id
             JOIN reporting_periods rp ON rp.id = u1.reporting_period_id
-            JOIN agencies a ON a.id = u1.agency_id
         WHERE
             u1.tenant_id = ?
         ORDER BY


### PR DESCRIPTION
### Ticket  Tracked within NAVA
## Description
- Users notified us of not being able to see uploads that were missing an agency code. When looking into the code it looks like the query to pull-in uploads from the database has a hard-requirement for this to exist. This PR removes the requirement and handles the scenario when EC code and Agency values are missing gracefully.

## Screenshots / Demo Video

## Testing

### Automated and Unit Tests
- [x] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [x] Provided ticket and description
- [ ] Provided screenshots/demo
- [ ] Provided testing information
- [x] Provided adequate test coverage for all new code
- [x] Added PR reviewers