### PR TITLE
Use environment variables to configure allowed email types

### DIFF
--- a/packages/server/src/lib/email.js
+++ b/packages/server/src/lib/email.js
@@ -85,6 +85,12 @@ async function deliverEmail({
     subject,
     emailType,
 }) {
+    if (!ENABLED_EMAIL_TYPES.includes(emailType)) {
+        log.info({ emailType, enabledEmailTypes: ENABLED_EMAIL_TYPES },
+            'this type of email is not enabled so it will not be sent');
+        return null;
+    }
+
     let userTags = [];
     const recipientId = await db.getUserIdForEmail(toAddress);
     const activeContext = tracer.scope().active()?.context();

--- a/packages/server/src/lib/email.js
+++ b/packages/server/src/lib/email.js
@@ -577,7 +577,13 @@ function yesterday() {
 }
 
 async function buildAndSendGrantDigestEmails(userId, openDate = yesterday()) {
-    console.log(`Building and sending Grants Digest email for user: ${userId} on ${openDate}`);
+    if (!ENABLED_EMAIL_TYPES.includes(tags.emailTypes.grantDigest)) {
+        log.info({ enabledEmailTypes: ENABLED_EMAIL_TYPES, thisEmailType: tags.emailTypes.grantDigest },
+            'aborting buildAndSendGrantDigestEmails() because this email type is not enabled');
+        return;
+    }
+    log.info({ userId, openDate }, 'building and sending Grants Digest email for user');
+
     /*
     1. get all saved searches mapped to each user
     2. call getAndSendGrantForSavedSearch to find new grants and send the digest
@@ -593,6 +599,8 @@ async function buildAndSendGrantDigestEmails(userId, openDate = yesterday()) {
     });
 
     await asyncBatch(inputs, getAndSendGrantForSavedSearch, 2);
+    log.info({ sentCount: inputs.length, openDate },
+        'successfully built and sent grant digest emails for saved searches');
 
     console.log(`Successfully built and sent grants digest emails for ${inputs.length} saved searches on ${openDate}`);
 }


### PR DESCRIPTION
## Description

This PR introduces two API server environment variables, `ENABLED_EMAIL_TYPES` and `DISABLE_ALL_EMAILS`, which allows emails to be selectively enabled or else entirely prevented from being sent. This behavior manifests as a module level constant array, `ENABLED_EMAIL_TYPES`, which will contain some subset of values from the `tags.emailTypes` object in `packages/server/src/lib/email/constants.js`.

- `DISABLE_ALL_EMAILS` env var: When set to a non-empty value, no emails will be sent, regardless of other environment configuration.
- `ENABLED_EMAIL_TYPES` env var: When set, is expected to provide a comma-separated string of zero or more email types (per the types defined in `packages/server/src/lib/email/constants.js`):
  - When the environment variable is unset or an empty string, all email types are enabled, allowing us to maintain existing behavior by default.
  - When the environment variable has a non-empty value, only the named emails (multiple can be provided with a by comma-separating individual email types) are allowed to send. If a value is provided that does not match a known email type, it is ignored and a warning is logged. If the environment variable is non-empty but no emails are enabled (i.e. no provided values match a known email type), another warning is logged.

Since the `ENABLED_EMAIL_TYPES` constant is loaded with the `packages/server/src/lib/email.js` module, log messages related to the configuration process are emitted whenever this module is first loaded (normally on startup of the API server).

Note that this change only introduces the ability to enable emails based on environment configuration – no environment variables are modified for any of our deployment environments in this PR.