### PR TITLE
Create GHA version-updates and security-updates groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,6 +36,15 @@ updates:
       timezone: "America/New_York"
     commit-message:
       prefix: 'Chore [deps:github-actions]'
+    groups:
+      version-updates:
+        applies-to: version-updates
+        patterns:
+          - "*"
+      security-updates:
+        applies-to: security-updates
+        patterns:
+          - "*"
   - package-ecosystem: "terraform"
     directory: "/terraform"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -41,10 +41,16 @@ updates:
         applies-to: version-updates
         patterns:
           - "*"
+        update-types:
+          - minor
+          - patch
       security-updates:
         applies-to: security-updates
         patterns:
           - "*"
+        update-types:
+          - minor
+          - patch
   - package-ecosystem: "terraform"
     directory: "/terraform"
     schedule:


### PR DESCRIPTION
This PR modifies our Dependabot config so that all updates for the `github-actions` ecosystem will be grouped into pull requests based on whether they are `applies-to: security-updates` or `applies-to: version-updates` (i.e. all security updates go into one PR group and all version updates go into another PR group).

Grouping updates for this ecosystem will cut down on PRs for this ecosystem, hopefully making review a bit easier. We have limited QA checks (mostly related to linting) for this ecosystem, so it's unlikely that this change would result in CI workloads failing for one bad update.

Note that this change only affects PRs with `minor` and `patch` semantic versioning changes; any dependency with a major version change will still get its own pull request.