### PR TITLE
Realign commit hash and version tag for tj-actions/changed-files

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -380,7 +380,7 @@ jobs:
         run: poetry install --no-interaction --no-ansi
       - name: Get Python changed files
         id: changed-py-files
-        uses: tj-actions/changed-files@b74df86ccb65173a8e33ba5492ac1a2ca6b216fd # v45.0.7
+        uses: tj-actions/changed-files@823fcebdb31bb35fdf2229d9f769b400309430d0 # v46.0.3
         with:
           files: |
             *.py


### PR DESCRIPTION
This resets the `tj-actions/changed-files` third party action to [v46.0.3](https://github.com/tj-actions/changed-files/releases/tag/v46.0.3).  The current commit hash points to the head commit of the `main` branch for that repo and the associated version comment is incorrect/out of date.

Not sure if this was a Dependabot issue or due to a typo when this action was first introduced into the QA workflow. Discussions related to a recent [security issue](https://github.com/tj-actions/changed-files/issues/2464) for this action suggest that some of the tags may have been affected, so that may be related.