### PR TITLE
feat: add flags for nava transition to disable login/add a banner

### DIFF
--- a/packages/client/public/deploy-config.js
+++ b/packages/client/public/deploy-config.js
@@ -28,6 +28,10 @@ window.APP_CONFIG.featureFlags = {
   shareTerminologyEnabled: true,
   followNotesEnabled: true,
   enableFullFileExport: true,
+  grantsTransitionMessageEnabled: true,
+  arpaTransitionMessageEnabled: true,
+  grantsLoginEnabled: true,
+  arpaLoginEnabled: true,
 };
 
 // Setting a GOOGLE_TAG_ID enables Google Analytics.

--- a/packages/client/src/arpa_reporter/views/LoginView.vue
+++ b/packages/client/src/arpa_reporter/views/LoginView.vue
@@ -3,6 +3,17 @@
 <template>
   <div class="my-3">
     <h1>ARPA Reporter Login</h1>
+    <div
+      v-if="transitionMessageEnabled"
+      :class="{
+        'alert alert-info': transitionMessageEnabled,
+      }"
+    >
+      <h2 class="h2">
+        The ARPA Reporter is now managed by Nava PBC.  Please access the tool at:
+        <a href="https://grants.navapbc.com/arpa_reporter">grants.navapbc.com/arpa_reporter</a>
+      </h2>
+    </div>
     <form @submit="login">
       <div class="form-group">
         <input
@@ -12,12 +23,14 @@
           name="email"
           placeholder="Email address"
           autofocus
+          :disabled="!loginEnabled"
         >
       </div>
       <div class="form-group">
         <button
           class="btn usdr-btn-primary"
           type="Submit"
+          :disabled="!loginEnabled"
           @click="login"
         >
           Send email with login link
@@ -47,6 +60,7 @@
 import { useVuelidate } from '@vuelidate/core';
 import { required, email, helpers } from '@vuelidate/validators';
 import { apiURL } from '@/helpers/fetchApi';
+import { arpaLoginEnabled, arpaTransitionMessageEnabled } from '@/helpers/featureFlags';
 
 export default {
   name: 'LoginView',
@@ -62,6 +76,14 @@ export default {
       email: '',
       serverResponse,
     };
+  },
+  computed: {
+    transitionMessageEnabled() {
+      return arpaTransitionMessageEnabled();
+    },
+    loginEnabled() {
+      return arpaLoginEnabled();
+    },
   },
   validations: {
     email: {

--- a/packages/client/src/helpers/featureFlags/index.js
+++ b/packages/client/src/helpers/featureFlags/index.js
@@ -24,3 +24,19 @@ export function grantNotesLimit() {
 export function enableFullFileExport() {
   return getFeatureFlags().enableFullFileExport === true;
 }
+
+export function grantsTransitionMessageEnabled() {
+  return getFeatureFlags().grantsTransitionMessageEnabled === true;
+}
+
+export function arpaTransitionMessageEnabled() {
+  return getFeatureFlags().arpaTransitionMessageEnabled === true;
+}
+
+export function grantsLoginEnabled() {
+  return getFeatureFlags().grantsLoginEnabled === true;
+}
+
+export function arpaLoginEnabled() {
+  return getFeatureFlags().arpaLoginEnabled === true;
+}

--- a/packages/client/src/views/LoginView.spec.js
+++ b/packages/client/src/views/LoginView.spec.js
@@ -1,7 +1,7 @@
 import LoginView from '@/views/LoginView.vue';
 
 import {
-  describe, it, expect, beforeEach, vi
+  describe, it, expect, beforeEach, vi,
 } from 'vitest';
 import { shallowMount } from '@vue/test-utils';
 

--- a/packages/client/src/views/LoginView.spec.js
+++ b/packages/client/src/views/LoginView.spec.js
@@ -1,9 +1,14 @@
 import LoginView from '@/views/LoginView.vue';
 
 import {
-  describe, it, expect, beforeEach,
+  describe, it, expect, beforeEach, vi
 } from 'vitest';
 import { shallowMount } from '@vue/test-utils';
+
+vi.mock('@/helpers/featureFlags', async (importOriginal) => ({
+  ...await importOriginal(),
+  grantsLoginEnabled: () => true,
+}));
 
 describe('LoginView', () => {
   const $route = {

--- a/packages/client/src/views/LoginView.vue
+++ b/packages/client/src/views/LoginView.vue
@@ -15,6 +15,19 @@
         class="mx-auto mb-3"
         top
       />
+
+      <div
+        v-if="transitionMessageEnabled"
+        class="mt-3"
+        :class="{
+          'alert alert-info': transitionMessageEnabled,
+        }"
+      >
+        <h2 class="h2">
+          The Grant Finder is now managed by Nava PBC.  Please access the tool at:
+          <a href="https://grants.navapbc.com">grants.navapbc.com</a>
+        </h2>
+      </div>
       <b-card-text class="mt-4 p-3 dropshadow-card">
         <h1 class="h3 my-4">
           Log in to Federal Grant Finder
@@ -33,6 +46,7 @@
               name="email"
               placeholder="Email address"
               autofocus
+              :disabled="!loginEnabled"
             >
           </div>
           <div
@@ -42,6 +56,7 @@
               variant="primary"
               class="btn-block"
               type="Submit"
+              :disabled="!loginEnabled"
               @click="login"
             >
               Send me the link
@@ -106,6 +121,7 @@
 import { useVuelidate } from '@vuelidate/core';
 import { required, email, helpers } from '@vuelidate/validators';
 import { apiURL } from '@/helpers/fetchApi';
+import { grantsLoginEnabled, grantsTransitionMessageEnabled } from '@/helpers/featureFlags';
 import logo from '@/assets/usdr_logo_standard_wide.svg';
 
 export default {
@@ -123,6 +139,14 @@ export default {
       serverResponse,
       logo,
     };
+  },
+  computed: {
+    loginEnabled() {
+      return grantsLoginEnabled();
+    },
+    transitionMessageEnabled() {
+      return grantsTransitionMessageEnabled();
+    },
   },
   validations: {
     email: {

--- a/terraform/prod.tfvars
+++ b/terraform/prod.tfvars
@@ -53,11 +53,15 @@ website_datadog_rum_options = {
   trackLongTasks          = true
 }
 website_feature_flags = {
-  newTerminologyEnabled      = true,
-  newGrantsDetailPageEnabled = true,
-  shareTerminologyEnabled    = true,
-  followNotesEnabled         = false,
-  enableFullFileExport       = true,
+  newTerminologyEnabled        = true,
+  newGrantsDetailPageEnabled   = true,
+  shareTerminologyEnabled      = true,
+  followNotesEnabled           = false,
+  enableFullFileExport         = true,
+  arpaTransitionMessageEnabled   = true,
+  grantsTransitionMessageEnabled = true,
+  arpaLoginEnabled               = false,
+  grantsLoginEnabled             = true,
 }
 
 // Google Analytics Account ID: 233192355, Property ID: 321194851, Stream ID: 3802896350

--- a/terraform/prod.tfvars
+++ b/terraform/prod.tfvars
@@ -53,11 +53,11 @@ website_datadog_rum_options = {
   trackLongTasks          = true
 }
 website_feature_flags = {
-  newTerminologyEnabled        = true,
-  newGrantsDetailPageEnabled   = true,
-  shareTerminologyEnabled      = true,
-  followNotesEnabled           = false,
-  enableFullFileExport         = true,
+  newTerminologyEnabled          = true,
+  newGrantsDetailPageEnabled     = true,
+  shareTerminologyEnabled        = true,
+  followNotesEnabled             = false,
+  enableFullFileExport           = true,
   arpaTransitionMessageEnabled   = true,
   grantsTransitionMessageEnabled = true,
   arpaLoginEnabled               = false,

--- a/terraform/staging.tfvars
+++ b/terraform/staging.tfvars
@@ -52,11 +52,15 @@ website_datadog_rum_options = {
   trackLongTasks          = true
 }
 website_feature_flags = {
-  newTerminologyEnabled      = true,
-  newGrantsDetailPageEnabled = true,
-  shareTerminologyEnabled    = true,
-  followNotesEnabled         = false,
-  enableFullFileExport       = true,
+  newTerminologyEnabled          = true,
+  newGrantsDetailPageEnabled     = true,
+  shareTerminologyEnabled        = true,
+  followNotesEnabled             = false,
+  enableFullFileExport           = true,
+  arpaTransitionMessageEnabled   = true,
+  grantsTransitionMessageEnabled = true,
+  arpaLoginEnabled               = false,
+  grantsLoginEnabled             = true,
 }
 
 // Google Analytics Account ID: 233192355, Property ID: 429910307, Stream ID: 7590745080


### PR DESCRIPTION
## Description
This PR adds four feature flags:
* grantsTransitionMessageEnabled
* arpaTransitionMessageEnabled
* grantsLoginEnabled
* arpaLoginEnabled

and associated behavior:
* showing a message on each login page encouraging users to go to the Nava instances
* disabling the input elements for each login page

This PR also enables the messages in all environments, and disables login for ARPA in all environments.

## Screenshots / Demo Video
Here is what this looks like with message on and input disabled:
<img width="1552" alt="Screenshot 2025-03-25 at 3 43 38 PM" src="https://github.com/user-attachments/assets/f7fbd036-96d7-4a91-b81e-1dd0aa0eea00" />
<img width="1552" alt="Screenshot 2025-03-25 at 3 44 11 PM" src="https://github.com/user-attachments/assets/8fef8994-3079-4db9-8401-a9c8c777448a" />

## Testing
I have enabled/disabled the flags locally and they behave as I expect, using the `deploy-config.js` mechanism.

### Automated and Unit Tests
- [ ] ~~Added Unit tests~~ n/a

### Manual tests for Reviewer
- [x] Added steps to test feature/functionality manually

## Checklist
- [x] Provided ticket and description
- [x] Provided screenshots/demo
- [x] Provided testing information
- [x] Provided adequate test coverage for all new code
- [x] Added PR reviewers